### PR TITLE
Fix an incorrect reference in the API stability article

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/API-stability-of-generated-code.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/API-stability-of-generated-code.md
@@ -31,7 +31,7 @@ Below is a table of example changes you might make to an OpenAPI document, and w
 
 > ‡: Adding a new response to an existing operation introduces a new enum case that the adopter needs to handle, so is a breaking change in OpenAPI and Swift.
 
-> §: Adding a new content type to an existing response is similar to [2]: it introduces a new enum case that the adopter needs to handle, so is a breaking change in OpenAPI and Swift.
+> §: Adding a new content type to an existing response is similar to ‡: it introduces a new enum case that the adopter needs to handle, so is a breaking change in OpenAPI and Swift.
 
 The table above is not exhaustive, but it shows a pattern:
 - Removing (or renaming) anything that the adopter might have relied on is usually a breaking change.


### PR DESCRIPTION
### Motivation

A typo in a docc article, references a non-existent item.

### Modifications

Fixed the reference.

### Result

The reference points to the right section now.

### Test Plan

N/A
