### PR TITLE
Retain operation level parameters over path level ones

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -154,7 +154,7 @@ extension OperationDescription {
             var mergedParameters: [UnresolvedParameter] = []
             var uniqueIdentifiers: Set<String> = []
 
-            for parameter in pathParameters + operation.parameters {
+            for parameter in operation.parameters + pathParameters {
                 let resolvedParameter = try parameter.resolve(in: components)
                 let identifier = resolvedParameter.location.rawValue + ":" + resolvedParameter.name
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -151,15 +151,16 @@ extension OperationDescription {
     /// - Throws: When an invalid JSON reference is found.
     var allParameters: [UnresolvedParameter] {
         get throws { 
-            var mergedParameters = [UnresolvedParameter]()
-            var uniqueIdentifiers = Set<String>()
+            var mergedParameters: [UnresolvedParameter] = []
+            var uniqueIdentifiers: Set<String> = []
 
             for parameter in pathParameters + operation.parameters {
                 let resolvedParameter = try parameter.resolve(in: components)
-                let identifier = resolvedParameter.name + resolvedParameter.location.rawValue
+                let identifier = resolvedParameter.location.rawValue + ":" + resolvedParameter.name
 
-                guard !uniqueIdentifiers.contains(identifier) 
-                else { continue }
+                guard !uniqueIdentifiers.contains(identifier) else { 
+                    continue 
+                }
 
                 mergedParameters.append(parameter)
                 uniqueIdentifiers.insert(identifier)

--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -150,23 +150,24 @@ extension OperationDescription {
     /// - Returns: An array of merged path item and operation level parameters without duplicates.
     /// - Throws: When an invalid JSON reference is found.
     var allParameters: [UnresolvedParameter] {
-        get throws { 
+        get throws {
             var mergedParameters: [UnresolvedParameter] = []
             var uniqueIdentifiers: Set<String> = []
 
-            for parameter in operation.parameters + pathParameters {
+            let allParameters = pathParameters + operation.parameters
+            for parameter in allParameters.reversed() {
                 let resolvedParameter = try parameter.resolve(in: components)
                 let identifier = resolvedParameter.location.rawValue + ":" + resolvedParameter.name
 
-                guard !uniqueIdentifiers.contains(identifier) else { 
-                    continue 
+                guard !uniqueIdentifiers.contains(identifier) else {
+                    continue
                 }
 
                 mergedParameters.append(parameter)
                 uniqueIdentifiers.insert(identifier)
             }
 
-            return mergedParameters
+            return mergedParameters.reversed()
         }
     }
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -144,10 +144,29 @@ extension OperationDescription {
         )
     }
 
-    /// Returns parameters from both the path item level
-    /// and the operation level.
+    /// Merged parameters from both the path item level and the operation level.
+    /// If duplicate parameters exist, only the parameters from the operation level are preserved.
+    ///
+    /// - Returns: An array of merged path item and operation level parameters without duplicates.
+    /// - Throws: When an invalid JSON reference is found.
     var allParameters: [UnresolvedParameter] {
-        pathParameters + operation.parameters
+        get throws { 
+            var mergedParameters = [UnresolvedParameter]()
+            var uniqueIdentifiers = Set<String>()
+
+            for parameter in pathParameters + operation.parameters {
+                let resolvedParameter = try parameter.resolve(in: components)
+                let identifier = resolvedParameter.name + resolvedParameter.location.rawValue
+
+                guard !uniqueIdentifiers.contains(identifier) 
+                else { continue }
+
+                mergedParameters.append(parameter)
+                uniqueIdentifiers.insert(identifier)
+            }
+
+            return mergedParameters
+        }
     }
 
     /// Returns all parameters by resolving any parameter references first.

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Operations/Test_OperationDescription.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Operations/Test_OperationDescription.swift
@@ -74,7 +74,7 @@ final class Test_OperationDescription: Test_Core {
         )
         let allParameters = try _test(pathItem)
 
-        XCTAssertEqual(allParameters, [operationLevelParameter, pathLevelParameter])
+        XCTAssertEqual(allParameters, [pathLevelParameter, operationLevelParameter])
     }
 
     private func _test(_ pathItem: OpenAPI.PathItem) throws -> [UnresolvedParameter] {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Operations/Test_OperationDescription.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Operations/Test_OperationDescription.swift
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIKit30
+import XCTest
+@testable import _OpenAPIGeneratorCore
+
+final class Test_OperationDescription: Test_Core {
+
+    func testAllParameters_duplicates_retainOnlyOperationParameters() throws {
+        let allParameters = try _test(
+            """
+            openapi: "3.0.0"
+            info:
+              title: "Test"
+              version: "1.0.0"
+            paths:
+              /system:
+                get:
+                  description: This is a unit test.
+                  responses:
+                    '200':
+                      description: Success
+                  parameters:
+                    - name: test
+                      in: query
+                      schema:
+                        type: string
+                parameters:
+                  - name: test
+                    in: query
+                    schema:
+                      type: integer
+            """
+        )
+
+        XCTAssertEqual(
+            allParameters,
+            [.b(OpenAPI.Parameter(name: "test", context: .query(required: false), schema: .integer))]
+        )
+    }
+
+    func testAllParameters_duplicates_keepsDuplicatesAtDifferentLocation() throws {
+        let allParameters = try _test(
+            """
+            openapi: "3.0.0"
+            info:
+              title: "Test"
+              version: "1.0.0"
+            paths:
+              /system:
+                get:
+                  description: This is a unit test.
+                  responses:
+                    '200':
+                      description: Success
+                  parameters:
+                    - name: test
+                      in: query
+                      schema:
+                        type: string
+                parameters:
+                  - name: test
+                    in: path
+                    required: true
+                    schema:
+                      type: integer
+            """
+        )
+
+        XCTAssertEqual(
+            allParameters,
+            [
+                .b(OpenAPI.Parameter(name: "test", context: .path, schema: .integer)),
+                .b(OpenAPI.Parameter(name: "test", context: .query(required: false), schema: .string))
+            ]
+        )
+    }
+
+    private func _test(_ yaml: String) throws -> [UnresolvedParameter] {
+        let document = try YamsParser()
+            .parseOpenAPI(
+                .init(
+                    absolutePath: URL(fileURLWithPath: "/foo.yaml"),
+                    contents: Data(yaml.utf8)
+                ),
+                config: .init(mode: .types),
+                diagnostics: PrintingDiagnosticCollector()
+            )
+
+        guard let operationDescription = try OperationDescription.all(
+            from: document.paths,
+            in: document.components,
+            asSwiftSafeName: { $0 }
+        ).first else {
+            XCTFail("Unable to retrieve the operation description.")
+            return []
+        }
+
+        return try operationDescription.allParameters
+    }
+}


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/168.

### Modifications

Previously, an operation's parameters were returned as a concatenation of the parameters from the path item level with those at operation level.

However, this is incorrect according to https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#fixed-fields-7. 
> A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there. The list MUST NOT include duplicated parameters.

With this change, we are merging the two arrays of parameters using a unique identifier of the location + name of parameters. If duplicate parameters exist, only the parameters from the operation level are preserved.

### Result

After this change, an operation's parameters won't contain any duplicate. 

### Test Plan

Add tests for `OperationDescription.allParameters` at `Tests/OpenAPIGeneratorCoreTests/Translator/Operations/Test_OperationDescription.swift`.