### PR TITLE
Docs: Change macos platform version

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.1.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.1.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "GreetingService",
     platforms: [
-        .macOS(.v10_15)
+        .macOS(.v13)
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
### Motivation

I was following the tutorial, but it was unable to build due to `OpenAPIVapor` requiring a higher minimum target

<img width="401" alt="Screenshot 2023-07-06 at 09 39 59" src="https://github.com/apple/swift-openapi-generator/assets/15106299/0f2b31ac-948f-448f-b9e9-51f71a76029a">

### Modifications

I changed the version of macOS in the "Generating server stubs in a Swift package" tutorial.

### Result

You should be able to follow the tutorial all the way through without errors

### Test Plan

Ran the soundness script.
