### PR TITLE
[Releases] Add a release config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  categories:
+    - title: SemVer Major
+      labels:
+        - semver/major
+    - title: SemVer Minor
+      labels:
+        - semver/minor
+    - title: SemVer Patch
+      labels:
+        - semver/patch
+    - title: Other Changes
+      labels:
+        - semver/none
+        - "*"


### PR DESCRIPTION
### Motivation

Make making releases easier and more standardized.

### Modifications

Like https://github.com/apple/swift-openapi-runtime/pull/14, but for the generator repo.

Adds the config file, which is then used by GitHub when drafting release notes.

### Result

Our next release notes will be drafted automitically, saving us time.

### Test Plan

Already did this for runtime: https://github.com/apple/swift-openapi-runtime/releases/tag/0.1.1
