### PR TITLE
Simplify swift-format soundness script

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,7 +90,7 @@ let package = Package(
         .testTarget(
             name: "OpenAPIGeneratorCoreTests",
             dependencies: [
-                "_OpenAPIGeneratorCore",
+                "_OpenAPIGeneratorCore"
             ]
         ),
 
@@ -103,7 +103,7 @@ let package = Package(
                 .product(name: "SwiftFormatConfiguration", package: "swift-format"),
             ],
             resources: [
-                .copy("Resources"),
+                .copy("Resources")
             ]
         ),
 
@@ -113,7 +113,7 @@ let package = Package(
         .testTarget(
             name: "PetstoreConsumerTests",
             dependencies: [
-                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime")
             ]
         ),
 
@@ -131,7 +131,7 @@ let package = Package(
             name: "OpenAPIGenerator",
             capability: .buildTool(),
             dependencies: [
-                "swift-openapi-generator",
+                "swift-openapi-generator"
             ]
         ),
     ]

--- a/scripts/run-swift-format.sh
+++ b/scripts/run-swift-format.sh
@@ -23,13 +23,8 @@ REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
 
 SWIFTFORMAT_BIN=${SWIFTFORMAT_BIN:-$(command -v swift-format)} || fatal "❌ SWIFTFORMAT_BIN unset and no swift-format on PATH"
 
-"${SWIFTFORMAT_BIN}" lint \
-  --parallel --recursive --strict \
-  "${REPO_ROOT}/Examples" \
-  "${REPO_ROOT}/IntegrationTest" \
-  "${REPO_ROOT}/Plugins" \
-  "${REPO_ROOT}/Sources" \
-  "${REPO_ROOT}/Tests" \
+git -C "${REPO_ROOT}" ls-files -z '*.swift' \
+  | xargs -0 "${SWIFTFORMAT_BIN}" lint --parallel --strict \
   && SWIFT_FORMAT_RC=$? || SWIFT_FORMAT_RC=$?
 
 if [ "${SWIFT_FORMAT_RC}" -ne 0 ]; then
@@ -37,7 +32,7 @@ if [ "${SWIFT_FORMAT_RC}" -ne 0 ]; then
 
   To fix, run the following command:
 
-    % swift-format format --parallel --recursive --in-place Examples IntegrationTest Plugins Sources Tests
+    % git ls-files -z '*.swift' | xargs -0 swift-format --in-place --parallel
   "
   exit "${SWIFT_FORMAT_RC}"
 fi


### PR DESCRIPTION
### Motivation

The `run-swift-format.sh` script run as part of soundness explicitly lists the directories to format. This is to avoid running `swift-format` on the contents of `.build/` which contains a checkouts of all the dependencies. This isn't necessary, as we can use Git to tell us what files need to be formatted, which can also make for a more robust script/command as we add new directories.

Additionally, with the previous strategy, `Package.swift` at the root of the repository was ignored. This was deliberate, but in hindsight I don't think the lack of trailing comma enforcement is worth us excluding it.

### Modifications

- Use `git ls-files` to determine which files need to be passed to `swift-format`.

### Result

- Script is simpler (also easier to add a one-shot command as a pre-commit hook).
- Package.swift is also formatted.

### Test Plan

None.