### PR TITLE
Generate @frozen enums for operation outputs and request/response bodies

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/RequestBody/translateRequestBody.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/RequestBody/translateRequestBody.swift
@@ -150,6 +150,7 @@ extension TypesFileTranslator {
         members: [Declaration]
     ) -> Declaration {
         let bodyEnumDecl: Declaration = .enum(
+            isFrozen: true,
             accessModifier: config.access,
             name: typeName.shortSwiftName,
             conformances: Constants.Operation.Output.conformances,

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponse.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponse.swift
@@ -83,6 +83,7 @@ extension TypesFileTranslator {
         }
         let hasNoContent: Bool = bodyCases.isEmpty
         let contentEnumDecl: Declaration = .enum(
+            isFrozen: true,
             accessModifier: config.access,
             name: bodyTypeName.shortSwiftName,
             conformances: Constants.Operation.Body.conformances,

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
@@ -161,6 +161,7 @@ extension TypesFileTranslator {
         }
 
         let enumDecl: Declaration = .enum(
+            isFrozen: true,
             accessModifier: config.access,
             name: outputTypeName.shortSwiftName,
             conformances: Constants.Operation.Output.conformances,

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -616,7 +616,7 @@ public enum Components {
     }
     /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
     public enum RequestBodies {
-        public enum UpdatePetRequest: Sendable, Equatable, Hashable {
+        @frozen public enum UpdatePetRequest: Sendable, Equatable, Hashable {
             /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json`.
             public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json/name`.
@@ -662,7 +662,7 @@ public enum Components {
             }
             /// Received HTTP response headers
             public var headers: Components.Responses.ErrorBadRequest.Headers
-            public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Equatable, Hashable {
                 /// - Remark: Generated from `#/components/responses/ErrorBadRequest/json`.
                 public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
                     /// - Remark: Generated from `#/components/responses/ErrorBadRequest/json/code`.
@@ -819,7 +819,7 @@ public enum Operations {
                 public init() {}
             }
             public var cookies: Operations.listPets.Input.Cookies
-            public enum Body: Sendable, Equatable, Hashable {}
+            @frozen public enum Body: Sendable, Equatable, Hashable {}
             public var body: Operations.listPets.Input.Body?
             /// Creates a new `Input`.
             ///
@@ -843,7 +843,7 @@ public enum Operations {
                 self.body = body
             }
         }
-        public enum Output: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Equatable, Hashable {
             public struct Ok: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     public var My_Response_UUID: Swift.String
@@ -863,7 +863,7 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.listPets.Output.Ok.Headers
-                public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Equatable, Hashable {
                     case json(Components.Schemas.Pets)
                 }
                 /// Received HTTP response body
@@ -894,7 +894,7 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.listPets.Output.Default.Headers
-                public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Equatable, Hashable {
                     case json(Components.Schemas._Error)
                 }
                 /// Received HTTP response body
@@ -953,7 +953,7 @@ public enum Operations {
                 public init() {}
             }
             public var cookies: Operations.createPet.Input.Cookies
-            public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Equatable, Hashable {
                 case json(Components.Schemas.CreatePetRequest)
             }
             public var body: Operations.createPet.Input.Body
@@ -979,7 +979,7 @@ public enum Operations {
                 self.body = body
             }
         }
-        public enum Output: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Equatable, Hashable {
             public struct Created: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     public var X_Extra_Arguments: Components.Schemas.CodeError?
@@ -993,7 +993,7 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.createPet.Output.Created.Headers
-                public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Equatable, Hashable {
                     case json(Components.Schemas.Pet)
                 }
                 /// Received HTTP response body
@@ -1054,7 +1054,7 @@ public enum Operations {
                 public init() {}
             }
             public var cookies: Operations.probe.Input.Cookies
-            public enum Body: Sendable, Equatable, Hashable {}
+            @frozen public enum Body: Sendable, Equatable, Hashable {}
             public var body: Operations.probe.Input.Body?
             /// Creates a new `Input`.
             ///
@@ -1078,7 +1078,7 @@ public enum Operations {
                 self.body = body
             }
         }
-        public enum Output: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Equatable, Hashable {
             public struct NoContent: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -1086,7 +1086,7 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.probe.Output.NoContent.Headers
-                public enum Body: Sendable, Equatable, Hashable {}
+                @frozen public enum Body: Sendable, Equatable, Hashable {}
                 /// Received HTTP response body
                 public var body: Operations.probe.Output.NoContent.Body?
                 /// Creates a new `NoContent`.
@@ -1168,7 +1168,7 @@ public enum Operations {
                 self.body = body
             }
         }
-        public enum Output: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Equatable, Hashable {
             public struct NoContent: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -1176,7 +1176,7 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.updatePet.Output.NoContent.Headers
-                public enum Body: Sendable, Equatable, Hashable {}
+                @frozen public enum Body: Sendable, Equatable, Hashable {}
                 /// Received HTTP response body
                 public var body: Operations.updatePet.Output.NoContent.Body?
                 /// Creates a new `NoContent`.
@@ -1205,7 +1205,7 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.updatePet.Output.BadRequest.Headers
-                public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Equatable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/json`.
                     public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
                         /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/json/message`.
@@ -1277,7 +1277,7 @@ public enum Operations {
                 public init() {}
             }
             public var cookies: Operations.uploadAvatarForPet.Input.Cookies
-            public enum Body: Sendable, Equatable, Hashable { case binary(Foundation.Data) }
+            @frozen public enum Body: Sendable, Equatable, Hashable { case binary(Foundation.Data) }
             public var body: Operations.uploadAvatarForPet.Input.Body
             /// Creates a new `Input`.
             ///
@@ -1301,7 +1301,7 @@ public enum Operations {
                 self.body = body
             }
         }
-        public enum Output: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Equatable, Hashable {
             public struct Ok: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -1309,7 +1309,9 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.Ok.Headers
-                public enum Body: Sendable, Equatable, Hashable { case binary(Foundation.Data) }
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case binary(Foundation.Data)
+                }
                 /// Received HTTP response body
                 public var body: Operations.uploadAvatarForPet.Output.Ok.Body
                 /// Creates a new `Ok`.
@@ -1338,7 +1340,7 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.PreconditionFailed.Headers
-                public enum Body: Sendable, Equatable, Hashable { case json(Swift.String) }
+                @frozen public enum Body: Sendable, Equatable, Hashable { case json(Swift.String) }
                 /// Received HTTP response body
                 public var body: Operations.uploadAvatarForPet.Output.PreconditionFailed.Body
                 /// Creates a new `PreconditionFailed`.
@@ -1368,7 +1370,7 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.InternalServerError.Headers
-                public enum Body: Sendable, Equatable, Hashable { case text(Swift.String) }
+                @frozen public enum Body: Sendable, Equatable, Hashable { case text(Swift.String) }
                 /// Received HTTP response body
                 public var body: Operations.uploadAvatarForPet.Output.InternalServerError.Body
                 /// Creates a new `InternalServerError`.


### PR DESCRIPTION
### Motivation

The generated code contains several enum types. A lot of these are just namespaces (i.e. the enum has no cases), but some are "proper" enums that we expect adopters to switch over. For example the operation output, and the request and response bodies.

To make using these types more ergonomic, we can annotate them as `@frozen`.  This is something we already do for other generated enum types (e.g. OneOf and enum types declared in the OpenAPI document).

### Modifications

- Add desired `@frozen` attributes to reference code
- Generate `@frozen` enum for request bodies
- Generate `@frozen` enum for response bodies
- Generate `@frozen` enum for operation outputs

### Result

Switching over operation outputs and request/response bodies is simpler.

### Resolves

- Resolves #105.

### Test Plan

Reference test updated.

