### PR TITLE
Add `await` and `Protocol` to the identifiers escaping rules

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Extensions/String.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/String.swift
@@ -217,5 +217,7 @@ fileprivate extension String {
         "Array",
         "Type",
         "type",
+        "Protocol",
+        "await",
     ]
 }


### PR DESCRIPTION
### Motivation

Resolves https://github.com/apple/swift-openapi-generator/issues/34

### Modifications

- Added `Protocol` to the keywords set.
- Added `await` to the keywords set.

### Result

- Would be able to support `Protocol` and `await` as property names.

### Test Plan

Tested and verified for both names. They are properly renamed to `_Protocol` and `_await`
