### PR TITLE
Disable ExistentialAny temporarily

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,17 @@
 //===----------------------------------------------------------------------===//
 import PackageDescription
 
+// General Swift-settings for all targets.
+var swiftSettings: [SwiftSetting] = []
+
+#if swift(>=5.9)
+swiftSettings.append(
+    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
+    // Require `any` for existential types.
+    .enableUpcomingFeature("ExistentialAny")
+)
+#endif
+
 let package = Package(
     name: "swift-openapi-generator",
     platforms: [
@@ -84,7 +95,8 @@ let package = Package(
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
                 .product(name: "SwiftFormat", package: "swift-format"),
                 .product(name: "SwiftFormatConfiguration", package: "swift-format"),
-            ]
+            ],
+            swiftSettings: swiftSettings
         ),
 
         // Generator Core Tests
@@ -92,7 +104,8 @@ let package = Package(
             name: "OpenAPIGeneratorCoreTests",
             dependencies: [
                 "_OpenAPIGeneratorCore"
-            ]
+            ],
+            swiftSettings: swiftSettings
         ),
 
         // GeneratorReferenceTests
@@ -105,7 +118,8 @@ let package = Package(
             ],
             resources: [
                 .copy("Resources")
-            ]
+            ],
+            swiftSettings: swiftSettings
         ),
 
         // PetstoreConsumerTests
@@ -115,7 +129,8 @@ let package = Package(
             name: "PetstoreConsumerTests",
             dependencies: [
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime")
-            ]
+            ],
+            swiftSettings: swiftSettings
         ),
 
         // Generator CLI
@@ -124,7 +139,8 @@ let package = Package(
             dependencies: [
                 "_OpenAPIGeneratorCore",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-            ]
+            ],
+            swiftSettings: swiftSettings
         ),
 
         // Build Plugin

--- a/Package.swift
+++ b/Package.swift
@@ -14,13 +14,6 @@
 //===----------------------------------------------------------------------===//
 import PackageDescription
 
-// General Swift-settings for all targets.
-let swiftSettings: [SwiftSetting] = [
-    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
-    // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny")
-]
-
 let package = Package(
     name: "swift-openapi-generator",
     platforms: [
@@ -91,8 +84,7 @@ let package = Package(
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
                 .product(name: "SwiftFormat", package: "swift-format"),
                 .product(name: "SwiftFormatConfiguration", package: "swift-format"),
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
 
         // Generator Core Tests
@@ -100,8 +92,7 @@ let package = Package(
             name: "OpenAPIGeneratorCoreTests",
             dependencies: [
                 "_OpenAPIGeneratorCore"
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
 
         // GeneratorReferenceTests
@@ -114,8 +105,7 @@ let package = Package(
             ],
             resources: [
                 .copy("Resources")
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
 
         // PetstoreConsumerTests
@@ -125,8 +115,7 @@ let package = Package(
             name: "PetstoreConsumerTests",
             dependencies: [
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime")
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
 
         // Generator CLI
@@ -135,8 +124,7 @@ let package = Package(
             dependencies: [
                 "_OpenAPIGeneratorCore",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
 
         // Build Plugin


### PR DESCRIPTION
### Motivation

Unfortunately until we adopt 5.9, adding ExistentialAny on upstream packages has unintended consequences for some downstream packages, so disabling for now. Details in https://github.com/apple/swift-openapi-generator/issues/120

### Modifications

Disabled the feature enforcement, but the code changes are there, so downstream adopters can still use them.

### Result

We won't be seeing the issue described in https://github.com/apple/swift-openapi-generator/issues/120.

### Test Plan

PR CI, which discovered the original issue.
