### PR TITLE
Add a proposal state for when merged behind a feature flag

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -30,7 +30,8 @@ The configuration file has the following keys:
     - `types`: Common types and abstractions used by generated client and server code.
     - `client`: Client code that can be used with any client transport (depends on code from `types`).
     - `server`: Server code that can be used with any server transport (depends on code from `types`).
-- `additionalImports` (optional): array of strings. Each string value Swift module name. An import statement will be added to the generated source files for each module.
+- `additionalImports` (optional): array of strings. Each string value is a Swift module name. An import statement will be added to the generated source files for each module.
+- `featureFlags` (optional): array of strings. Each string must be a valid feature flag to enable. For a list of currently supported feature flags, check out [FeatureFlags.swift](https://github.com/apple/swift-openapi-generator/blob/main/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift).
 
 ### Example config files
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/Proposals.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/Proposals.md
@@ -20,7 +20,7 @@ While it's encouraged to get feedback by opening a pull request with a proposal 
 4. Open a pull request with your proposal and solicit feedback from other contributors.
 5. Once a maintainer confirms that the proposal is ready for review, the state is updated accordingly. The review period is 7 days, and ends when one of the maintainers marks the proposal as Ready for Implementation, or Deferred.
 6. Before the pull request is merged, there should be an implementation ready, either in the same pull request, or a separate one, linked from the proposal.
-7. The proposal is considered Approved once the implementation and proposal PRs have been merged.
+7. The proposal is considered Approved once the implementation, proposal PRs have been merged, and, if originally disabled by a feature flag, feature flag enabled unconditionally.
 
 If you have any questions, tag [Honza Dvorsky](https://github.com/czechboy0) or [Si Beaumont](https://github.com/simonjbeaumont) in your issue or pull request on GitHub.
 
@@ -29,6 +29,7 @@ If you have any questions, tag [Honza Dvorsky](https://github.com/czechboy0) or 
 - Awaiting Review
 - In Review
 - Ready for Implementation
+- Merged behind a Feature Flag
 - Approved
 - Deferred
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/Proposals.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/Proposals.md
@@ -29,7 +29,7 @@ If you have any questions, tag [Honza Dvorsky](https://github.com/czechboy0) or 
 - Awaiting Review
 - In Review
 - Ready for Implementation
-- Merged behind a Feature Flag
+- In Preview
 - Approved
 - Deferred
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-NNNN.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-NNNN.md
@@ -10,6 +10,7 @@ Feature name (template proposal)
 - Issue: [apple/swift-openapi-generator#1](https://github.com/apple/swift-openapi-generator/issues/1)
 - Implementation:
     - [apple/swift-openapi-generator#1](https://github.com/apple/swift-openapi-generator/pull/1)
+- Feature flag: `proposalNNNN`
 - Affected components:
     - generator
     - runtime


### PR DESCRIPTION
### Motivation

When introducing breaking changes, it can be convenient to hide the new behavior behind a feature flag. However, up until now, proposals didn't have a state that represents "feature landed but is not enabled by default yet".

### Modifications

This PR introduces a new state for proposals for this.

Also, added missing documentation for the `featureFlags` key in the config file.

### Result

Now proposals can be moved to the new state before their feature is enabled unconditionally.

### Test Plan

N/A
