### PR TITLE
Relax minimum macOS requirement to 10.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
         ),
 
         // Tests-only: Runtime library linked by generated code
-        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.1.1")),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.1.3")),
 
         // Build and preview docs
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import PackageDescription
 let package = Package(
     name: "swift-openapi-generator",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v10_15)
     ],
     products: [
         .executable(name: "swift-openapi-generator", targets: ["swift-openapi-generator"]),

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The generated code, runtime library, and transports are supported on more platfo
 | Component | macOS | Linux | iOS | tvOS | watchOS |
 | -: | :-: | :-: | :-: | :-: | :-: |
 | Generator plugin and CLI            | ✅ 13+  | ✅     | ❌     | ❌     | ❌    |
-| Generated code, runtime, transports | ✅ 13+  | ✅     | ✅ 16+ | ✅ 16+ | ✅ 9+ |
+| Generated code, runtime, transports | ✅ 10.15+  | ✅     | ✅ 13+ | ✅ 13+ | ✅ 6+ |
 
 ## Documentation
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
@@ -53,7 +53,7 @@ The generated code, runtime library, and transports are supported on more platfo
 | Component | macOS | Linux | iOS | tvOS | watchOS |
 | -: | :-: | :-: | :-: | :-: | :-: |
 | Generator plugin and CLI            | ✅ 13+  | ✅     | ❌     | ❌     | ❌    |
-| Generated code, runtime, transports | ✅ 13+  | ✅     | ✅ 16+ | ✅ 16+ | ✅ 9+ |
+| Generated code, runtime, transports | ✅ 10.15+  | ✅     | ✅ 13+ | ✅ 13+ | ✅ 6+ |
 
 ## Topics
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.1.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.1.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingServiceClient",
     platforms: [
-        .macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9),
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
     ],
     targets: [
         .executableTarget(

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.2.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingServiceClient",
     platforms: [
-        .macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9),
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.3.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.3.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingServiceClient",
     platforms: [
-        .macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9),
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.4.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.4.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingServiceClient",
     platforms: [
-        .macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9),
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.5.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.Package.5.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingServiceClient",
     platforms: [
-        .macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9),
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.1.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.1.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingService",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v10_15)
     ],
     targets: [
         .executableTarget(

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.2.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingService",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v10_15)
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.3.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.3.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingService",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v10_15)
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.4.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.4.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingService",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v10_15)
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.5.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.5.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingService",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v10_15)
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),


### PR DESCRIPTION
### Motivation

Reduce deployment target by 3 versions to gain more adoption.

### Modifications

- Reduced deployment targets by 3 versions
- Modified `client.Package.x` and `server.Package.x` files to reflect new deployment targets
- Modified documentation to reflect new deployment targets

### Result

Deployment target will be reduced by 3 versions and documentation will reflect such changes.

### Resolves

- Resolves #62

### Related PRs

- Paired with https://github.com/apple/swift-openapi-runtime/pull/18
