### PR TITLE
Support Yams 5.0 (support 4.0.0 ..< 6.0.0)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",
-            from: "4.0.0"
+            "4.0.0"..<"6.0.0"
         ),
 
         // CLI Tool


### PR DESCRIPTION
### Motivation

We're not on the latest major version of Yams, which blocks adopters updating
their dependency on Yams. But since updating is cheap (we're not using any of
the APIs that have changed in the latest release) we can upgrade to allow
dependency resolution for others.

### Modifications

- Update dependency on Yams to 5.0.0.

### Result

- Unblocks adopters wishing to use Yams >= 5.0.0.

### Test Plan

CI.
