### PR TITLE
[Generator] Consistent style for initializing local variables

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
@@ -172,19 +172,19 @@ extension ClientFileTranslator {
             .identifier(Constants.Operations.namespace)
             .dot(description.methodName)
 
-        let operationArg: FunctionArgumentDescription = .init(
+        let operationArg = FunctionArgumentDescription(
             label: "forOperation",
             expression: operationTypeExpr.dot("id")
         )
-        let inputArg: FunctionArgumentDescription = .init(
+        let inputArg = FunctionArgumentDescription(
             label: "input",
             expression: .identifier(Constants.Operation.Input.variableName)
         )
-        let serializerArg: FunctionArgumentDescription = .init(
+        let serializerArg = FunctionArgumentDescription(
             label: "serializer",
             expression: try translateClientSerializer(description)
         )
-        let deserializerArg: FunctionArgumentDescription = .init(
+        let deserializerArg = FunctionArgumentDescription(
             label: "deserializer",
             expression: try translateClientDeserializer(description)
         )

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
@@ -29,7 +29,7 @@ extension FileTranslator {
         let knownKeys =
             properties
             .map(\.originalName)
-        let knownKeysFunctionArg: FunctionArgumentDescription = .init(
+        let knownKeysFunctionArg = FunctionArgumentDescription(
             label: "knownKeys",
             expression: .literal(
                 .array(

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
@@ -144,7 +144,7 @@ extension FileTranslator {
             typeUsage = valueTypeUsage.asDictionaryValue
         }
 
-        let extraProperty: PropertyBlueprint = .init(
+        let extraProperty = PropertyBlueprint(
             comment: .doc("A container of undocumented properties."),
             originalName: "additionalProperties",
             typeUsage: typeUsage,

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
@@ -72,7 +72,7 @@ extension FileTranslator {
                     ]
                 )
             }
-            let unknownCase: SwitchCaseDescription = .init(
+            let unknownCase = SwitchCaseDescription(
                 kind: .default,
                 body: [
                     .expression(
@@ -126,7 +126,7 @@ extension FileTranslator {
                     ]
                 )
             }
-            let unknownCase: SwitchCaseDescription = .init(
+            let unknownCase = SwitchCaseDescription(
                 kind: .case(
                     .valueBinding(
                         kind: .let,
@@ -147,7 +147,7 @@ extension FileTranslator {
                 ]
             )
 
-            let variableDescription: VariableDescription = .init(
+            let variableDescription = VariableDescription(
                 accessModifier: config.access,
                 kind: .var,
                 left: "rawValue",
@@ -186,7 +186,7 @@ extension FileTranslator {
             )
         }
 
-        let enumDescription: EnumDescription = .init(
+        let enumDescription = EnumDescription(
             isFrozen: true,
             accessModifier: config.access,
             name: typeName.shortSwiftName,

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateTypealias.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateTypealias.swift
@@ -26,7 +26,7 @@ extension FileTranslator {
         userDescription: String?,
         to existingTypeUsage: TypeUsage
     ) throws -> Declaration {
-        let typealiasDescription: TypealiasDescription = .init(
+        let typealiasDescription = TypealiasDescription(
             accessModifier: config.access,
             name: typeName.shortSwiftName,
             existingType: existingTypeUsage.fullyQualifiedNonOptionalSwiftName

--- a/Sources/_OpenAPIGeneratorCore/Translator/RequestBody/translateRequestBody.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/RequestBody/translateRequestBody.swift
@@ -204,7 +204,7 @@ extension ClientFileTranslator {
                         ])
                 )
             )
-            let caseDesc: SwitchCaseDescription = .init(
+            let caseDesc = SwitchCaseDescription(
                 kind: .case(.dot(contentTypeIdentifier), ["value"]),
                 body: [
                     .expression(bodyAssignExpr)
@@ -213,7 +213,7 @@ extension ClientFileTranslator {
             return caseDesc
         }
         if !requestBody.request.required {
-            let noneCase: SwitchCaseDescription = .init(
+            let noneCase = SwitchCaseDescription(
                 kind: .case(.dot("none")),
                 body: [
                     .expression(

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseOutcome.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseOutcome.swift
@@ -276,8 +276,7 @@ extension ServerFileTranslator {
         let responseVarDecl: Declaration = .variable(
             kind: .var,
             left: "response",
-            type: "Response",
-            right: .dot("init")
+            right: .identifier("Response")
                 .call([
                     .init(label: "statusCode", expression: statusCodeExpr)
                 ])

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
@@ -192,19 +192,19 @@ extension ServerFileTranslator {
             .identifier(Constants.Operations.namespace)
             .dot(description.methodName)
 
-        let operationArg: FunctionArgumentDescription = .init(
+        let operationArg = FunctionArgumentDescription(
             label: "forOperation",
             expression: operationTypeExpr.dot("id")
         )
-        let requestArg: FunctionArgumentDescription = .init(
+        let requestArg = FunctionArgumentDescription(
             label: "request",
             expression: .identifier("request")
         )
-        let metadataArg: FunctionArgumentDescription = .init(
+        let metadataArg = FunctionArgumentDescription(
             label: "with",
             expression: .identifier("metadata")
         )
-        let methodArg: FunctionArgumentDescription = .init(
+        let methodArg = FunctionArgumentDescription(
             label: "using",
             expression: .closureInvocation(
                 body: [
@@ -218,11 +218,11 @@ extension ServerFileTranslator {
                 ]
             )
         )
-        let deserializerArg: FunctionArgumentDescription = .init(
+        let deserializerArg = FunctionArgumentDescription(
             label: "deserializer",
             expression: try translateServerDeserializer(description)
         )
-        let serializerArg: FunctionArgumentDescription = .init(
+        let serializerArg = FunctionArgumentDescription(
             label: "serializer",
             expression: try translateServerSerializer(description)
         )

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
@@ -30,7 +30,7 @@ extension TypesFileTranslator {
             operations
             .map(translateAPIProtocolDeclaration(operation:))
 
-        let protocolDescription: ProtocolDescription = .init(
+        let protocolDescription = ProtocolDescription(
             accessModifier: config.access,
             name: Constants.APIProtocol.typeName,
             conformances: Constants.APIProtocol.conformances,

--- a/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
@@ -16,7 +16,7 @@ import XCTest
 
 final class Test_TextBasedRenderer: XCTestCase {
 
-    var renderer: TextBasedRenderer = .init()
+    var renderer = TextBasedRenderer()
 
     func testComment() throws {
         try _test(

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -114,7 +114,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .ok(value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: 200)
+                    var response = Response(statusCode: 200)
                     suppressMutabilityWarning(&response)
                     try converter.setHeaderFieldAsText(
                         in: &response.headerFields,
@@ -141,7 +141,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     return response
                 case let .`default`(statusCode, value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: statusCode)
+                    var response = Response(statusCode: statusCode)
                     suppressMutabilityWarning(&response)
                     switch value.body {
                     case let .json(value):
@@ -203,7 +203,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .created(value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: 201)
+                    var response = Response(statusCode: 201)
                     suppressMutabilityWarning(&response)
                     try converter.setHeaderFieldAsJSON(
                         in: &response.headerFields,
@@ -225,7 +225,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     return response
                 case let .badRequest(value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: 400)
+                    var response = Response(statusCode: 400)
                     suppressMutabilityWarning(&response)
                     try converter.setHeaderFieldAsText(
                         in: &response.headerFields,
@@ -277,7 +277,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .noContent(value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: 204)
+                    var response = Response(statusCode: 204)
                     suppressMutabilityWarning(&response)
                     return response
                 case let .undocumented(statusCode, _): return .init(statusCode: statusCode)
@@ -328,12 +328,12 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .noContent(value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: 204)
+                    var response = Response(statusCode: 204)
                     suppressMutabilityWarning(&response)
                     return response
                 case let .badRequest(value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: 400)
+                    var response = Response(statusCode: 400)
                     suppressMutabilityWarning(&response)
                     switch value.body {
                     case let .json(value):
@@ -398,7 +398,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .ok(value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: 200)
+                    var response = Response(statusCode: 200)
                     suppressMutabilityWarning(&response)
                     switch value.body {
                     case let .binary(value):
@@ -415,7 +415,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     return response
                 case let .preconditionFailed(value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: 412)
+                    var response = Response(statusCode: 412)
                     suppressMutabilityWarning(&response)
                     switch value.body {
                     case let .json(value):
@@ -432,7 +432,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     return response
                 case let .internalServerError(value):
                     suppressUnusedWarning(value)
-                    var response: Response = .init(statusCode: 500)
+                    var response = Response(statusCode: 500)
                     suppressMutabilityWarning(&response)
                     switch value.body {
                     case let .text(value):


### PR DESCRIPTION
### Motivation

Move to a consistent style when initializing local variables, always use `let foo = Foo(...)` vs `let foo: Foo = .init(...)`.

### Modifications

Updated all occurrences of the latter to use the former.

Also updated for the generated code.

### Result

Consistent local variable initialization.

### Test Plan

All tests passed.
