### PR TITLE
Generate deprecation annotations based on OpenAPI document

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -1451,3 +1451,13 @@ extension KeywordKind {
         .try(hasPostfixQuestionMark: false)
     }
 }
+
+extension Declaration {
+    /// Returns a new deprecated variant of the declaration if `shouldDeprecate` is true.
+    func deprecate(if shouldDeprecate: Bool) -> Self {
+        if shouldDeprecate {
+            return .deprecated(.init(), self)
+        }
+        return self
+    }
+}

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
@@ -26,7 +26,8 @@ extension FileTranslator {
     func translateObjectStruct(
         typeName: TypeName,
         openAPIDescription: String?,
-        objectContext: JSONSchema.ObjectContext
+        objectContext: JSONSchema.ObjectContext,
+        isDeprecated: Bool
     ) throws -> Declaration {
 
         let documentedProperties: [PropertyBlueprint] =
@@ -61,6 +62,7 @@ extension FileTranslator {
                 }
                 return PropertyBlueprint(
                     comment: comment,
+                    isDeprecated: value.deprecated,
                     originalName: key,
                     typeUsage: propertyType,
                     associatedDeclarations: associatedDeclarations
@@ -86,6 +88,7 @@ extension FileTranslator {
         return translateStructBlueprint(
             StructBlueprint(
                 comment: comment,
+                isDeprecated: isDeprecated,
                 access: config.access,
                 typeName: typeName,
                 conformances: Constants.ObjectStruct.conformances,

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
@@ -90,7 +90,8 @@ extension FileTranslator {
             let objectDecl = try translateObjectStruct(
                 typeName: typeName,
                 openAPIDescription: overrides.userDescription ?? coreContext.description,
-                objectContext: objectContext
+                objectContext: objectContext,
+                isDeprecated: coreContext.deprecated
             )
             return [objectDecl]
         case let .string(coreContext, _):

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
@@ -64,12 +64,8 @@ extension FileTranslator {
             conformances: blueprint.conformances,
             members: members
         )
-        let structDecl: Declaration = .struct(structDesc)
 
-        guard let comment = blueprint.comment else {
-            return structDecl
-        }
-        return .commentable(comment, structDecl.deprecate(if: blueprint.isDeprecated))
+        return .commentable(blueprint.comment, .struct(structDesc).deprecate(if: blueprint.isDeprecated))
     }
 
     /// Returns a declaration of an initializer declared in a structure.

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
@@ -69,7 +69,7 @@ extension FileTranslator {
         guard let comment = blueprint.comment else {
             return structDecl
         }
-        return .commentable(comment, structDecl)
+        return .commentable(comment, structDecl.deprecate(if: blueprint.isDeprecated))
     }
 
     /// Returns a declaration of an initializer declared in a structure.
@@ -144,6 +144,7 @@ extension FileTranslator {
                     type: propertyTypeName
                 )
             )
+            .deprecate(if: property.isDeprecated)
         )
         return property.associatedDeclarations + [propertyDecl]
     }

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
@@ -106,7 +106,7 @@ struct PropertyBlueprint {
     /// A documentation comment for the property.
     var comment: Comment? = nil
 
-    /// Whether the type should be annotated as deprecated.
+    /// Whether the property should be annotated as deprecated.
     var isDeprecated: Bool = false
 
     /// The original name of the property specified in the OpenAPI document.

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
@@ -20,6 +20,9 @@ struct StructBlueprint {
     /// A documentation comment for the structure.
     var comment: Comment?
 
+    /// Whether the type should be annotated as deprecated.
+    var isDeprecated: Bool = false
+
     /// An access modifier.
     var access: AccessModifier?
 
@@ -102,6 +105,9 @@ struct PropertyBlueprint {
 
     /// A documentation comment for the property.
     var comment: Comment? = nil
+
+    /// Whether the type should be annotated as deprecated.
+    var isDeprecated: Bool = false
 
     /// The original name of the property specified in the OpenAPI document.
     var originalName: String

--- a/Sources/_OpenAPIGeneratorCore/Translator/Parameters/translateParameter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Parameters/translateParameter.swift
@@ -44,6 +44,7 @@ extension TypesFileTranslator {
             associatedDeclarations = []
         }
         return .init(
+            isDeprecated: parameter.parameter.deprecated,
             originalName: parameter.name,
             typeUsage: parameter.typeUsage,
             associatedDeclarations: associatedDeclarations

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
@@ -57,7 +57,7 @@ extension TypesFileTranslator {
         let function = FunctionDescription(signature: signature)
         return .commentable(
             operationComment,
-            .function(function)
+            .function(function).deprecate(if: description.operation.deprecated)
         )
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
@@ -208,7 +208,6 @@ extension TypesFileTranslator {
                     ]
                 )
             )
-            .deprecate(if: operation.endpoint.operation.deprecated)
         )
         return operationEnumDecl
     }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
@@ -208,6 +208,7 @@ extension TypesFileTranslator {
                     ]
                 )
             )
+            .deprecate(if: operation.endpoint.operation.deprecated)
         )
         return operationEnumDecl
     }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStructBlueprint.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStructBlueprint.swift
@@ -56,7 +56,7 @@ final class Test_translateStructBlueprint: Test_Core {
     func _testStruct(_ blueprint: StructBlueprint) throws -> [DeclInfo] {
         let translator = makeTypesTranslator()
         let decl = translator.translateStructBlueprint(blueprint)
-        guard case .struct(let structDecl) = decl else {
+        guard case .struct(let structDecl) = decl.strippingTopComment else {
             throw UnexpectedDeclError(actual: decl.info.kind, expected: .struct)
         }
         XCTAssertEqual(structDecl.name, "Foo")

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStructBlueprint.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStructBlueprint.swift
@@ -53,6 +53,12 @@ final class Test_translateStructBlueprint: Test_Core {
         )
     }
 
+    func testDeprecatedStruct() throws {
+        let blueprint = StructBlueprint(isDeprecated: true, typeName: Self.testTypeName, properties: [])
+        let decl = makeTypesTranslator().translateStructBlueprint(blueprint)
+        XCTAssertEqual(decl.strippingTopComment.info.kind, .deprecated)
+    }
+
     func _testStruct(_ blueprint: StructBlueprint) throws -> [DeclInfo] {
         let translator = makeTypesTranslator()
         let decl = translator.translateStructBlueprint(blueprint)

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -50,6 +50,7 @@ paths:
         - name: My-Request-UUID
           in: header
           description: Request identifier
+          deprecated: true
           schema:
             format: uuid
             type: string
@@ -116,6 +117,7 @@ paths:
   /probe/:
     post:
       operationId: probe
+      deprecated: true
       responses:
         '204':
           description: Ack
@@ -370,6 +372,17 @@ components:
         - $ref: '#/components/schemas/MessagedExercise'
       discriminator:
         propertyName: kind
+    DeprecatedObject:
+      deprecated: true
+      type: object
+      properties: {}
+      additionalProperties: false
+    ObjectWithDeprecatedProperty:
+      type: object
+      properties:
+        message:
+          type: string
+          deprecated: true
   responses:
     ErrorBadRequest:
       description: Bad request

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -50,7 +50,6 @@ paths:
         - name: My-Request-UUID
           in: header
           description: Request identifier
-          deprecated: true
           schema:
             format: uuid
             type: string
@@ -204,6 +203,13 @@ components:
       schema:
         type: integer
         format: int64
+    header.deprecatedHeader:
+      name: deprecatedHeader
+      in: header
+      deprecated: true
+      description: A deprecated header parameter
+      schema:
+        type: string
   schemas:
     Pet:
       type: object

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -609,6 +609,10 @@ public enum Components {
         ///
         /// - Remark: Generated from `#/components/parameters/path.petId`.
         public typealias path_petId = Swift.Int64
+        /// A deprecated header parameter
+        ///
+        /// - Remark: Generated from `#/components/parameters/header.deprecatedHeader`.
+        public typealias header_deprecatedHeader = Swift.String
     }
     /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
     public enum RequestBodies {
@@ -800,7 +804,7 @@ public enum Operations {
             }
             public var query: Operations.listPets.Input.Query
             public struct Headers: Sendable, Equatable, Hashable {
-                @available(*, deprecated) public var My_Request_UUID: Swift.String?
+                public var My_Request_UUID: Swift.String?
                 /// Creates a new `Headers`.
                 ///
                 /// - Parameters:

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -21,7 +21,8 @@ public protocol APIProtocol: Sendable {
     func createPet(_ input: Operations.createPet.Input) async throws -> Operations.createPet.Output
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
-    func probe(_ input: Operations.probe.Input) async throws -> Operations.probe.Output
+    @available(*, deprecated) func probe(_ input: Operations.probe.Input) async throws
+        -> Operations.probe.Output
     /// Update just a specific property of an existing pet. Nothing is updated if no request body is provided.
     ///
     /// - Remark: HTTP `PATCH /pets/{petId}`.
@@ -577,6 +578,26 @@ public enum Components {
                 }
             }
         }
+        /// - Remark: Generated from `#/components/schemas/DeprecatedObject`.
+        @available(*, deprecated)
+        public struct DeprecatedObject: Codable, Equatable, Hashable, Sendable {
+            /// Creates a new `DeprecatedObject`.
+            public init() {}
+            public init(from decoder: Decoder) throws {
+                try decoder.ensureNoAdditionalProperties(knownKeys: [])
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/ObjectWithDeprecatedProperty`.
+        public struct ObjectWithDeprecatedProperty: Codable, Equatable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/ObjectWithDeprecatedProperty/message`.
+            @available(*, deprecated) public var message: Swift.String?
+            /// Creates a new `ObjectWithDeprecatedProperty`.
+            ///
+            /// - Parameters:
+            ///   - message:
+            public init(message: Swift.String? = nil) { self.message = message }
+            public enum CodingKeys: String, CodingKey { case message }
+        }
     }
     /// Types generated from the `#/components/parameters` section of the OpenAPI document.
     public enum Parameters {
@@ -779,7 +800,7 @@ public enum Operations {
             }
             public var query: Operations.listPets.Input.Query
             public struct Headers: Sendable, Equatable, Hashable {
-                public var My_Request_UUID: Swift.String?
+                @available(*, deprecated) public var My_Request_UUID: Swift.String?
                 /// Creates a new `Headers`.
                 ///
                 /// - Parameters:
@@ -1006,7 +1027,7 @@ public enum Operations {
     }
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
-    public enum probe {
+    @available(*, deprecated) public enum probe {
         public static let id: String = "probe"
         public struct Input: Sendable, Equatable, Hashable {
             public struct Path: Sendable, Equatable, Hashable {

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -1031,7 +1031,7 @@ public enum Operations {
     }
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
-    @available(*, deprecated) public enum probe {
+    public enum probe {
         public static let id: String = "probe"
         public struct Input: Sendable, Equatable, Hashable {
             public struct Path: Sendable, Equatable, Hashable {

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -11,7 +11,14 @@ services:
   test:
     image: *image
     environment:
-      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      # Because OpenAPI supports deprecation, the generated code could include
+      # deprecated symbols, which will produce warnings.
+      #
+      # We'll desable -warnings-as-errors for now and revisit this when we
+      # refactor the compilation of the generated code into a separate
+      # pipeline.
+      #
+      # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -10,7 +10,14 @@ services:
   test:
     image: *image
     environment:
-      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      # Because OpenAPI supports deprecation, the generated code could include
+      # deprecated symbols, which will produce warnings.
+      #
+      # We'll desable -warnings-as-errors for now and revisit this when we
+      # refactor the compilation of the generated code into a separate
+      # pipeline.
+      #
+      # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -11,7 +11,14 @@ services:
   test:
     image: *image
     environment:
-      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      # Because OpenAPI supports deprecation, the generated code could include
+      # deprecated symbols, which will produce warnings.
+      #
+      # We'll desable -warnings-as-errors for now and revisit this when we
+      # refactor the compilation of the generated code into a separate
+      # pipeline.
+      #
+      # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
 
   shell:


### PR DESCRIPTION
### Motivation

The OpenAPI spec supports declaring various parts of the API as deprecated, including operations, parameters, schemas, and properties. These can be surfaced in the generated code by adding `@available(*, deprecated)` annotations to the functions, types, and properties. 

### Modifications

- Support for deprecated OpenAPI schemas.
- Support for deprecated OpenAPI properties.
- Support for deprecated OpenAPI operations.

For deprecated operations, these are annotated on the function requirements in the generated `APIProtocol`.

### Result

Deprecated annotations are generated for the parts of the API marked as deprecated in the OpenAPI document.

### Test Plan

- Added `#/components/schemas/DeprecatedObject` to reference test.
- Added `#/components/schemas/ObjectWithDeprecatedProperty` to reference test.
- Marked `#/paths//probe//post` operation as deprecated in reference test.
- Marked `#/components/parameters/My-Request-UUID` parameter as deprecated in reference test.
- Unit tests for rendering `DeprecatedDescription` already existed.

### Resolves

Resolves #26.
