### PR TITLE
Emit a descriptive error when running the generator on iOS, tvOS, or watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,11 +19,9 @@ let package = Package(
     platforms: [
         .macOS(.v10_15),
 
-        // The platforms below are not currently supported for running the
-        // generator itself (only the generated code), they are here
-        // to allow the generator to emit a more descriptive error,
-        // see the file PlatformChecks.swift for details.
-        .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
+        // The platforms below are not currently supported for running the generator itself.
+        // We include them here to allow the us to emit a more descriptive compiler error.
+        .iOS("99"), .tvOS("99"), .watchOS("99"),
     ],
     products: [
         .executable(name: "swift-openapi-generator", targets: ["swift-openapi-generator"]),

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,13 @@ import PackageDescription
 let package = Package(
     name: "swift-openapi-generator",
     platforms: [
-        .macOS(.v10_15)
+        .macOS(.v10_15),
+
+        // The platforms below are not currently supported for running the
+        // generator itself (only the generated code), they are here
+        // to allow the generator to emit a more descriptive error,
+        // see the file PlatformChecks.swift for details.
+        .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
     ],
     products: [
         .executable(name: "swift-openapi-generator", targets: ["swift-openapi-generator"]),

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,9 @@ let package = Package(
     platforms: [
         .macOS(.v10_15),
 
-        // The platforms below are not currently supported for running the generator itself.
-        // We include them here to allow the us to emit a more descriptive compiler error.
+        // The platforms below are not currently supported for running
+        // the generator itself. We include them here to allow the generator
+        // to emit a more descriptive compiler error.
         .iOS("99"), .tvOS("99"), .watchOS("99"),
     ],
     products: [

--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -1,3 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
 
 // Details: https://github.com/apple/swift-openapi-generator/issues/86
 #if os(iOS) || os(tvOS) || os(watchOS)

--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -1,0 +1,5 @@
+
+// Details: https://github.com/apple/swift-openapi-generator/issues/86
+#if os(iOS) || os(tvOS) || os(watchOS)
+#error("Running the generator tool itself is not supported on iOS, tvOS, and watchOS. Check that your app is not linking the generator directly. For details, check out: https://github.com/apple/swift-openapi-generator/issues/86")
+#endif

--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Details: https://github.com/apple/swift-openapi-generator/issues/86
+// Emit a compiler error if this library is linked with a target in an adopter
+// project.
 #if !(os(macOS) || os(Linux))
-#error("Running the generator tool itself is not supported on iOS, tvOS, and watchOS. Check that your app is not linking the generator directly. For details, check out: https://github.com/apple/swift-openapi-generator/issues/86")
+#error("_OpenAPIGeneratorCore is only to be used by swift-openapi-generator itself—your target should not link this library or the command line tool directly.")
 #endif

--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -13,6 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 // Details: https://github.com/apple/swift-openapi-generator/issues/86
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if !(os(macOS) || os(Linux))
 #error("Running the generator tool itself is not supported on iOS, tvOS, and watchOS. Check that your app is not linking the generator directly. For details, check out: https://github.com/apple/swift-openapi-generator/issues/86")
 #endif


### PR DESCRIPTION
### Motivation

Resolves #86, which some adopters are hitting by accident.

### Modifications

Makes the generator itself build successfully on iOS, tvOS, watchOS, but not really, as I just added an explicit, clear error on those platforms pointing out that the adopter probably did this by accident, and how to fix it.

### Result

A clear, descriptive error is now emitted when the adopter links the `_OpenAPIGeneratorCore` target from e.g. an iOS app (most likely by accident):

```
.../swift-openapi-generator/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift:4:8 Running the generator tool itself is not supported on iOS, tvOS, and watchOS. Check that your app is not linking the generator directly. For details, check out: https://github.com/apple/swift-openapi-generator/issues/86
```

### Test Plan

Tested locally by creating an iOS app with a lower deployment target and linked the generator directly. The error goes away when the linkages is removed, as expected.
