### PR TITLE
docs: Emphasize target setting in Xcode tutorial

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/ClientXcode.tutorial
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/ClientXcode.tutorial
@@ -101,7 +101,7 @@
             @Step {
                 Repeat the same steps two more times, with the packages `https://github.com/apple/swift-openapi-runtime` and `https://github.com/apple/swift-openapi-urlsession`.
                 
-                This time do check the library products to be added to the GeneratedClient target.
+                This time, do check the library products to be added to the **GeneratedClient target**. Note, this might not be the default target Xcode offers to add the libraries to.
             }
             @Step {
                 To finish configuring the build plugin in your target, navigate to the Build Phases tab of the GeneratedClient in the Project Editor, and expand the Run Build Tool Plug-ins section.


### PR DESCRIPTION
### Motivation

In our Xcode tutorial we outline the steps to enable Swift OpenAPI Generator on a separate framework. When you come to add the package dependencies on the runtime and transport libraries the default target Xcode offers to add them to is not this new framework. Failing to add them to the framework target causes linker issues.

This is implied in our guide but it's pretty subtle and a user tripped up over this.

### Modifications

- Emphasize which target the libraries need to be added to in the Xcode tutorial.

### Result

Hopefully clearer step in the tutorial. 

### Test Plan

Ran through the steps manually and confirmed this generates a building app.

### Resolves

Resolves #57.