### PR TITLE
package: Bump swift-format and swift-syntax to 508.0.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,13 +29,13 @@ let package = Package(
         // Generate Swift code
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "508.0.0"
+            from: "508.0.1"
         ),
 
         // Format Swift code
         .package(
             url: "https://github.com/apple/swift-format.git",
-            from: "508.0.0"
+            from: "508.0.1"
         ),
 
         // General algorithms


### PR DESCRIPTION
### Motivation

Our swift-format dependency (508.0.0) had an `.upToNextMinor` version dependency on swift-argument-parser, which presented challenges for adopters of swift-openapi-generator who wanted to also use newer versions of swift-argument-parser. There's just been a release of swift-format (and swift-syntax) that relaxes its dependency on swift-argument-parser to an `.upToNextMajor`.

### Modifications

- Bump swift-format and swift-syntax to 508.0.1.

### Result

Adopters will be able to use newer versions of swift-argument-parser when using swift-openapi-generator.

### Test Plan

CI.