### PR TITLE
Fix typo in comments in docker-compose files

### DIFF
--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -14,7 +14,7 @@ services:
       # Because OpenAPI supports deprecation, the generated code could include
       # deprecated symbols, which will produce warnings.
       #
-      # We'll desable -warnings-as-errors for now and revisit this when we
+      # We'll disable -warnings-as-errors for now and revisit this when we
       # refactor the compilation of the generated code into a separate
       # pipeline.
       #

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -13,7 +13,7 @@ services:
       # Because OpenAPI supports deprecation, the generated code could include
       # deprecated symbols, which will produce warnings.
       #
-      # We'll desable -warnings-as-errors for now and revisit this when we
+      # We'll disable -warnings-as-errors for now and revisit this when we
       # refactor the compilation of the generated code into a separate
       # pipeline.
       #

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -14,7 +14,7 @@ services:
       # Because OpenAPI supports deprecation, the generated code could include
       # deprecated symbols, which will produce warnings.
       #
-      # We'll desable -warnings-as-errors for now and revisit this when we
+      # We'll disable -warnings-as-errors for now and revisit this when we
       # refactor the compilation of the generated code into a separate
       # pipeline.
       #


### PR DESCRIPTION
### Motivation

In #92 we made some changes to the Compose files for CI. It introduced some typos in some comments.

### Modifications

Fix typos in the compose files.

### Result

Compose files don't have typos.

### Test Plan

None.