### PR TITLE
Fix a broken reference test

### DIFF
--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -171,7 +171,7 @@ paths:
         '412':
           description: Avatar is not acceptable
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
 components:

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -282,7 +282,7 @@ public struct Client: APIProtocol {
                 try converter.headerFieldAdd(
                     in: &request.headerFields,
                     name: "accept",
-                    value: "application/octet-stream, application/json"
+                    value: "application/octet-stream, text/plain"
                 )
                 request.body = try converter.bodyAddRequired(
                     input.body,
@@ -315,13 +315,13 @@ public struct Client: APIProtocol {
                         .init()
                     try converter.validateContentTypeIfPresent(
                         in: response.headerFields,
-                        substring: "application/json"
+                        substring: "text/plain"
                     )
                     let body: Operations.uploadAvatarForPet.Output.PreconditionFailed.Body =
                         try converter.bodyGet(
                             Swift.String.self,
                             from: response.body,
-                            transforming: { value in .json(value) }
+                            transforming: { value in .text(value) }
                         )
                     return .preconditionFailed(.init(headers: headers, body: body))
                 default: return .undocumented(statusCode: response.statusCode, .init())

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -422,20 +422,14 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     suppressUnusedWarning(value)
                     var response: Response = .init(statusCode: 412)
                     suppressMutabilityWarning(&response)
-                    try converter.validateAcceptIfPresent(
-                        "application/json",
-                        in: request.headerFields
-                    )
+                    try converter.validateAcceptIfPresent("text/plain", in: request.headerFields)
                     response.body = try converter.bodyAdd(
                         value.body,
                         headerFields: &response.headerFields,
                         transforming: { wrapped in
                             switch wrapped {
-                            case let .json(value):
-                                return .init(
-                                    value: value,
-                                    contentType: "application/json; charset=utf-8"
-                                )
+                            case let .text(value):
+                                return .init(value: value, contentType: "text/plain")
                             }
                         }
                     )

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -1300,7 +1300,7 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.PreconditionFailed.Headers
-                public enum Body: Sendable, Equatable, Hashable { case json(Swift.String) }
+                public enum Body: Sendable, Equatable, Hashable { case text(Swift.String) }
                 /// Received HTTP response body
                 public var body: Operations.uploadAvatarForPet.Output.PreconditionFailed.Body
                 /// Creates a new `PreconditionFailed`.

--- a/Tests/PetstoreConsumerTests/Common.swift
+++ b/Tests/PetstoreConsumerTests/Common.swift
@@ -111,10 +111,6 @@ extension Data {
         "efgh"
     }
 
-    static var quotedEfghString: String {
-        #""efgh""#
-    }
-
     static var efgh: Data {
         efghString.data(using: .utf8)!
     }

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -381,7 +381,7 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(
                 request.headerFields,
                 [
-                    .init(name: "accept", value: "application/octet-stream, application/json"),
+                    .init(name: "accept", value: "application/octet-stream, text/plain"),
                     .init(name: "content-type", value: "application/octet-stream"),
                 ]
             )
@@ -420,7 +420,7 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(
                 request.headerFields,
                 [
-                    .init(name: "accept", value: "application/octet-stream, application/json"),
+                    .init(name: "accept", value: "application/octet-stream, text/plain"),
                     .init(name: "content-type", value: "application/octet-stream"),
                 ]
             )
@@ -428,9 +428,9 @@ final class Test_Client: XCTestCase {
             return .init(
                 statusCode: 412,
                 headers: [
-                    .init(name: "content-type", value: "application/json")
+                    .init(name: "content-type", value: "text/plain")
                 ],
-                encodedBody: Data.quotedEfghString
+                encodedBody: Data.efghString
             )
         }
         let response = try await client.uploadAvatarForPet(
@@ -444,7 +444,7 @@ final class Test_Client: XCTestCase {
             return
         }
         switch value.body {
-        case .json(let json):
+        case .text(let json):
             XCTAssertEqual(json, Data.efghString)
         }
     }

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -410,7 +410,7 @@ final class Test_Server: XCTestCase {
                     throw TestError.unexpectedValue(input.body)
                 }
                 XCTAssertEqualStringifiedData(avatar, Data.abcdString)
-                return .preconditionFailed(.init(body: .json(Data.efghString)))
+                return .preconditionFailed(.init(body: .text(Data.efghString)))
             }
         )
         let response = try await server.uploadAvatarForPet(
@@ -418,7 +418,7 @@ final class Test_Server: XCTestCase {
                 path: "/api/pets/1/avatar",
                 method: .put,
                 headerFields: [
-                    .init(name: "accept", value: "application/octet-stream, application/json"),
+                    .init(name: "accept", value: "application/octet-stream, text/plain"),
                     .init(name: "content-type", value: "application/octet-stream"),
                 ],
                 encodedBody: Data.abcdString
@@ -433,12 +433,12 @@ final class Test_Server: XCTestCase {
         XCTAssertEqual(
             response.headerFields,
             [
-                .init(name: "content-type", value: "application/json; charset=utf-8")
+                .init(name: "content-type", value: "text/plain")
             ]
         )
         XCTAssertEqualStringifiedData(
             response.body,
-            Data.quotedEfghString
+            Data.efghString
         )
     }
 }


### PR DESCRIPTION
### Motivation

When we fixed plain text bodies in https://github.com/apple/swift-openapi-runtime/pull/9, we surfaced an existing issue now tracked by https://github.com/apple/swift-openapi-generator/issues/43. Coincidentally, the generator integration test actually contained an instance of this uncommon pair of content-type: application/json + body: fragment string. So the test was broken before this PR.

This PR can be considered a follow-up of https://github.com/apple/swift-openapi-runtime/pull/9.

### Modifications

Until https://github.com/apple/swift-openapi-generator/issues/43 is addressed, we can't both have plain text responses working correctly, and also continue to support the case of a JSON string as a body, so I changed the reference test to instead use the (more common) plain text response. Updated accordingly, all the changes are in tests only.

### Result

The reference test now passes again with the latest version of the runtime library.

### Test Plan

This whole PR is to fix a test, so ensured all tests pass.
