### PR TITLE
Lower unsupported platform minimum versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         // The platforms below are not currently supported for running
         // the generator itself. We include them here to allow the generator
         // to emit a more descriptive compiler error.
-        .iOS("99"), .tvOS("99"), .watchOS("99"),
+        .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
     ],
     products: [
         .executable(name: "swift-openapi-generator", targets: ["swift-openapi-generator"]),


### PR DESCRIPTION
### Motivation

Reported in #124.

In 0.1.4 (in PR #87), we improved the build time errors emitted when an adopter tries to link the generator binary itself to a product that runs on iOS, tvOS, etc (non-macOS/Linux).

Unfortunately, that broke the ability to build multi-platform packages for iOS and friends, as the minimum platform check would fail (we claim we support iOS "99"). 

Some build systems and IDEs don't correctly separate platform checks for plugins (which run on the host platform) and the final binary (which runs on the destination platform). We should help report these issues, but at the same time, we should fix this regression in 0.1.4 to work at least as well as 0.1.3 did.

### Modifications

Lower the minimum platforms to match the runtime library. This doesn't actually make the generate build correctly on these platforms (as we still have `PlatformChecks.swift`, which contains a hard, descriptive error when building on iOS and friends), it just allows passing the (incorrect) platform check in some cases.

### Result

Fixes #124.

Now, adopters can build on the same platforms they could with 0.1.3, and we still don't build on the unsupported platforms.

### Test Plan

Tested by using a local workspace and verified that with this change, a simple package that uses the generator can build for iOS.
