### PR TITLE
CI: remove temporary gitconfig workaround

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -15,13 +15,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    # Note: This temporary step creates a gitconfig to use SSH for a dependency
-    # that is not yet public. This can be removed once it is public.
-    command: git config --global url."git@github.com:apple/swift-openapi-runtime".insteadOf "https://github.com/apple/swift-openapi-runtime"
-    volumes:
-      - ci-gitconfig:/ci-gitconfig
-    environment:
-      - GIT_CONFIG_GLOBAL=/ci-gitconfig/gitconfig
 
   common: &common
     image: *image
@@ -29,10 +22,7 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ..:/code:z
-      - ci-gitconfig:/ci-gitconfig
     working_dir: /code
-    environment:
-      - GIT_CONFIG_GLOBAL=/ci-gitconfig/gitconfig
 
   soundness:
     <<: *common
@@ -46,5 +36,3 @@ services:
     <<: *common
     entrypoint: /bin/bash
 
-volumes:
-  ci-gitconfig:


### PR DESCRIPTION
### Motivation

The repo is public now. There is no need for the workaround anymore.

### Modifications

Remove gitconfig workaround added in https://github.com/apple/swift-openapi-generator/pull/3
