### PR TITLE
Enable the generated server-side code to validate the content-type.

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
@@ -22,14 +22,15 @@ extension ServerFileTranslator {
         _ operation: OperationDescription
     ) throws -> Expression {
         var closureBody: [CodeBlock] = []
-        
+
         let typedRequestBody = try typedRequestBody(in: operation)
-        
+
         if let headerValueForValidation = typedRequestBody?
             .content
             .content
             .contentType
-            .headerValueForValidation {
+            .headerValueForValidation
+        {
             let validateContentTypeExpr: Expression = .try(
                 .identifier("converter").dot("validateContentTypeIfPresent")
                     .call([
@@ -42,7 +43,7 @@ extension ServerFileTranslator {
             )
             closureBody.append(.expression(validateContentTypeExpr))
         }
-        
+
         let inputTypeName = operation.inputTypeName
 
         func locationSpecificInputDecl(
@@ -115,7 +116,7 @@ extension ServerFileTranslator {
                     .init(label: "body", expression: .identifier("body")),
                 ])
         )
-        
+
         closureBody.append(
             contentsOf: inputMemberDecls.map(CodeBlock.declaration) + [.expression(returnExpr)]
         )

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
@@ -21,6 +21,28 @@ extension ServerFileTranslator {
     func translateServerDeserializer(
         _ operation: OperationDescription
     ) throws -> Expression {
+        var closureBody: [CodeBlock] = []
+        
+        let typedRequestBody = try typedRequestBody(in: operation)
+        
+        if let headerValueForValidation = typedRequestBody?
+            .content
+            .content
+            .contentType
+            .headerValueForValidation {
+            let validateContentTypeExpr: Expression = .try(
+                .identifier("converter").dot("validateContentTypeIfPresent")
+                    .call([
+                        .init(label: "in", expression: .identifier("request").dot("headerFields")),
+                        .init(
+                            label: "substring",
+                            expression: .literal(headerValueForValidation)
+                        ),
+                    ])
+            )
+            closureBody.append(.expression(validateContentTypeExpr))
+        }
+        
         let inputTypeName = operation.inputTypeName
 
         func locationSpecificInputDecl(
@@ -67,7 +89,7 @@ extension ServerFileTranslator {
         .map(locationSpecificInputDecl(locatedIn:fromParameters:))
 
         let bodyDecl = try translateRequestBodyInServer(
-            typedRequestBody(in: operation),
+            typedRequestBody,
             requestVariableName: "request",
             bodyVariableName: "body",
             inputTypeName: inputTypeName
@@ -93,12 +115,14 @@ extension ServerFileTranslator {
                     .init(label: "body", expression: .identifier("body")),
                 ])
         )
+        
+        closureBody.append(
+            contentsOf: inputMemberDecls.map(CodeBlock.declaration) + [.expression(returnExpr)]
+        )
 
         return .closureInvocation(
             argumentNames: ["request", "metadata"],
-            body: inputMemberDecls.map(CodeBlock.declaration) + [
-                .expression(returnExpr)
-            ]
+            body: closureBody
         )
     }
 

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -180,7 +180,12 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
             with: metadata,
             forOperation: Operations.createPet.id,
             using: APIHandler.createPet,
-            deserializer: { request, metadata in let path: Operations.createPet.Input.Path = .init()
+            deserializer: { request, metadata in
+                try converter.validateContentTypeIfPresent(
+                    in: request.headerFields,
+                    substring: "application/json"
+                )
+                let path: Operations.createPet.Input.Path = .init()
                 let query: Operations.createPet.Input.Query = .init()
                 let headers: Operations.createPet.Input.Headers = .init(
                     X_Extra_Arguments: try converter.getOptionalHeaderFieldAsJSON(
@@ -309,6 +314,10 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
             forOperation: Operations.updatePet.id,
             using: APIHandler.updatePet,
             deserializer: { request, metadata in
+                try converter.validateContentTypeIfPresent(
+                    in: request.headerFields,
+                    substring: "application/json"
+                )
                 let path: Operations.updatePet.Input.Path = .init(
                     petId: try converter.getPathParameterAsText(
                         in: metadata.pathParameters,
@@ -380,6 +389,10 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
             forOperation: Operations.uploadAvatarForPet.id,
             using: APIHandler.uploadAvatarForPet,
             deserializer: { request, metadata in
+                try converter.validateContentTypeIfPresent(
+                    in: request.headerFields,
+                    substring: "application/octet-stream"
+                )
                 let path: Operations.uploadAvatarForPet.Input.Path = .init(
                     petId: try converter.getPathParameterAsText(
                         in: metadata.pathParameters,

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -231,6 +231,46 @@ final class Test_Server: XCTestCase {
         )
     }
 
+    
+    func testCreatePet_withIncorrectContentType() async throws {
+        client = .init(
+            createPetBlock: { input in
+                return .created(
+                    .init(
+                        headers: .init(
+                            X_Extra_Arguments: .init(code: 1)
+                        ),
+                        body: .json(
+                            .init(id: 1, name: "Fluffz")
+                        )
+                    )
+                )
+            }
+        )
+        
+        do {
+            _ = try await server.createPet(
+                .init(
+                    path: "/api/pets",
+                    method: .post,
+                    headerFields: [
+                        .init(name: "x-extra-arguments", value: #"{"code":1}"#),
+                        .init(name: "content-type", value: "text/plain; charset=utf-8"),
+                    ],
+                    encodedBody: #"""
+                        {
+                          "name" : "Fluffz"
+                        }
+                        """#
+                ),
+                .init()
+            )
+            XCTFail("The method should have thrown an error.")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
+    
     func testUpdatePet_204_withBody() async throws {
         client = .init(
             updatePetBlock: { input in

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -236,6 +236,7 @@ final class Test_Server: XCTestCase {
         client = .init(
             createPetBlock: { input in
                 XCTFail("The handler should not have been called")
+                fatalError("Unreachable")
             }
         )
         

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -235,16 +235,7 @@ final class Test_Server: XCTestCase {
     func testCreatePet_withIncorrectContentType() async throws {
         client = .init(
             createPetBlock: { input in
-                return .created(
-                    .init(
-                        headers: .init(
-                            X_Extra_Arguments: .init(code: 1)
-                        ),
-                        body: .json(
-                            .init(id: 1, name: "Fluffz")
-                        )
-                    )
-                )
+                XCTFail("The handler should not have been called")
             }
         )
         
@@ -266,9 +257,7 @@ final class Test_Server: XCTestCase {
                 .init()
             )
             XCTFail("The method should have thrown an error.")
-        } catch {
-            XCTAssertNotNil(error)
-        }
+        } catch {}
     }
     
     func testUpdatePet_204_withBody() async throws {

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -231,7 +231,6 @@ final class Test_Server: XCTestCase {
         )
     }
 
-    
     func testCreatePet_withIncorrectContentType() async throws {
         client = .init(
             createPetBlock: { input in
@@ -239,7 +238,7 @@ final class Test_Server: XCTestCase {
                 fatalError("Unreachable")
             }
         )
-        
+
         do {
             _ = try await server.createPet(
                 .init(
@@ -260,7 +259,7 @@ final class Test_Server: XCTestCase {
             XCTFail("The method should have thrown an error.")
         } catch {}
     }
-    
+
     func testUpdatePet_204_withBody() async throws {
         client = .init(
             updatePetBlock: { input in


### PR DESCRIPTION
### Motivation
I am interested this tool and have selected something that I can work on.
Resolve #16 

### Modifications

To validate content-type header string in server program, I modify `traslateServerDesirializer` method . 

### Result

For example you will define below opeapi yaml 

```
  /greet:
    post:
      operationId: postGreeting
      requestBody:
        required: true
        content:
          text/plain:
            schema:
              type: string
```

when you try the request, runtime error happen.

```
$ curl localhost:8080/api/greet -X POST \             
> -H "Content-Type: application/json" \
> -d '{ "name": "foo" }'

{"error":true,"reason":"Server error - operationID: postGreeting, request: path: \/api\/greet, query: <nil>, method: HTTPMethod(value: OpenAPIRuntime.HTTPMethod.(unknown context at $106e9fd78).OpenAPIHTTPMethod.POST), header fields: [Host: localhost:8080, User-Agent: curl\/7.88.1, Accept: *\/*, Content-Type: application\/json, Content-Length: 64], body (prefix): { \"name\": \"foo\"}, metadata: path parameters: [:], query parameters: [], operationInput: <nil>, operationOutput: <nil>, underlying error: Unexpected Content-Type header: application\/json"}
```

### Test Plan

I have made the necessary changes to adapt to the newly generated code on the reference server side and have confirmed that it passes the tests locally.