### PR TITLE
Hide strict OpenAPI validation behind a feature flag

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
+++ b/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
@@ -39,6 +39,11 @@ public enum FeatureFlag: String, Hashable, Equatable, Codable, CaseIterable {
     /// Tracking issues:
     /// - https://github.com/apple/swift-openapi-generator/pull/95
     case proposal0001
+
+    /// Stricted input OpenAPI document validation.
+    ///
+    /// Check for structural issues and detect cycles proactively.
+    case strictOpenAPIValidation
 }
 
 /// A set of enabled feature flags.

--- a/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
+++ b/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
@@ -125,31 +125,33 @@ func makeGeneratorPipeline(
             postTransitionHooks: [
                 { doc in
 
-                    // Run OpenAPIKit's built-in validation.
-                    try doc.validate()
+                    if config.featureFlags.contains(.strictOpenAPIValidation) {
+                        // Run OpenAPIKit's built-in validation.
+                        try doc.validate()
 
-                    // Validate that the document is dereferenceable, which
-                    // catches reference cycles, which we don't yet support.
-                    _ = try doc.locallyDereferenced()
+                        // Validate that the document is dereferenceable, which
+                        // catches reference cycles, which we don't yet support.
+                        _ = try doc.locallyDereferenced()
 
-                    // Also explicitly dereference the parts of components
-                    // that the generator uses. `locallyDereferenced()` above
-                    // only dereferences paths/operations, but not components.
-                    let components = doc.components
-                    try components.schemas.forEach { schema in
-                        _ = try schema.value.dereferenced(in: components)
-                    }
-                    try components.parameters.forEach { schema in
-                        _ = try schema.value.dereferenced(in: components)
-                    }
-                    try components.headers.forEach { schema in
-                        _ = try schema.value.dereferenced(in: components)
-                    }
-                    try components.requestBodies.forEach { schema in
-                        _ = try schema.value.dereferenced(in: components)
-                    }
-                    try components.responses.forEach { schema in
-                        _ = try schema.value.dereferenced(in: components)
+                        // Also explicitly dereference the parts of components
+                        // that the generator uses. `locallyDereferenced()` above
+                        // only dereferences paths/operations, but not components.
+                        let components = doc.components
+                        try components.schemas.forEach { schema in
+                            _ = try schema.value.dereferenced(in: components)
+                        }
+                        try components.parameters.forEach { schema in
+                            _ = try schema.value.dereferenced(in: components)
+                        }
+                        try components.headers.forEach { schema in
+                            _ = try schema.value.dereferenced(in: components)
+                        }
+                        try components.requestBodies.forEach { schema in
+                            _ = try schema.value.dereferenced(in: components)
+                        }
+                        try components.responses.forEach { schema in
+                            _ = try schema.value.dereferenced(in: components)
+                        }
                     }
 
                     return doc


### PR DESCRIPTION
### Motivation

In https://github.com/apple/swift-openapi-generator/pull/130, we introduced stricted validation of input OpenAPI documents. Reflecting back, since this might start rejecting OpenAPI document that were previously accepted, that is considered a breaking change and should be hidden behind a feature flag, only to be enabled unconditionally in the next breaking version.

### Modifications

Hide the new validation behind a feature flag.

### Result

Without providing the feature flag explicitly, the generator will maintain its old behavior and not perform strict validation.

### Test Plan

N/A - this is a speculative fix to maintain backwards compatibility in the 0.1.x version.
