### PR TITLE
Specify default code listing language for DocC catalog

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -14,7 +14,7 @@ The configuration file is named `openapi-generator-config.yaml` or `openapi-gene
 
 > In the following tutorial, we will use `openapi-generator-config.yaml` as an example.
 
-```
+```text
 .
 ├── Package.swift
 └── Sources

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Contributing-to-Swift-OpenAPI-Generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Contributing-to-Swift-OpenAPI-Generator.md
@@ -38,7 +38,7 @@ The generated code relies on functionality in the runtime library that is not pa
 
 To use this functionality, use an SPI import:
 
-```swift
+```
 @_spi(Generated) import OpenAPIRuntime
 ```
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Contributing-to-Swift-OpenAPI-Generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Contributing-to-Swift-OpenAPI-Generator.md
@@ -38,7 +38,7 @@ The generated code relies on functionality in the runtime library that is not pa
 
 To use this functionality, use an SPI import:
 
-```
+```swift
 @_spi(Generated) import OpenAPIRuntime
 ```
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Info.plist
+++ b/Sources/swift-openapi-generator/Documentation.docc/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CDDefaultCodeListingLanguage</key>
+	<string>swift</string>
 	<key>CFBundleName</key>
 	<string>swift-openapi-generator</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
### Motivation

Resolves https://github.com/apple/swift-openapi-generator/issues/20

### Modifications

- Added `CDDefaultCodeListingLanguage` to info.plist
- Updated ambiguous language highlightings

### Result

Swift code blocks no longer needs to be explicitly marked as such.

### Test Plan

Files inside the docc archive - Tested and verified with both explicit and non-explicit swift markings.
Files outside the docc archive - TBD
