### PR TITLE
Add support for .yml extension (openapi.yml and openapi-generator-config.yml)

### DIFF
--- a/Plugins/OpenAPIGenerator/plugin.swift
+++ b/Plugins/OpenAPIGenerator/plugin.swift
@@ -20,6 +20,8 @@ struct SwiftOpenAPIGeneratorPlugin {
         case incompatibleTarget(targetName: String)
         case noConfigFound(targetName: String)
         case noDocumentFound(targetName: String)
+        case multiConfigFound(targetName: String, files: [Path])
+        case multiDocumentFound(targetName: String, files: [Path])
 
         var description: String {
             switch self {
@@ -28,10 +30,16 @@ struct SwiftOpenAPIGeneratorPlugin {
                     "Incompatible target called '\(targetName)'. Only Swift source targets can be used with the Swift OpenAPI generator plugin."
             case .noConfigFound(let targetName):
                 return
-                    "No config found in the target named '\(targetName)'. Add a file called 'openapi-generator-config.yaml' or 'openapi-generator-config.yml' to the target's source directory. See documentation for details."
+                    "No config file found in the target named '\(targetName)'. Add a file called 'openapi-generator-config.yaml' or 'openapi-generator-config.yml' to the target's source directory. See documentation for details."
             case .noDocumentFound(let targetName):
                 return
                     "No OpenAPI document found in the target named '\(targetName)'. Add a file called 'openapi.yaml', 'openapi.yml' or 'openapi.json' (can also be a symlink) to the target's source directory. See documentation for details."
+            case .multiConfigFound(let targetName, let files):
+                return
+                    "Multiple config files found in the target named '\(targetName)', but exactly one is required. Found \(files.map(\.description).joined(separator: " "))."
+            case .multiDocumentFound(let targetName, let files):
+                return
+                    "Multiple OpenAPI documents found in the target named '\(targetName)', but exactly one is required. Found \(files.map(\.description).joined(separator: " "))."
             }
         }
 
@@ -50,16 +58,23 @@ struct SwiftOpenAPIGeneratorPlugin {
         targetName: String
     ) throws -> [Command] {
         let inputFiles = sourceFiles
-        guard let config = inputFiles.first(where: {
-            supportedConfigFiles.contains($0.path.lastComponent)
-        })?.path else {
+        let matchedConfigs = inputFiles.filter { supportedConfigFiles.contains($0.path.lastComponent) }.map(\.path)
+        guard matchedConfigs.count > 0 else {
             throw Error.noConfigFound(targetName: targetName)
         }
-        guard let doc = inputFiles.first(where: {
-            supportedDocFiles.contains($0.path.lastComponent)
-        })?.path else {
+        guard matchedConfigs.count == 1 else {
+            throw Error.multiConfigFound(targetName: targetName, files: matchedConfigs)
+        }
+        let config = matchedConfigs[0]
+
+        let matchedDocs = inputFiles.filter { supportedDocFiles.contains($0.path.lastComponent) }.map(\.path)
+        guard matchedDocs.count > 0 else {
             throw Error.noDocumentFound(targetName: targetName)
         }
+        guard matchedDocs.count == 1 else {
+            throw Error.multiDocumentFound(targetName: targetName, files: matchedDocs)
+        }
+        let doc = matchedDocs[0]
         let genSourcesDir = pluginWorkDirectory.appending("GeneratedSources")
         let outputFiles: [Path] = GeneratorMode.allCases.map { genSourcesDir.appending($0.outputFileName) }
         return [

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -10,7 +10,9 @@ The command-line tool also uses the same configuration file.
 
 ### Create a configuration file
 
-The configuration file is named `openapi-generator-config.yaml` and must exist in the target source directory.
+The configuration file is named `openapi-generator-config.yaml` or `openapi-generator-config.yml` and must exist in the target source directory.
+
+> In the following tutorial, we will use `openapi-generator-config.yaml` as an example.
 
 ```
 .

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -62,8 +62,10 @@ read -ra PATHS_TO_CHECK_FOR_LICENSE <<< "$( \
   ":(exclude)**/Package.resolved" \
   ":(exclude)**/README.md" \
   ":(exclude)**/openapi.yaml" \
+  ":(exclude)**/openapi.yml" \
   ":(exclude)**/petstore.yaml" \
   ":(exclude)**/openapi-generator-config.yaml" \
+  ":(exclude)**/openapi-generator-config.yml" \
   | xargs -0 \
 )"
 

--- a/scripts/run-swift-format.sh
+++ b/scripts/run-swift-format.sh
@@ -37,7 +37,7 @@ if [ "${SWIFT_FORMAT_RC}" -ne 0 ]; then
 
   To fix, run the following command:
 
-    % swift-format format --parallel --recursive --in-place Examples IntegrationTests Plugins Sources Tests
+    % swift-format format --parallel --recursive --in-place Examples IntegrationTest Plugins Sources Tests
   "
   exit "${SWIFT_FORMAT_RC}"
 fi


### PR DESCRIPTION
### Motivation

Some openapi file use `.yml` as the yaml file extension, we should support this instead of forcing user to rename it.

> https://github.com/discourse/discourse_api_docs/blob/main/openapi.yml

### Modifications

Add yml file extension support

### Result

_[After your change, what will change.]_

### Test Plan

_[Describe the steps you took, or will take, to qualify the change - such as adjusting tests and manual testing.]_
