### PR TITLE
Use existential any in generated code

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -377,6 +377,11 @@ struct ParameterDescription: Equatable, Codable {
     /// For example, in `bar baz: String = "hi"`, `name` is `baz`.
     var name: String? = nil
 
+    /// The existential any keyword.
+    ///
+    /// For example, in `bar baz: any Client = ...`, `any` is the keyword referred to here.
+    var anyKeyword: Bool = false
+
     /// The type name of the parameter.
     ///
     /// For example, in `bar baz: String = "hi"`, `type` is `String`.

--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -610,6 +610,9 @@ struct TextBasedRenderer: RendererProtocol {
             }
         }
         words.append(":")
+        if parameterDescription.anyKeyword {
+            words.append("any")
+        }
         words.append(parameterDescription.type)
         if let defaultValue = parameterDescription.defaultValue {
             words.append("=")

--- a/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/ClientTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/ClientTranslator.swift
@@ -79,10 +79,14 @@ struct ClientFileTranslator: FileTranslator {
                         type: Constants.Configuration.typeName,
                         defaultValue: .dot("init").call([])
                     ),
-                    .init(label: "transport", type: Constants.Client.Transport.typeName),
+                    .init(
+                        label: "transport",
+                        anyKeyword: true,
+                        type: Constants.Client.Transport.typeName
+                    ),
                     .init(
                         label: "middlewares",
-                        type: "[\(Constants.Client.Middleware.typeName)]",
+                        type: "[any \(Constants.Client.Middleware.typeName)]",
                         defaultValue: .literal(.array([]))
                     ),
                 ],

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
@@ -593,7 +593,7 @@ fileprivate extension FileTranslator {
             accessModifier: config.access,
             kind: .function(name: "encode"),
             parameters: [
-                .init(label: "to", name: "encoder", type: "Encoder")
+                .init(label: "to", name: "encoder", anyKeyword: true, type: "Encoder")
             ],
             keywords: [
                 .throws
@@ -610,7 +610,7 @@ fileprivate extension FileTranslator {
             accessModifier: config.access,
             kind: .initializer,
             parameters: [
-                .init(label: "from", name: "decoder", type: "Decoder")
+                .init(label: "from", name: "decoder", anyKeyword: true, type: "Decoder")
             ],
             keywords: [
                 .throws

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
@@ -79,6 +79,7 @@ struct ServerFileTranslator: FileTranslator {
                     .init(
                         label: "on",
                         name: "transport",
+                        anyKeyword: true,
                         type: Constants.Server.Transport.typeName
                     ),
                     .init(
@@ -93,7 +94,7 @@ struct ServerFileTranslator: FileTranslator {
                     ),
                     .init(
                         label: "middlewares",
-                        type: "[\(Constants.Server.Middleware.typeName)]",
+                        type: "[any \(Constants.Server.Middleware.typeName)]",
                         defaultValue: .literal(.array([]))
                     ),
                 ],

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -22,8 +22,8 @@ public struct Client: APIProtocol {
     public init(
         serverURL: URL,
         configuration: Configuration = .init(),
-        transport: ClientTransport,
-        middlewares: [ClientMiddleware] = []
+        transport: any ClientTransport,
+        middlewares: [any ClientMiddleware] = []
     ) {
         self.client = .init(
             serverURL: serverURL,

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -14,10 +14,10 @@ extension APIProtocol {
     ///   - configuration: A set of configuration values for the server.
     ///   - middlewares: A list of middlewares to call before the handler.
     public func registerHandlers(
-        on transport: ServerTransport,
+        on transport: any ServerTransport,
         serverURL: URL = .defaultOpenAPIServerURL,
         configuration: Configuration = .init(),
-        middlewares: [ServerMiddleware] = []
+        middlewares: [any ServerMiddleware] = []
     ) throws {
         let server = UniversalServer(
             serverURL: serverURL,

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -177,8 +177,10 @@ public enum Components {
                 /// - Parameters:
                 ///   - value1:
                 public init(value1: Components.Schemas.ExtraInfo) { self.value1 = value1 }
-                public init(from decoder: Decoder) throws { value1 = try .init(from: decoder) }
-                public func encode(to encoder: Encoder) throws { try value1.encode(to: encoder) }
+                public init(from decoder: any Decoder) throws { value1 = try .init(from: decoder) }
+                public func encode(to encoder: any Encoder) throws {
+                    try value1.encode(to: encoder)
+                }
             }
             /// Extra information about the error.
             ///
@@ -268,7 +270,7 @@ public enum Components {
             ///   - foo:
             public init(foo: Swift.String? = nil) { self.foo = foo }
             public enum CodingKeys: String, CodingKey { case foo }
-            public init(from decoder: Decoder) throws {
+            public init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 foo = try container.decodeIfPresent(Swift.String.self, forKey: .foo)
                 try decoder.ensureNoAdditionalProperties(knownKeys: ["foo"])
@@ -293,12 +295,12 @@ public enum Components {
                 self.additionalProperties = additionalProperties
             }
             public enum CodingKeys: String, CodingKey { case foo }
-            public init(from decoder: Decoder) throws {
+            public init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 foo = try container.decodeIfPresent(Swift.String.self, forKey: .foo)
                 additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: ["foo"])
             }
-            public func encode(to encoder: Encoder) throws {
+            public func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfPresent(foo, forKey: .foo)
                 try encoder.encodeAdditionalProperties(additionalProperties)
@@ -323,12 +325,12 @@ public enum Components {
                 self.additionalProperties = additionalProperties
             }
             public enum CodingKeys: String, CodingKey { case foo }
-            public init(from decoder: Decoder) throws {
+            public init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 foo = try container.decodeIfPresent(Swift.String.self, forKey: .foo)
                 additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: ["foo"])
             }
-            public func encode(to encoder: Encoder) throws {
+            public func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfPresent(foo, forKey: .foo)
                 try encoder.encodeAdditionalProperties(additionalProperties)
@@ -374,11 +376,11 @@ public enum Components {
                 self.value1 = value1
                 self.value2 = value2
             }
-            public init(from decoder: Decoder) throws {
+            public init(from decoder: any Decoder) throws {
                 value1 = try .init(from: decoder)
                 value2 = try .init(from: decoder)
             }
-            public func encode(to encoder: Encoder) throws {
+            public func encode(to encoder: any Encoder) throws {
                 try value1.encode(to: encoder)
                 try value2.encode(to: encoder)
             }
@@ -412,7 +414,7 @@ public enum Components {
                 self.value1 = value1
                 self.value2 = value2
             }
-            public init(from decoder: Decoder) throws {
+            public init(from decoder: any Decoder) throws {
                 value1 = try? .init(from: decoder)
                 value2 = try? .init(from: decoder)
                 try DecodingError.verifyAtLeastOneSchemaIsNotNil(
@@ -421,7 +423,7 @@ public enum Components {
                     codingPath: decoder.codingPath
                 )
             }
-            public func encode(to encoder: Encoder) throws {
+            public func encode(to encoder: any Encoder) throws {
                 try value1?.encode(to: encoder)
                 try value2?.encode(to: encoder)
             }
@@ -449,7 +451,7 @@ public enum Components {
             case case4(Components.Schemas.OneOfAny.Case4Payload)
             /// Parsed a case that was not defined in the OpenAPI document.
             case undocumented(OpenAPIRuntime.OpenAPIValueContainer)
-            public init(from decoder: Decoder) throws {
+            public init(from decoder: any Decoder) throws {
                 do {
                     self = .case1(try .init(from: decoder))
                     return
@@ -470,7 +472,7 @@ public enum Components {
                 let value = try container.decode(OpenAPIRuntime.OpenAPIValueContainer.self)
                 self = .undocumented(value)
             }
-            public func encode(to encoder: Encoder) throws {
+            public func encode(to encoder: any Encoder) throws {
                 switch self {
                 case let .case1(value): try value.encode(to: encoder)
                 case let .case2(value): try value.encode(to: encoder)
@@ -540,11 +542,11 @@ public enum Components {
                 self.value1 = value1
                 self.value2 = value2
             }
-            public init(from decoder: Decoder) throws {
+            public init(from decoder: any Decoder) throws {
                 value1 = try .init(from: decoder)
                 value2 = try .init(from: decoder)
             }
-            public func encode(to encoder: Encoder) throws {
+            public func encode(to encoder: any Encoder) throws {
                 try value1.encode(to: encoder)
                 try value2.encode(to: encoder)
             }
@@ -558,7 +560,7 @@ public enum Components {
             /// Parsed a case that was not defined in the OpenAPI document.
             case undocumented(OpenAPIRuntime.OpenAPIObjectContainer)
             public enum CodingKeys: String, CodingKey { case kind }
-            public init(from decoder: Decoder) throws {
+            public init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 let discriminator = try container.decode(String.self, forKey: .kind)
                 switch discriminator {
@@ -570,7 +572,7 @@ public enum Components {
                     self = .undocumented(value)
                 }
             }
-            public func encode(to encoder: Encoder) throws {
+            public func encode(to encoder: any Encoder) throws {
                 switch self {
                 case let .Walk(value): try value.encode(to: encoder)
                 case let .MessagedExercise(value): try value.encode(to: encoder)
@@ -583,7 +585,7 @@ public enum Components {
         public struct DeprecatedObject: Codable, Equatable, Hashable, Sendable {
             /// Creates a new `DeprecatedObject`.
             public init() {}
-            public init(from decoder: Decoder) throws {
+            public init(from decoder: any Decoder) throws {
                 try decoder.ensureNoAdditionalProperties(knownKeys: [])
             }
         }


### PR DESCRIPTION
### Motivation

The generated code doesn't use existential any which disables the user targets of this package to enable the `.enableUpcomingFeature("ExistentialAny")` swift settings.

### Modifications

Always use existential any in the generated code. An exhaustive list of the protocols I found being used which now use existential any:
* `any Decoder`
* `any Encoder`
* `any ClientTransport`
* `any ServerTransport`
* `any ClientMiddleware`
* `any ServerMiddleware`

### Result

Both compatibility with users who wish to enable the `ExistentialAny` upcoming-feature flag on their targets, as well as being ready for Swift 6.

### Test Plan

Modified the tests to reflect this change.

### Considerations

* Moving to existential any should not break any user codes.
* I did not include the `some` keyword as that might be removed for Swift 6 and become the default when no related keywords are used, from what i've read in the forums.