### PR TITLE
[Tests] Add an integration test product for easier iteration

### DIFF
--- a/IntegrationTest/Package.swift
+++ b/IntegrationTest/Package.swift
@@ -19,6 +19,15 @@ let package = Package(
     platforms: [
         .macOS(.v13)
     ],
+    products: [
+        .library(name: "IntegrationTestLibrary", targets: [
+            "Types",
+            "Client",
+            "Server",
+            "MockTransportClient",
+            "MockTransportServer",
+        ]),
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),
         .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.1.0")),

--- a/IntegrationTest/Package.swift
+++ b/IntegrationTest/Package.swift
@@ -20,13 +20,16 @@ let package = Package(
         .macOS(.v13)
     ],
     products: [
-        .library(name: "IntegrationTestLibrary", targets: [
-            "Types",
-            "Client",
-            "Server",
-            "MockTransportClient",
-            "MockTransportServer",
-        ]),
+        .library(
+            name: "IntegrationTestLibrary",
+            targets: [
+                "Types",
+                "Client",
+                "Server",
+                "MockTransportClient",
+                "MockTransportServer",
+            ]
+        )
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),


### PR DESCRIPTION
### Motivation

Some IDEs don't allow you to trigger building of targets, only products.

### Modifications

Added an umbrella library product to make it possible to build locally in an IDE, not just using `swift build`.

### Result

Now the product shows up in IDEs, allowing developers to iterate on the code and rebuild.

### Test Plan

Tested that it shows up locally.
