### PR TITLE
Bumps OpenAPIKit to version 3.0.0-alpha.7 fixing an issue with trailing slashes.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         // Read OpenAPI documents
         .package(
             url: "https://github.com/mattpolzin/OpenAPIKit.git",
-            exact: "3.0.0-alpha.6"
+            exact: "3.0.0-alpha.7"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -113,7 +113,7 @@ paths:
                 $ref: '#/components/schemas/Pet'
         '400':
           $ref: '#/components/responses/ErrorBadRequest'
-  /probe:
+  /probe/:
     post:
       operationId: probe
       responses:

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -211,14 +211,14 @@ public struct Client: APIProtocol {
             }
         )
     }
-    /// - Remark: HTTP `POST /probe`.
-    /// - Remark: Generated from `#/paths//probe/post(probe)`.
+    /// - Remark: HTTP `POST /probe/`.
+    /// - Remark: Generated from `#/paths//probe//post(probe)`.
     public func probe(_ input: Operations.probe.Input) async throws -> Operations.probe.Output {
         try await client.send(
             input: input,
             forOperation: Operations.probe.id,
             serializer: { input in
-                let path = try converter.renderedRequestPath(template: "/probe", parameters: [])
+                let path = try converter.renderedRequestPath(template: "/probe/", parameters: [])
                 var request: OpenAPIRuntime.Request = .init(path: path, method: .post)
                 suppressMutabilityWarning(&request)
                 return request

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -265,8 +265,8 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
             }
         )
     }
-    /// - Remark: HTTP `POST /probe`.
-    /// - Remark: Generated from `#/paths//probe/post(probe)`.
+    /// - Remark: HTTP `POST /probe/`.
+    /// - Remark: Generated from `#/paths//probe//post(probe)`.
     func probe(request: Request, metadata: ServerRequestMetadata) async throws -> Response {
         try await handle(
             request: request,

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -19,8 +19,8 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `POST /pets`.
     /// - Remark: Generated from `#/paths//pets/post(createPet)`.
     func createPet(_ input: Operations.createPet.Input) async throws -> Operations.createPet.Output
-    /// - Remark: HTTP `POST /probe`.
-    /// - Remark: Generated from `#/paths//probe/post(probe)`.
+    /// - Remark: HTTP `POST /probe/`.
+    /// - Remark: Generated from `#/paths//probe//post(probe)`.
     func probe(_ input: Operations.probe.Input) async throws -> Operations.probe.Output
     /// Update just a specific property of an existing pet. Nothing is updated if no request body is provided.
     ///
@@ -1004,8 +1004,8 @@ public enum Operations {
             case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
         }
     }
-    /// - Remark: HTTP `POST /probe`.
-    /// - Remark: Generated from `#/paths//probe/post(probe)`.
+    /// - Remark: HTTP `POST /probe/`.
+    /// - Remark: Generated from `#/paths//probe//post(probe)`.
     public enum probe {
         public static let id: String = "probe"
         public struct Input: Sendable, Equatable, Hashable {
@@ -1079,7 +1079,7 @@ public enum Operations {
             }
             /// Ack
             ///
-            /// - Remark: Generated from `#/paths//probe/post(probe)/responses/204`.
+            /// - Remark: Generated from `#/paths//probe//post(probe)/responses/204`.
             ///
             /// HTTP response code: `204 noContent`.
             case noContent(Operations.probe.Output.NoContent)

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -344,7 +344,7 @@ final class Test_Client: XCTestCase {
     func testProbe_204() async throws {
         transport = .init { request, baseURL, operationID in
             XCTAssertEqual(operationID, "probe")
-            XCTAssertEqual(request.path, "/probe")
+            XCTAssertEqual(request.path, "/probe/")
             XCTAssertNil(request.query)
             XCTAssertEqual(baseURL.absoluteString, "/api")
             XCTAssertEqual(request.method, .post)


### PR DESCRIPTION
### Motivation
As discussed in #51, there was an issue with paths containing trailing slashes. The problem was identified in the [OpenAPIKit](https://github.com/mattpolzin/OpenAPIKit) dependency. It was fixed in the PR https://github.com/mattpolzin/OpenAPIKit/pull/274.

### Modifications
This PR updates the OpenAPIKit dependency version from `3.0.0-alpha.6` to `3.0.0-alpha.7` ([available here](https://github.com/mattpolzin/OpenAPIKit/releases/tag/3.0.0-alpha.7)), which includes the mentioned PR.

### Result
If a path ends with a trailing slash, such as `foo/bar/`, the generated functions will now correctly call the path `foo/bar/` instead of (as previously) `foo/bar`.

### Test Plan
Replaced an endpoint in the reference test to use a path with a trailing slash.

### Resolves
- Resolves https://github.com/apple/swift-openapi-generator/issues/51