### PR TITLE
Fix a typo in the name of the transformingFirstLetter method

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Extensions/String.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/String.swift
@@ -24,12 +24,12 @@ extension String {
 
     /// Returns a copy of the string with the first letter uppercased.
     var uppercasingFirstLetter: String {
-        tranformingFirstLetter { $0.uppercased() }
+        transformingFirstLetter { $0.uppercased() }
     }
 
     /// Returns a copy of the string with the first letter lowercased.
     var lowercasingFirstLetter: String {
-        tranformingFirstLetter { $0.lowercased() }
+        transformingFirstLetter { $0.lowercased() }
     }
 }
 
@@ -44,7 +44,7 @@ fileprivate extension String {
     /// Returns a copy of the string with the first letter modified by
     /// the specified closure.
     /// - Parameter transformation: A closure that modifies the first letter.
-    func tranformingFirstLetter<T>(_ transformation: (Character) -> T) -> String where T: StringProtocol {
+    func transformingFirstLetter<T>(_ transformation: (Character) -> T) -> String where T: StringProtocol {
         guard let firstLetterIndex = self.firstIndex(where: \.isLetter) else {
             return self
         }


### PR DESCRIPTION
### Motivation

Correct grammar.

### Modifications

Update method name inside of `fileprivate extension`.

### Result

Grammar fixed.

### Test Plan

n/a
