### PR TITLE
docs: Add missing subcommand to manual CLI invocation example

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Manually-invoking-the-generator-CLI.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Manually-invoking-the-generator-CLI.md
@@ -21,7 +21,7 @@ If you need to commit the generated code to your source repository (for example,
 To generate Swift code to a specific directory, clone the generator repository and run the following command from the checkout directory:
 
 ```console
-% swift run swift-openapi-generator \
+% swift run swift-openapi-generator generate \
     --mode types --mode client \
     --output-directory path/to/desired/output-dir \
     path/to/openapi.yaml


### PR DESCRIPTION
### Motivation

While I was doing some changes to other parts of the code, I had to manually run the CLI to obtain the generated code, however, the command was not working. Only after did I realize that the `generate` keyword was missing!


### Modifications

Modified the `Manually-invoking-the-generator-CLI.md` file to fix the CLI command instruction.


### Result

Users now know how to properly manually execute the CLI.


### Test Plan

As of now I didn't add any tests for this. I'm not really sure where to start. My idea was to check if the function `createBuildCommands` from the `Plugins/OpenAPIGenerator/plugin.swift` file was returning the correct command with the `generate` argument. I was not able to import the `SwiftOpenAPIGeneratorPlugin` struct from a test file, meaning that I was not able to do this.
