### PR TITLE
Add finer-grain reference tests for translation phase

### DIFF
--- a/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
@@ -33,7 +33,7 @@ extension TestConfig {
 }
 
 /// Tests that the generator produces Swift files that match a reference.
-class ReferenceTests: XCTestCase {
+class FileBasedReferenceTests: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
@@ -141,7 +141,7 @@ class ReferenceTests: XCTestCase {
     }
 }
 
-extension ReferenceTests {
+extension FileBasedReferenceTests {
     private func makeGeneratorPipeline(config: Config) -> GeneratorPipeline {
 
         let parser = YamsParser()

--- a/Tests/OpenAPIGeneratorReferenceTests/ReferenceTest.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/ReferenceTest.swift
@@ -82,10 +82,8 @@ class ReferenceTests: XCTestCase {
         )
 
         // Run the requested generator invocation
-        let diagnostics: DiagnosticCollector = strictDiagnosticsCollector
         let generatorPipeline = self.makeGeneratorPipeline(
-            config: referenceTest.asConfig,
-            diagnostics: diagnostics
+            config: referenceTest.asConfig
         )
         let generatedOutputSource = try generatorPipeline.run(input)
 
@@ -143,31 +141,8 @@ class ReferenceTests: XCTestCase {
     }
 }
 
-struct StrictDiagnosticsCollector: DiagnosticCollector {
-    var test: XCTestCase
-
-    func emit(_ diagnostic: Diagnostic) {
-        print("Test emitted diagnostic: \(diagnostic.description)")
-        switch diagnostic.severity {
-        case .note:
-            // no need to fail, just print
-            break
-        case .warning, .error:
-            XCTFail("Failing with a diagnostic: \(diagnostic.description)")
-        }
-    }
-}
-
 extension ReferenceTests {
-
-    var strictDiagnosticsCollector: DiagnosticCollector {
-        StrictDiagnosticsCollector(test: self)
-    }
-
-    private func makeGeneratorPipeline(
-        config: Config,
-        diagnostics: DiagnosticCollector
-    ) -> GeneratorPipeline {
+    private func makeGeneratorPipeline(config: Config) -> GeneratorPipeline {
 
         let parser = YamsParser()
         let translator = MultiplexTranslator()
@@ -183,7 +158,7 @@ extension ReferenceTests {
                 return newFile
             },
             config: config,
-            diagnostics: diagnostics
+            diagnostics: XCTestDiagnosticCollector(test: self)
         )
     }
 

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -92,7 +92,6 @@ final class SnippetBasedReferenceTests: XCTestCase {
             schemas:
               MyObject:
                 type: object
-                title: My object
                 properties:
                   id:
                     type: integer
@@ -175,7 +174,6 @@ final class SnippetBasedReferenceTests: XCTestCase {
             schemas:
               MyObject:
                 type: object
-                title: My object
                 properties: {}
                 additionalProperties: false
                 deprecated: true
@@ -200,7 +198,6 @@ final class SnippetBasedReferenceTests: XCTestCase {
             schemas:
               MyObject:
                 type: object
-                title: My object
                 properties:
                   id:
                     type: string

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -88,35 +88,35 @@ final class SnippetBasedReferenceTests: XCTestCase {
 
     func testComponentsSchemasObject() throws {
         let componentsYAML = """
-            schemas:
-              MyObject:
-                type: object
-                title: My object
-                properties:
-                  id:
-                    type: integer
-                    format: int64
-                  alias:
-                    type: string
-                required:
-                  - id
-        """
+                schemas:
+                  MyObject:
+                    type: object
+                    title: My object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
+                      alias:
+                        type: string
+                    required:
+                      - id
+            """
         let expectedSwift = """
-            public enum Schemas {
-              public struct MyObject: Codable, Equatable, Hashable, Sendable {
-                public var id: Swift.Int64
-                public var alias: Swift.String?
-                public init(id: Swift.Int64, alias: Swift.String? = nil) {
-                    self.id = id
-                    self.alias = alias
+                public enum Schemas {
+                  public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                    public var id: Swift.Int64
+                    public var alias: Swift.String?
+                    public init(id: Swift.Int64, alias: Swift.String? = nil) {
+                        self.id = id
+                        self.alias = alias
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case id
+                        case alias
+                    }
+                  }
                 }
-                public enum CodingKeys: String, CodingKey {
-                    case id
-                    case alias
-                }
-              }
-            }
-        """
+            """
         let translator = try makeTypesTranslator(componentsYAML: componentsYAML)
         let translation = try translator.translateSchemas(translator.components.schemas)
         try XCTAssertSwiftEquivalent(translation, expectedSwift)
@@ -124,48 +124,48 @@ final class SnippetBasedReferenceTests: XCTestCase {
 
     func testComponentsSchemasEnum() throws {
         let componentsYAML = """
-          schemas:
-            MyEnum:
-              type: string
-              enum:
-                - one
-                -
-                - $tart
-                - public
-        """
+              schemas:
+                MyEnum:
+                  type: string
+                  enum:
+                    - one
+                    -
+                    - $tart
+                    - public
+            """
         let expectedSwift = """
-            public enum Schemas {
-                @frozen
-                public enum MyEnum: RawRepresentable, Codable, Equatable, Hashable, Sendable,
-                    _AutoLosslessStringConvertible, CaseIterable
-                {
-                    case one
-                    case _empty
-                    case _tart
-                    case _public
-                    case undocumented(String)
-                    public init?(rawValue: String) {
-                        switch rawValue {
-                            case "one": self = .one
-                            case "": self = ._empty
-                            case "$tart": self = ._tart
-                            case "public": self = ._public
-                            default: self = .undocumented(rawValue)
+                public enum Schemas {
+                    @frozen
+                    public enum MyEnum: RawRepresentable, Codable, Equatable, Hashable, Sendable,
+                        _AutoLosslessStringConvertible, CaseIterable
+                    {
+                        case one
+                        case _empty
+                        case _tart
+                        case _public
+                        case undocumented(String)
+                        public init?(rawValue: String) {
+                            switch rawValue {
+                                case "one": self = .one
+                                case "": self = ._empty
+                                case "$tart": self = ._tart
+                                case "public": self = ._public
+                                default: self = .undocumented(rawValue)
+                            }
                         }
-                    }
-                    public var rawValue: String {
-                        switch self {
-                            case let .undocumented(string): return string
-                            case .one: return "one"
-                            case ._empty: return ""
-                            case ._tart: return "$tart"
-                            case ._public: return "public"
+                        public var rawValue: String {
+                            switch self {
+                                case let .undocumented(string): return string
+                                case .one: return "one"
+                                case ._empty: return ""
+                                case ._tart: return "$tart"
+                                case ._public: return "public"
+                            }
                         }
+                        public static var allCases: [MyEnum] { [.one, ._empty, ._tart, ._public] }
                     }
-                    public static var allCases: [MyEnum] { [.one, ._empty, ._tart, ._public] }
                 }
-            }
-        """
+            """
         let translator = try makeTypesTranslator(componentsYAML: componentsYAML)
         let translation = try translator.translateSchemas(translator.components.schemas)
         try XCTAssertSwiftEquivalent(translation, expectedSwift)

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -168,6 +168,56 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
         )
     }
+
+    func testComponentsSchemasDeprecatedObject() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              MyObject:
+                type: object
+                title: My object
+                properties: {}
+                additionalProperties: false
+                deprecated: true
+            """,
+            """
+            public enum Schemas {
+                @available(*, deprecated)
+                public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                    public init() {}
+                    public init(from decoder: Decoder) throws {
+                        try decoder.ensureNoAdditionalProperties(knownKeys: [])
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsSchemasObjectWithDeprecatedProperty() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              MyObject:
+                type: object
+                title: My object
+                properties:
+                  id:
+                    type: string
+                    deprecated: true
+            """,
+            """
+            public enum Schemas {
+                public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                    @available(*, deprecated)
+                    public var id: Swift.String?
+                    public init(id: Swift.String? = nil) { self.id = id }
+                    public enum CodingKeys: String, CodingKey { case id }
+                }
+            }
+            """
+        )
+    }
 }
 
 extension SnippetBasedReferenceTests {

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1,0 +1,351 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIKit30
+import XCTest
+import Yams
+@testable import _OpenAPIGeneratorCore
+
+/// Tests that the generator produces Swift code that match a reference.
+final class SnippetBasedReferenceTests: XCTestCase {
+    func testComponentsHeadersInline() throws {
+        try self.assertHeadersTranslation(
+            """
+            openapi: "3.0.3"
+            info:
+              title: "Test"
+              version: "0.0.0"
+            paths: {}
+            components:
+              headers:
+                MyHeader:
+                  schema:
+                    type: string
+            """,
+            """
+            public enum Headers {
+              public typealias MyHeader = Swift.String
+            }
+            """
+        )
+    }
+
+    func testComponentsHeadersReference() throws {
+        try self.assertHeadersTranslation(
+            """
+            openapi: "3.0.3"
+            info:
+              title: "Test"
+              version: "0.0.0"
+            paths: {}
+            components:
+              headers:
+                MyHeader:
+                  schema:
+                    $ref: "#/components/schemas/MySchema"
+            """,
+            """
+            public enum Headers {
+              public typealias MyHeader = Components.Schemas.MySchema
+            }
+            """
+        )
+    }
+
+    func testComponentsParametersInline() throws {
+        try self.assertParametersTranslation(
+            """
+            openapi: "3.0.3"
+            info:
+              title: "Test"
+              version: "0.0.0"
+            paths: {}
+            components:
+              parameters:
+                MyParam:
+                  in: query
+                  name: my_param
+                  schema:
+                    type: string
+            """,
+            """
+            public enum Parameters {
+              public typealias MyParam = Swift.String
+            }
+            """
+        )
+    }
+
+    func testComponentsParametersReference() throws {
+        try self.assertParametersTranslation(
+            """
+            openapi: "3.0.3"
+            info:
+              title: "Test"
+              version: "0.0.0"
+            paths: {}
+            components:
+              parameters:
+                MyParam:
+                  in: query
+                  name: my_param
+                  schema:
+                    $ref: "#/components/schemas/MySchema"
+            """,
+            """
+            public enum Parameters {
+              public typealias MyParam = Components.Schemas.MySchema
+            }
+            """
+        )
+    }
+
+    func testComponentsSchemasObject() throws {
+        let openAPIDocument = """
+                openapi: "3.0.3"
+                info:
+                  title: "Test"
+                  version: "0.0.0"
+                paths: {}
+                components:
+                  schemas:
+                    MyObject:
+                      type: object
+                      title: My object
+                      properties:
+                        id:
+                          type: integer
+                          format: int64
+                        alias:
+                          type: string
+                      required:
+                        - id
+            """
+        let expectedSwift = """
+                public enum Schemas {
+                  public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                    public var id: Swift.Int64
+                    public var alias: Swift.String?
+                    public init(id: Swift.Int64, alias: Swift.String? = nil) {
+                        self.id = id
+                        self.alias = alias
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case id
+                        case alias
+                    }
+                  }
+                }
+            """
+        let translator = try makeTypesTranslator(openAPIDocument)
+        let translation = try translator.translateSchemas(translator.components.schemas)
+        try XCTAssertSwiftEquivalent(translation, expectedSwift)
+    }
+
+    func testComponentsSchemasEnum() throws {
+        let openAPIDocument = """
+                openapi: "3.0.3"
+                info:
+                  title: "Test"
+                  version: "0.0.0"
+                paths: {}
+                components:
+                  schemas:
+                    MyEnum:
+                      type: string
+                      enum:
+                        - one
+                        # empty
+                        -
+                        # illegal character
+                        - $tart
+                        # keyword
+                        - public
+            """
+        let expectedSwift = """
+                public enum Schemas {
+                    @frozen
+                    public enum MyEnum: RawRepresentable, Codable, Equatable, Hashable, Sendable,
+                        _AutoLosslessStringConvertible, CaseIterable
+                    {
+                        case one
+                        case _empty
+                        case _tart
+                        case _public
+                        case undocumented(String)
+                        public init?(rawValue: String) {
+                            switch rawValue {
+                                case "one": self = .one
+                                case "": self = ._empty
+                                case "$tart": self = ._tart
+                                case "public": self = ._public
+                                default: self = .undocumented(rawValue)
+                            }
+                        }
+                        public var rawValue: String {
+                            switch self {
+                                case let .undocumented(string): return string
+                                case .one: return "one"
+                                case ._empty: return ""
+                                case ._tart: return "$tart"
+                                case ._public: return "public"
+                            }
+                        }
+                        public static var allCases: [MyEnum] { [.one, ._empty, ._tart, ._public] }
+                    }
+                }
+            """
+        let translator = try makeTypesTranslator(openAPIDocument)
+        let translation = try translator.translateSchemas(translator.components.schemas)
+        try XCTAssertSwiftEquivalent(translation, expectedSwift)
+    }
+}
+
+extension SnippetBasedReferenceTests {
+    func makeTypesTranslator(_ openAPIDocument: String) throws -> TypesFileTranslator {
+        let document = try YAMLDecoder().decode(OpenAPI.Document.self, from: openAPIDocument)
+        return TypesFileTranslator(
+            config: Config(mode: .types),
+            diagnostics: XCTestDiagnosticCollector(test: self),
+            components: document.components
+        )
+    }
+
+    func assertHeadersTranslation(
+        _ openAPIDocument: String,
+        _ expectedSwift: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let translator = try makeTypesTranslator(openAPIDocument)
+        let translation = try translator.translateComponentHeaders(translator.components.headers)
+        try XCTAssertSwiftEquivalent(translation, expectedSwift, file: file, line: line)
+    }
+
+    func assertParametersTranslation(
+        _ openAPIDocument: String,
+        _ expectedSwift: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let translator = try makeTypesTranslator(openAPIDocument)
+        let translation = try translator.translateComponentParameters(translator.components.parameters)
+        try XCTAssertSwiftEquivalent(translation, expectedSwift, file: file, line: line)
+    }
+}
+
+private func XCTAssertEqualWithDiff(
+    _ actual: String,
+    _ expected: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
+    if actual == expected { return }
+    XCTFail(
+        """
+        XCTAssertEqualWithDiff failed (click for diff)
+        \(try diff(expected: expected, actual: actual))
+        """,
+        file: file,
+        line: line
+    )
+}
+
+private func XCTAssertSwiftEquivalent(
+    _ declaration: Declaration,
+    _ expectedSwift: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
+    try XCTAssertEqualWithDiff(
+        TextBasedRenderer().renderedDeclaration(declaration.strippingComments).swiftFormatted,
+        expectedSwift.swiftFormatted,
+        file: file,
+        line: line
+    )
+}
+
+private func diff(expected: String, actual: String) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = [
+        "bash", "-c",
+        "diff -U5 --label=expected <(echo '\(expected)') --label=actual <(echo '\(actual)')",
+    ]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    try process.run()
+    process.waitUntilExit()
+    let pipeData = try XCTUnwrap(
+        pipe.fileHandleForReading.readToEnd(),
+        """
+        No output from command:
+        \(process.executableURL!.path) \(process.arguments!.joined(separator: " "))
+        """
+    )
+    return String(decoding: pipeData, as: UTF8.self)
+}
+
+fileprivate extension Declaration {
+    var strippingComments: Self { stripComments(self) }
+
+    func stripComments(_ decl: Declaration) -> Declaration {
+        switch decl {
+        case let .commentable(_, d):
+            return stripComments(d)
+        case let .deprecated(a, b):
+            return .deprecated(a, stripComments(b))
+        case var .protocol(p):
+            p.members = p.members.map(stripComments(_:))
+            return .protocol(p)
+        case var .function(f):
+            f.body = f.body?.map(stripComments(_:))
+            return .function(f)
+        case var .extension(e):
+            e.declarations = e.declarations.map(stripComments(_:))
+            return .extension(e)
+        case var .struct(s):
+            s.members = s.members.map(stripComments(_:))
+            return .struct(s)
+        case var .enum(e):
+            e.members = e.members.map(stripComments(_:))
+            return .enum(e)
+        case var .variable(v):
+            v.body = stripComments(v.body)
+            return .variable(v)
+        case let .typealias(t):
+            return .typealias(t)
+        case let .enumCase(e):
+            return .enumCase(e)
+        }
+    }
+
+    func stripComments(_ body: [CodeBlock]?) -> [CodeBlock]? {
+        body.map(stripComments(_:))
+    }
+
+    func stripComments(_ body: [CodeBlock]) -> [CodeBlock] {
+        body.map(stripComments(_:))
+    }
+
+    func stripComments(_ codeBlock: CodeBlock) -> CodeBlock {
+        CodeBlock(comment: nil, item: stripComments(codeBlock.item))
+    }
+
+    func stripComments(_ codeBlockItem: CodeBlockItem) -> CodeBlockItem {
+        switch codeBlockItem {
+        case let .declaration(d): return .declaration(stripComments(d))
+        case .expression: return codeBlockItem
+        }
+    }
+}

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -471,7 +471,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 public struct BadRequest: Sendable, Equatable, Hashable {
                     public struct Headers: Sendable, Equatable, Hashable { public init() {} }
                     public var headers: Components.Responses.BadRequest.Headers
-                    public enum Body: Sendable, Equatable, Hashable {}
+                    @frozen public enum Body: Sendable, Equatable, Hashable {}
                     public var body: Components.Responses.BadRequest.Body?
                     public init(
                         headers: Components.Responses.BadRequest.Headers = .init(),
@@ -502,7 +502,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 public struct BadRequest: Sendable, Equatable, Hashable {
                     public struct Headers: Sendable, Equatable, Hashable { public init() {} }
                     public var headers: Components.Responses.BadRequest.Headers
-                    public enum Body: Sendable, Equatable, Hashable {
+                    @frozen public enum Body: Sendable, Equatable, Hashable {
                         case json(Swift.String)
                     }
                     public var body: Components.Responses.BadRequest.Body
@@ -539,7 +539,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                             self.X_Reason = X_Reason }
                     }
                     public var headers: Components.Responses.BadRequest.Headers
-                    public enum Body: Sendable, Equatable, Hashable {}
+                    @frozen public enum Body: Sendable, Equatable, Hashable {}
                     public var body: Components.Responses.BadRequest.Body?
                     public init(
                         headers: Components.Responses.BadRequest.Headers,
@@ -566,7 +566,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum RequestBodies {
-                public enum MyResponseBody: Sendable, Equatable, Hashable {
+                @frozen public enum MyResponseBody: Sendable, Equatable, Hashable {
                     case json(Swift.String)
                 }
             }
@@ -586,7 +586,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum RequestBodies {
-                public enum MyResponseBody: Sendable, Equatable, Hashable {
+                @frozen public enum MyResponseBody: Sendable, Equatable, Hashable {
                     case json(Components.Schemas.MyBody)
                 }
             }

--- a/Tests/OpenAPIGeneratorReferenceTests/XCTestDiagnosticCollector.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/XCTestDiagnosticCollector.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import _OpenAPIGeneratorCore
+import XCTest
+
+// A diagnostic collector that fails the running test on a warning or error.
+struct XCTestDiagnosticCollector: DiagnosticCollector {
+    var test: XCTestCase
+
+    func emit(_ diagnostic: Diagnostic) {
+        print("Test emitted diagnostic: \(diagnostic.description)")
+        switch diagnostic.severity {
+        case .note:
+            // no need to fail, just print
+            break
+        case .warning, .error:
+            XCTFail("Failing with a diagnostic: \(diagnostic.description)")
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

We have a reference test, which we've been making use of to validate end-to-end generation from OpenAPI document matches handwritten Swift files. This started out life as the canonical Petstore example from the OpenAPI specification but has since been augmented in various ways to test out some edge cases. This approach isn't scaling too well as we have an all-or-nothing test.

We also don't have great test coverage over the translation phase of the generator pipeline, which translates between the parsed OpenAPI document to an intermediate representation.

### Modifications

Add test harnesses for finer grain reference tests that exercise smaller sections of the translation phase. It should allow us to test a small OpenAPI document renders to _equivalent_ Swift source (stripping comments and reformatting).

### Result

Hopefully a more modular and maintainable testing strategy as we try to support more of the OpenAPI specification.

### Test Plan

This PR _is_ tests.