### PR TITLE
Deprecation warnings not emitted when calling operations that are deprecated

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
@@ -212,6 +212,7 @@ extension ClientFileTranslator {
                     .expression(sendExpr)
                 ]
             )
+            .deprecate(if: description.operation.deprecated)
         )
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
@@ -285,6 +285,7 @@ extension ServerFileTranslator {
                     .expression(handleExpr)
                 ]
             )
+            .deprecate(if: description.operation.deprecated)
         )
 
         return (registerCall, functionDecl)

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -213,7 +213,9 @@ public struct Client: APIProtocol {
     }
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
-    public func probe(_ input: Operations.probe.Input) async throws -> Operations.probe.Output {
+    @available(*, deprecated) public func probe(_ input: Operations.probe.Input) async throws
+        -> Operations.probe.Output
+    {
         try await client.send(
             input: input,
             forOperation: Operations.probe.id,

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -272,7 +272,9 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     }
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
-    func probe(request: Request, metadata: ServerRequestMetadata) async throws -> Response {
+    @available(*, deprecated) func probe(request: Request, metadata: ServerRequestMetadata)
+        async throws -> Response
+    {
         try await handle(
             request: request,
             with: metadata,

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -341,6 +341,7 @@ final class Test_Client: XCTestCase {
         }
     }
 
+    @available(*, deprecated)
     func testProbe_204() async throws {
         transport = .init { request, baseURL, operationID in
             XCTAssertEqual(operationID, "probe")
@@ -359,6 +360,7 @@ final class Test_Client: XCTestCase {
         }
     }
 
+    @available(*, deprecated)
     func testProbe_undocumented() async throws {
         transport = .init { request, baseURL, operationID in
             .init(statusCode: 503)


### PR DESCRIPTION
### Motivation

Fixes #149.

Turns out that when a function is deprecated in a protocol, then calling the function on a concrete type that conforms to that protocol does _not_ emit a warning unless the function _implementation_ is also annotated as deprecated.

### Modifications

This PR emits deprecation annotations for the client and server implementations of `APIProtocol`'s functions.

### Result

Warnings are now correctly emitted regardless of whether the adopter calls methods on `let client: MyClient` where `MyClient: APIProtocol`, or on `let client: any APIProtocol`, leading to better communication between the author of the OpenAPI document and the adopter of the generated Swift code about the API evolution and future removal of operations.

### Test Plan

Adapted integration tests.
