### PR TITLE
fix: Correct data type of date-formatted strings

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
@@ -215,7 +215,7 @@ struct TypeMatcher {
                 typeName = .swift("String")
             case .binary:
                 typeName = .foundation("Data")
-            case .date, .dateTime:
+            case .dateTime:
                 typeName = .foundation("Date")
             default:
                 typeName = .swift("String")

--- a/Sources/swift-openapi-generator/Documentation.docc/Development/Converting-between-data-and-Swift-types.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Development/Converting-between-data-and-Swift-types.md
@@ -50,8 +50,8 @@ Below is a list of the "dimensions" across which the helper methods differ:
 - **Swift type** represents the generated type in Swift that best represents the JSON schema defined in the OpenAPI document. For example, a `string` schema is generated as `Swift.String`, an `object` schema is generated as a Swift structure, and an `array` schema is generated as a `Swift.Array` generic over the element type. For the helper methods, it's important which protocol they conform to, as those are used for serialization. Values:
     - _string-convertible_ refers to types that conform to `LosslessStringConvertible`
     - _array of string-convertibles_ refers to an array of types that conform to `LosslessStringConvertible`
-    - _date_ is represented by `Foundation.Date`
-    - _array of dates_ refers to an array of `Foundation.Date`
+    - _date-time_ is represented by `Foundation.Date`
+    - _array of date-times_ refers to an array of `Foundation.Date`
     - _codable_ refers to types that conform to `Codable`
     - _data_ is represented by `Foundation.Data`
 - **Optional/required** represents whether the method works with optional values. Values:

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
@@ -26,7 +26,7 @@ final class Test_TypeMatcher: Test_Core {
         (.string, "Swift.String"),
         (.string(.init(format: .byte), .init()), "Swift.String"),
         (.string(.init(format: .binary), .init()), "Foundation.Data"),
-        (.string(.init(format: .date), .init()), "Foundation.Date"),
+        (.string(.init(format: .date), .init()), "Swift.String"),
         (.string(.init(format: .dateTime), .init()), "Foundation.Date"),
 
         (.integer, "Swift.Int"),


### PR DESCRIPTION
### Motivation

While OpenAPI date-formatted strings do not contain information about a specific time, `Foundation.Date` only supports full timestamps. Also, `ISO8601DateTranscoder` does not support parsing ISO-8601 dates without time information. This commit introduces the expected behavior that date-only strings are not automatically decoded to `Foundation.Date` objects. This PR fixes issue #136.

### Modifications

`.date` was removed from the case-condition that defined `Foundation.Date` as the applicable type name.

### Result

`date`-formatted strings are no longer represented as `Foundation.Date` but as `Swift.String` objects.

### Test Plan

Tests were adapted so that the correct Swift type for `date`-formatted strings is ensured.