### PR TITLE
Allow more types of subschemas in anyOf/allOf

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
@@ -242,8 +242,9 @@ extension FileTranslator {
     /// - Parameter schema: A schema to check.
     func isRefToObjectishSchemaAndSupported(_ schema: JSONSchema) throws -> IsSchemaSupportedResult {
         switch schema.value {
-        case .reference:
-            return try isObjectishSchemaAndSupported(schema)
+        case let .reference(ref, _):
+            let referencedSchema = try components.lookup(ref)
+            return try isObjectishSchemaAndSupported(referencedSchema)
         default:
             return .unsupported(
                 reason: .notRef,

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
@@ -141,7 +141,7 @@ extension FileTranslator {
                     schema: schema
                 )
             }
-            return try areObjectishSchemasAndSupported(schemas)
+            return try areSchemasSupported(schemas)
         case .any(of: let schemas, _):
             guard !schemas.isEmpty else {
                 return .unsupported(
@@ -149,7 +149,7 @@ extension FileTranslator {
                     schema: schema
                 )
             }
-            return try areObjectishSchemasAndSupported(schemas)
+            return try areSchemasSupported(schemas)
         case .one(of: let schemas, let context):
             guard !schemas.isEmpty else {
                 return .unsupported(
@@ -206,20 +206,6 @@ extension FileTranslator {
         return .supported
     }
 
-    /// Returns a result indicating whether the provided schemas
-    /// are reference, object, or allOf schemas and supported.
-    /// - Parameter schemas: Schemas to check.
-    /// - Returns: `.supported` if all schemas match; `.unsupported` otherwise.
-    func areObjectishSchemasAndSupported(_ schemas: [JSONSchema]) throws -> IsSchemaSupportedResult {
-        for schema in schemas {
-            let result = try isObjectishSchemaAndSupported(schema)
-            guard result == .supported else {
-                return result
-            }
-        }
-        return .supported
-    }
-
     /// Returns a result indicating whether the provided schema
     /// is an reference, object, or allOf (object-ish) schema and is supported.
     /// - Parameter schema: A schemas to check.
@@ -228,7 +214,7 @@ extension FileTranslator {
         case .object, .reference:
             return try isSchemaSupported(schema)
         case .all(of: let schemas, _):
-            return try areObjectishSchemasAndSupported(schemas)
+            return try areSchemasSupported(schemas)
         default:
             return .unsupported(
                 reason: .notObjectish,

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
@@ -142,12 +142,12 @@ Supported features are always provided on _both_ client and server.
 - [x] enum
 - [x] type
 - [x] allOf
-    - a wrapper struct is generated and children must be object schemas
+    - a wrapper struct is generated, children can be any schema
 - [x] oneOf
-    - if a discriminator is specified (recommended), children must be object schemas
+    - if a discriminator is specified, each child must be a reference to an object schema
     - if no discriminator is specified, children can be any schema
 - [x] anyOf
-    - children must be object schemas
+    - a wrapper struct is generated, children can be any schema
 - [ ] not
 - [x] items
 - [x] properties

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
@@ -60,28 +60,42 @@ class Test_isSchemaSupported: XCTestCase {
             )
         ),
 
-        // allOf with two schemas
+        // allOf with many schemas
         .all(of: [
             .object(properties: [
                 "Foo": .string
             ]),
             .reference(.component(named: "MyObj")),
+            .string,
+            .array(items: .string),
         ]),
 
-        // oneOf with two schemas
+        // oneOf with a discriminator with two objectish schemas
         .one(of: [
             .object(properties: [
                 "Foo": .string
             ]),
             .reference(.component(named: "MyObj")),
         ]),
+        
+        // oneOf without a discriminator with various schemas
+        .one(of: [
+            .object(properties: [
+                "Foo": .string
+            ]),
+            .reference(.component(named: "MyObj")),
+            .string,
+            .array(items: .string),
+        ]),
 
-        // anyOf with two schemas
+        // anyOf with various schemas
         .any(of: [
             .object(properties: [
                 "Foo": .string
             ]),
             .reference(.component(named: "MyObj")),
+            .string,
+            .array(items: .string),
         ]),
     ]
     func testSupportedTypes() throws {
@@ -101,8 +115,8 @@ class Test_isSchemaSupported: XCTestCase {
         // an allOf without any subschemas
         (.all(of: []), .noSubschemas),
 
-        // an allOf with non-object-ish schemas
-        (.all(of: [.string, .integer]), .notObjectish),
+        // a oneOf with a discriminator with non-object-ish schemas
+        (.one(of: .reference(.internal(.component(name: "Foo"))), discriminator: .init(propertyName: "foo")), .notObjectish),
 
         // a oneOf with a discriminator with an inline subschema
         (.one(of: .object, discriminator: .init(propertyName: "foo")), .notRef),

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
@@ -77,7 +77,7 @@ class Test_isSchemaSupported: XCTestCase {
             ]),
             .reference(.component(named: "MyObj")),
         ]),
-        
+
         // oneOf without a discriminator with various schemas
         .one(of: [
             .object(properties: [
@@ -116,7 +116,10 @@ class Test_isSchemaSupported: XCTestCase {
         (.all(of: []), .noSubschemas),
 
         // a oneOf with a discriminator with non-object-ish schemas
-        (.one(of: .reference(.internal(.component(name: "Foo"))), discriminator: .init(propertyName: "foo")), .notObjectish),
+        (
+            .one(of: .reference(.internal(.component(name: "Foo"))), discriminator: .init(propertyName: "foo")),
+            .notObjectish
+        ),
 
         // a oneOf with a discriminator with an inline subschema
         (.one(of: .object, discriminator: .init(propertyName: "foo")), .notRef),

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
@@ -24,6 +24,7 @@ class Test_isSchemaSupported: XCTestCase {
             components: .init(schemas: [
                 "Foo": .string,
                 "MyObj": .object,
+                "MyObj2": .object,
             ])
         )
     }
@@ -71,12 +72,11 @@ class Test_isSchemaSupported: XCTestCase {
         ]),
 
         // oneOf with a discriminator with two objectish schemas
-        .one(of: [
-            .object(properties: [
-                "Foo": .string
-            ]),
-            .reference(.component(named: "MyObj")),
-        ]),
+        .one(
+            of: .reference(.component(named: "MyObj")),
+            .reference(.component(named: "MyObj2")),
+            discriminator: .init(propertyName: "foo")
+        ),
 
         // oneOf without a discriminator with various schemas
         .one(of: [

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1251,13 +1251,6 @@ extension SnippetBasedReferenceTests {
         line: UInt = #line
     ) throws {
         let translator = try makeTypesTranslator(componentsYAML: componentsYAML)
-        let schemas = translator.components.schemas
-        for (key, schema) in schemas {
-            XCTAssertTrue(
-                try translator.isSchemaSupported(schema) == .supported,
-                "Schema \(schema.prettyDescription) for key \(key) is not supported"
-            )
-        }
         let translation = try translator.translateSchemas(translator.components.schemas)
         try XCTAssertSwiftEquivalent(translation, expectedSwift, file: file, line: line)
     }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -236,20 +236,30 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 public struct MyAllOf: Codable, Equatable, Hashable, Sendable {
                     public var value1: Components.Schemas.A
                     public var value2: Components.Schemas.B
+                    public var value3: Swift.String
+                    public var value4: [Swift.Int]
                     public init(
                         value1: Components.Schemas.A,
-                        value2: Components.Schemas.B
+                        value2: Components.Schemas.B,
+                        value3: Swift.String,
+                        value4: [Swift.Int]
                     ) {
                         self.value1 = value1
                         self.value2 = value2
+                        self.value3 = value3
+                        self.value4 = value4
                     }
                     public init(from decoder: any Decoder) throws {
                         value1 = try .init(from: decoder)
                         value2 = try .init(from: decoder)
+                        value3 = try .init(from: decoder)
+                        value4 = try .init(from: decoder)
                     }
                     public func encode(to encoder: any Encoder) throws {
                         try value1.encode(to: encoder)
                         try value2.encode(to: encoder)
+                        try value3.encode(to: encoder)
+                        try value4.encode(to: encoder)
                     }
                 }
             }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -224,6 +224,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 allOf:
                   - $ref: '#/components/schemas/A'
                   - $ref: '#/components/schemas/B'
+                  - type: string
+                  - type: array
+                    items:
+                      type: integer
             """,
             """
             public enum Schemas {
@@ -263,6 +267,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 anyOf:
                   - $ref: '#/components/schemas/A'
                   - $ref: '#/components/schemas/B'
+                  - type: string
+                  - type: array
+                    items:
+                      type: integer
             """,
             """
             public enum Schemas {
@@ -271,18 +279,26 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 public struct MyAnyOf: Codable, Equatable, Hashable, Sendable {
                     public var value1: Components.Schemas.A?
                     public var value2: Components.Schemas.B?
+                    public var value3: Swift.String?
+                    public var value4: [Swift.Int]?
                     public init(
                         value1: Components.Schemas.A? = nil,
-                        value2: Components.Schemas.B? = nil
+                        value2: Components.Schemas.B? = nil,
+                        value3: Swift.String? = nil,
+                        value4: [Swift.Int]? = nil
                     ) {
                         self.value1 = value1
                         self.value2 = value2
+                        self.value3 = value3
+                        self.value4 = value4
                     }
                     public init(from decoder: any Decoder) throws {
                         value1 = try? .init(from: decoder)
                         value2 = try? .init(from: decoder)
+                        value3 = try? .init(from: decoder)
+                        value4 = try? .init(from: decoder)
                         try DecodingError.verifyAtLeastOneSchemaIsNotNil(
-                            [value1, value2],
+                            [value1, value2, value3, value4],
                             type: Self.self,
                             codingPath: decoder.codingPath
                         )
@@ -290,6 +306,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public func encode(to encoder: any Encoder) throws {
                         try value1?.encode(to: encoder)
                         try value2?.encode(to: encoder)
+                        try value3?.encode(to: encoder)
+                        try value4?.encode(to: encoder)
                     }
                 }
             }
@@ -1223,6 +1241,13 @@ extension SnippetBasedReferenceTests {
         line: UInt = #line
     ) throws {
         let translator = try makeTypesTranslator(componentsYAML: componentsYAML)
+        let schemas = translator.components.schemas
+        for (key, schema) in schemas {
+            XCTAssertTrue(
+                try translator.isSchemaSupported(schema) == .supported,
+                "Schema \(schema.prettyDescription) for key \(key) is not supported"
+            )
+        }
         let translation = try translator.translateSchemas(translator.components.schemas)
         try XCTAssertSwiftEquivalent(translation, expectedSwift, file: file, line: line)
     }


### PR DESCRIPTION
### Motivation

Previously, we enforced that child schemas of `anyOf` and `allOf` are object-ish (aka objects, refs to objects, or allOfs of objects) schemas. That made is easier to get started, but that limitation isn't needed anymore, the generated code can handle any child schemas nowadays, and a few high-profile OpenAPI docs are using this and were blocked on our limitation.

### Modifications

Remove the limitation that only object-ish schemas can be child schemas of anyOf and allOf.

> Note: oneOf is different, we always supported any schema when there is no discriminator specified, and require refs to object-ish schemas when a discriminator is specified.

### Result

OpenAPI documents that, for example do the following, can be generated now:

```
anyOf:
  - type: string
  - type: integer
```

### Test Plan

Updated the unit tests for `isSchemaSupported`, where most of the work was, plus amended anyOf/allOf snippet tests to also include non-object-ish schemas.
