### PR TITLE
Move DocC and integration tests into separate CI pipelines

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -27,8 +27,6 @@ services:
   soundness:
     <<: *common
     command: /bin/bash -xcl "swift -version && uname -a && ./scripts/soundness.sh"
-    environment:
-      SWIFT_OPENAPI_GENERATOR_REPO_URL: file:///code
 
   test:
     <<: *common
@@ -38,3 +36,14 @@ services:
     <<: *common
     entrypoint: /bin/bash
 
+  integration-test:
+    <<: *common
+    command: /bin/bash -xcl "swift -version && uname -a && bash ./scripts/run-integration-test.sh"
+    environment:
+      SWIFT_OPENAPI_GENERATOR_REPO_URL: file:///code
+
+  docc-test:
+    <<: *common
+    command: /bin/bash -xcl "swift -version && uname -a && bash ./scripts/check-for-docc-warnings.sh"
+    environment:
+      DOCC_TARGET: swift-openapi-generator

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -20,15 +20,12 @@ fatal() { error "$@"; exit 1; }
 
 CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 NUM_CHECKS_FAILED=0
-export DOCC_TARGET=swift-openapi-generator
 
 SCRIPT_PATHS=(
   "${CURRENT_SCRIPT_DIR}/check-for-broken-symlinks.sh"
   "${CURRENT_SCRIPT_DIR}/check-for-unacceptable-language.sh"
   "${CURRENT_SCRIPT_DIR}/check-license-headers.sh"
   "${CURRENT_SCRIPT_DIR}/run-swift-format.sh"
-  "${CURRENT_SCRIPT_DIR}/check-for-docc-warnings.sh"
-  "${CURRENT_SCRIPT_DIR}/run-integration-test.sh"
 )
 
 for SCRIPT_PATH in "${SCRIPT_PATHS[@]}"; do


### PR DESCRIPTION
### Motivation

Like many other projects, we have a soundness script which runs in CI. It started out with some fast policy and style tests but has grown over time. It currently has:

1. Check for broken symlinks
2. Check for unacceptable language
3. Check all files have a license headers
4. Run swift-format lint
5. Check DocC compiliation has no warnings
6. Run integration test

On my machine, (5) takes 19s and (6) takes 1m13s.

The soundness script should be cheap to run so as not to disclosure running it often—potentially even adding it to a precommit hook.

Removing (5) and (6) from the soundness suite means it takes 3s, which is more reasonable.

### Modifications

- Add `integration-test` to Compose file.
- Add `docc-test` to Compose file.
- Stop running DocC and integration tests in `soundness.sh`.

### Result

Running `soundness.sh` takes 3s (was ~1m30s).

### Test Plan

The following commands all succeed when run locally:

- `./scripts/soundness.sh`
- `docker-compose -f docker/docker-compose.yaml run soundness`
- `docker-compose -f docker/docker-compose.yaml run docc-test`
- `docker-compose -f docker/docker-compose.yaml run integration-test`

### Notes

This PR should be used to stand up the new CI pipelines and shouldn't be merged
until we see them passing.
