### PR TITLE
Forward schema warnings to diagnostics

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
@@ -74,6 +74,20 @@ extension FileTranslator {
 
         let value = schema.value
 
+        // Attach any warnings from the parsed schema as a diagnostic.
+        for warning in schema.warnings {
+            diagnostics.emit(
+                .warning(
+                    message: "Schema warning: \(warning.description)",
+                    context: [
+                        "codingPath": warning.codingPathString ?? "<none>",
+                        "contextString": warning.contextString ?? "<none>",
+                        "subjectName": warning.subjectName ?? "<none>",
+                    ]
+                )
+            )
+        }
+
         // If this type maps to a referenceable schema, define a typealias
         if let builtinType = try typeMatcher.tryMatchReferenceableType(for: schema) {
             let typealiasDecl = try translateTypealias(

--- a/Tests/OpenAPIGeneratorCoreTests/TestUtilities.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/TestUtilities.swift
@@ -189,3 +189,14 @@ func newTypeName(swiftFQName: String, jsonFQName: String) throws -> TypeName {
             .map(TypeName.Component.init)
     )
 }
+
+/// A diagnostic collector that accumulates all received diagnostics into
+/// an array.
+final class AccumulatingDiagnosticCollector: DiagnosticCollector {
+
+    private(set) var diagnostics: [Diagnostic] = []
+
+    func emit(_ diagnostic: Diagnostic) {
+        diagnostics.append(diagnostic)
+    }
+}

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import OpenAPIKit30
+import Yams
+@testable import _OpenAPIGeneratorCore
+
+class Test_translateSchemas: Test_Core {
+
+    func testSchemaWarningsForwardedToGeneratorDiagnostics() throws {
+        let typeName = TypeName(swiftKeyPath: ["Foo"])
+
+        let schemaWithWarnings = try YAMLDecoder()
+            .decode(
+                JSONSchema.self,
+                from: #"""
+                    type: string
+                    items:
+                      type: integer
+                    """#
+            )
+
+        let cases: [(JSONSchema, [String])] = [
+            (.string, []),
+
+            (
+                schemaWithWarnings,
+                [
+                    "warning: Schema warning: Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: string. Specifically, attributes for these other types: [\"array\"]. [context: codingPath=, contextString=, subjectName=OpenAPI Schema]"
+                ]
+            ),
+        ]
+
+        for (schema, diagnosticDescriptions) in cases {
+            let collector = AccumulatingDiagnosticCollector()
+            let translator = makeTranslator(diagnostics: collector)
+            _ = try translator.translateSchema(
+                typeName: typeName,
+                schema: schema,
+                overrides: .none
+            )
+            XCTAssertEqual(collector.diagnostics.map(\.description), diagnosticDescriptions)
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

OpenAPIKit emits warnings about parsed `JSONSchema` objects that could be helpful to adopters when debugging issues. Today, we are ignoring them.

### Modifications

This PR forwards them into the diagnostics collector as warnings.

### Result

When a schema is malformed in a way that OpenAPIKit still manages to parse it, but has issues, adopters will see these issues emitted as all other diagnostics we emit.

### Test Plan

Added a unit test.
