### PR TITLE
Refactor ContentType + improve content type matching

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
@@ -162,9 +162,8 @@ extension FileTranslator {
             )
         }
         let chosenContent: (SchemaContent, OpenAPI.Content)?
-        if let (contentKey, contentValue) = map.first(where: { $0.key.isJSON }),
+        if let (contentKey, contentValue) = map.first(where: { $0.key.isJSON }) {
             let contentType = ContentType(contentKey.typeAndSubtype)
-        {
             chosenContent = (
                 .init(
                     contentType: contentType,
@@ -172,9 +171,8 @@ extension FileTranslator {
                 ),
                 contentValue
             )
-        } else if let (contentKey, contentValue) = map.first(where: { $0.key.isText }),
+        } else if let (contentKey, contentValue) = map.first(where: { $0.key.isText }) {
             let contentType = ContentType(contentKey.typeAndSubtype)
-        {
             chosenContent = (
                 .init(
                     contentType: contentType,
@@ -182,10 +180,8 @@ extension FileTranslator {
                 ),
                 contentValue
             )
-        } else if !excludeBinary,
-            let (contentKey, contentValue) = map.first(where: { $0.key.isBinary }),
+        } else if !excludeBinary, let (contentKey, contentValue) = map.first(where: { $0.key.isBinary }) {
             let contentType = ContentType(contentKey.typeAndSubtype)
-        {
             chosenContent = (
                 .init(
                     contentType: contentType,
@@ -234,9 +230,8 @@ extension FileTranslator {
         excludeBinary: Bool = false,
         foundIn: String
     ) -> SchemaContent? {
-        if contentKey.isJSON,
+        if contentKey.isJSON {
             let contentType = ContentType(contentKey.typeAndSubtype)
-        {
             diagnostics.emitUnsupportedIfNotNil(
                 contentValue.encoding,
                 "Custom encoding for JSON content",
@@ -247,18 +242,15 @@ extension FileTranslator {
                 schema: contentValue.schema
             )
         }
-        if contentKey.isText,
+        if contentKey.isText {
             let contentType = ContentType(contentKey.typeAndSubtype)
-        {
             return .init(
                 contentType: contentType,
                 schema: .b(.string)
             )
         }
-        if !excludeBinary,
-            contentKey.isBinary,
+        if !excludeBinary, contentKey.isBinary {
             let contentType = ContentType(contentKey.typeAndSubtype)
-        {
             return .init(
                 contentType: contentType,
                 schema: .b(.string(format: .binary))

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
@@ -41,7 +41,7 @@ extension FileTranslator {
                 return swiftSafeName(for: rawMIMEType)
             }
         } else {
-            switch contentType {
+            switch contentType.category {
             case .json:
                 return "json"
             case .text:

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import OpenAPIKit30
+@testable import _OpenAPIGeneratorCore
+
+final class Test_ContentType: Test_Core {
+
+    func testDecoding() throws {
+        let cases: [(String, ContentType.Category)] = [
+            ("application/json", .json),
+            ("application/x-www-form-urlencoded", .binary),
+            ("multipart/form-data", .binary),
+            ("text/plain", .text),
+            ("*/*", .binary),
+            ("application/xml", .binary),
+            ("application/octet-stream", .binary),
+            ("application/myformat+json", .json),
+            ("foo/bar", .binary),
+        ]
+        for (rawValue, category) in cases {
+            let contentType = ContentType(rawValue)
+            XCTAssertEqual(contentType.category, category)
+            XCTAssertEqual(contentType.rawMIMEType, rawValue)
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

The `ContentType` type had two issues:
- the enum where all cases had the same associated string value was not a good representation of the data
- the parsing was too strict and didn't match e.g. `foo/bar+json` as a JSON content type

### Modifications

Refactored `ContentType` to split the raw value storage from the `Category` (new term, ideas of a better name are welcome) of content types (`json`, `text`, or `binary`).

Also, improved the mapping to match https://json-schema.org/draft/2020-12/json-schema-core.html#section-4.2

### Result

Now the type is easier to work with, and parsing correctly recognizes `foo/bar+json` as JSON.

### Test Plan

Added unit tests.
