### PR TITLE
Calculate required reponse header parameters for initialize

### DIFF
--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -107,6 +107,13 @@ paths:
                 application/json:
                   schema:
                     $ref: '#/components/schemas/CodeError'
+            X-Extra-Arguments2:
+              required: true
+              description: "A description here."
+              content:
+                application/json:
+                  schema:
+                    $ref: '#/components/schemas/CodeError'
           content:
             application/json:
               schema:

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -174,6 +174,11 @@ public struct Client: APIProtocol {
                             in: response.headerFields,
                             name: "X-Extra-Arguments",
                             as: Components.Schemas.CodeError.self
+                        ),
+                        X_Extra_Arguments2: try converter.getRequiredHeaderFieldAsJSON(
+                            in: response.headerFields,
+                            name: "X-Extra-Arguments2",
+                            as: Components.Schemas.CodeError.self
                         )
                     )
                     try converter.validateContentTypeIfPresent(

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -220,6 +220,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                         name: "X-Extra-Arguments",
                         value: value.headers.X_Extra_Arguments
                     )
+                    try converter.setHeaderFieldAsJSON(
+                        in: &response.headerFields,
+                        name: "X-Extra-Arguments2",
+                        value: value.headers.X_Extra_Arguments2
+                    )
                     try converter.validateAcceptIfPresent(
                         "application/json",
                         in: request.headerFields

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -686,7 +686,7 @@ public enum Components {
             ///   - headers: Received HTTP response headers
             ///   - body: Received HTTP response body
             public init(
-                headers: Components.Responses.ErrorBadRequest.Headers,
+                headers: Components.Responses.ErrorBadRequest.Headers = .init(),
                 body: Components.Responses.ErrorBadRequest.Body
             ) {
                 self.headers = headers
@@ -985,12 +985,18 @@ public enum Operations {
             public struct Created: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     public var X_Extra_Arguments: Components.Schemas.CodeError?
+                    public var X_Extra_Arguments2: Components.Schemas.CodeError
                     /// Creates a new `Headers`.
                     ///
                     /// - Parameters:
                     ///   - X_Extra_Arguments:
-                    public init(X_Extra_Arguments: Components.Schemas.CodeError? = nil) {
+                    ///   - X_Extra_Arguments2:
+                    public init(
+                        X_Extra_Arguments: Components.Schemas.CodeError? = nil,
+                        X_Extra_Arguments2: Components.Schemas.CodeError
+                    ) {
                         self.X_Extra_Arguments = X_Extra_Arguments
+                        self.X_Extra_Arguments2 = X_Extra_Arguments2
                     }
                 }
                 /// Received HTTP response headers

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -519,7 +519,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
-    func testComponentsResponsesResponseWithHeader() throws {
+    func testComponentsResponsesResponseWithOptionalHeader() throws {
         try self.assertResponsesTranslation(
             """
             responses:
@@ -536,6 +536,42 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public struct Headers: Sendable, Equatable, Hashable {
                         public var X_Reason: Swift.String?
                         public init(X_Reason: Swift.String? = nil) {
+                            self.X_Reason = X_Reason }
+                    }
+                    public var headers: Components.Responses.BadRequest.Headers
+                    @frozen public enum Body: Sendable, Equatable, Hashable {}
+                    public var body: Components.Responses.BadRequest.Body?
+                    public init(
+                        headers: Components.Responses.BadRequest.Headers = .init(),
+                        body: Components.Responses.BadRequest.Body? = nil
+                    ) {
+                        self.headers = headers
+                        self.body = body
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsResponsesResponseWithRequiredHeader() throws {
+        try self.assertResponsesTranslation(
+            """
+            responses:
+              BadRequest:
+                description: Bad request
+                headers:
+                  X-Reason:
+                    schema:
+                      type: string
+                    required: true
+            """,
+            """
+            public enum Responses {
+                public struct BadRequest: Sendable, Equatable, Hashable {
+                    public struct Headers: Sendable, Equatable, Hashable {
+                        public var X_Reason: Swift.String
+                        public init(X_Reason: Swift.String) {
                             self.X_Reason = X_Reason }
                     }
                     public var headers: Components.Responses.BadRequest.Headers

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -170,6 +170,7 @@ final class Test_Client: XCTestCase {
                 headers: [
                     .init(name: "content-type", value: "application/json; charset=utf-8"),
                     .init(name: "x-extra-arguments", value: #"{"code":1}"#),
+                    .init(name: "x-extra-arguments2", value: #"{"code":9999}"#),
                 ],
                 encodedBody: #"""
                     {
@@ -192,6 +193,7 @@ final class Test_Client: XCTestCase {
             return
         }
         XCTAssertEqual(value.headers.X_Extra_Arguments, .init(code: 1))
+        XCTAssertEqual(value.headers.X_Extra_Arguments2, .init(code: 9999))
         switch value.body {
         case .json(let pets):
             XCTAssertEqual(pets, .init(id: 1, name: "Fluffz"))

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -137,7 +137,7 @@ final class Test_Server: XCTestCase {
                 return .created(
                     .init(
                         headers: .init(
-                            X_Extra_Arguments: .init(code: 1)
+                            X_Extra_Arguments2: .init(code: 1)
                         ),
                         body: .json(
                             .init(id: 1, name: "Fluffz")
@@ -166,7 +166,7 @@ final class Test_Server: XCTestCase {
         XCTAssertEqual(
             response.headerFields,
             [
-                .init(name: "X-Extra-Arguments", value: #"{"code":1}"#),
+                .init(name: "X-Extra-Arguments2", value: #"{"code":1}"#),
                 .init(name: "content-type", value: "application/json; charset=utf-8"),
             ]
         )


### PR DESCRIPTION
### Motivation

Resolve #30

### Modifications

To ensure the initialization of response headers when there is at least one required response header, 
I added private method for calculate necessory parameters, and applied it to the Structure Declalation returned by the `translateStructBlueprint` method.

With the current `PropertyBlueprint` structure, it seems difficult to address this issue.
This is because the `defaultValue` of the PropertyBlueprint is used for member variables and initialization variables, and the method of generating the Structure Blueprint seems to be common. 

There may be a way to reconsider the PropertyBlueprint structure, but considering the impact and current needs, adopted the implementation as a private method once. It seems to be a complicated implementation, so if you have any other suggestions please let me know. 

### Result

If one or more required request header parameters are present,
Generates code that needs to set request header parameters when create response.

For example you define the yaml below

```yaml
      responses:
        '200':
          description: A success response with a greeting.
          headers:
            X-Extra-Arguments:
              required: false
              description: "A description here."
              content:
                application/json:
                  schema:
                    $ref: '#/components/schemas/Greeting'
```

Types.swift is Generated like blow, and you should not set response headers when initialize

<img width="765" alt="スクリーンショット 2023-07-29 14 44 45" src="https://github.com/apple/swift-openapi-generator/assets/16571394/c8e5779a-e851-40d6-9c68-9ced8af4dcc2">


If you set required true
```yaml
            X-Extra-Arguments:
              required: true

```

Types.swift is Generated like blow, and you should set reponse headers when initialize

![スクリーンショット 2023-07-29 14 52 55](https://github.com/apple/swift-openapi-generator/assets/16571394/33890627-126e-4d94-af89-040943d2b489)

### Test Plan

Modify tests to verify whether code generation is correct and generated code can be executed in cases of mandatory parameters and optional parameters