### PR TITLE
Support empty string OpenAPI identifiers

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Extensions/String.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/String.swift
@@ -63,7 +63,7 @@ fileprivate extension String {
     /// ensures that the identifier starts with a letter and not a number.
     var sanitizedForSwiftCode: String {
         guard !isEmpty else {
-            return self
+            return "_empty"
         }
 
         // Only allow [a-zA-Z][a-zA-Z0-9_]*

--- a/Tests/OpenAPIGeneratorCoreTests/Extensions/Test_String.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Extensions/Test_String.swift
@@ -29,6 +29,9 @@ final class Test_String: Test_Core {
 
             // Reserved name
             ("Type", "_Type"),
+
+            // Empty string
+            ("", "_empty")
         ]
         for (input, sanitized) in cases {
             XCTAssertEqual(input.asSwiftSafeName, sanitized)

--- a/Tests/OpenAPIGeneratorCoreTests/Extensions/Test_String.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Extensions/Test_String.swift
@@ -31,7 +31,7 @@ final class Test_String: Test_Core {
             ("Type", "_Type"),
 
             // Empty string
-            ("", "_empty")
+            ("", "_empty"),
         ]
         for (input, sanitized) in cases {
             XCTAssertEqual(input.asSwiftSafeName, sanitized)

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -35,6 +35,7 @@ paths:
             - water
             - land
             - air
+            - ""
             type: string
         - name: feeds
           in: query

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -691,6 +691,7 @@ public enum Operations {
                     case water
                     case land
                     case air
+                    case _empty
                     /// Parsed a raw value that was not defined in the OpenAPI document.
                     case undocumented(String)
                     public init?(rawValue: String) {
@@ -698,6 +699,7 @@ public enum Operations {
                         case "water": self = .water
                         case "land": self = .land
                         case "air": self = .air
+                        case "": self = ._empty
                         default: self = .undocumented(rawValue)
                         }
                     }
@@ -707,9 +709,10 @@ public enum Operations {
                         case .water: return "water"
                         case .land: return "land"
                         case .air: return "air"
+                        case ._empty: return ""
                         }
                     }
-                    public static var allCases: [habitatPayload] { [.water, .land, .air] }
+                    public static var allCases: [habitatPayload] { [.water, .land, .air, ._empty] }
                 }
                 public var habitat: Operations.listPets.Input.Query.habitatPayload?
                 /// - Remark: Generated from `#/paths/pets/GET/query/feedsPayload`.


### PR DESCRIPTION
### Motivation

The OpenAPI specification allows the use of the empty string in some places, for example in the following enum, which we've seen in some real-world OpenAPI documents:

```yaml
type: string
enum:
  - ""
  - foo
  - bar
```

We have code that converts an OpenAPI identifier to a suitable string that can be used as a Swift identifier. It currently returns an empty string when given an empty string as input, which is not a valid Swift identifier. We already have some logic there to avoid clashing with some Swift keywords, so this can be extended to handle the empty string.

### Modifications

- Map the empty string OpenAPI identifier to "_empty"

### Result

We can generate compiling code when presented with empty string OpenAPI identifiers.

### Test Plan

- Added unit test.
- Extended reference test.

### Resolves

- Resolves #33.