### PR TITLE
[Bugfix] Finalize diagnostics even when an error is thrown

### DIFF
--- a/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
@@ -78,11 +78,15 @@ extension _GenerateOptions {
                 isDryRun: isDryRun,
                 diagnostics: diagnostics
             )
+            try finalizeDiagnostics()
         } catch let error as Diagnostic {
             // Emit our nice Diagnostics message instead of relying on ArgumentParser output.
             diagnostics.emit(error)
+            try finalizeDiagnostics()
             throw ExitCode.failure
+        } catch {
+            try finalizeDiagnostics()
+            throw error
         }
-        try finalizeDiagnostics()
     }
 }


### PR DESCRIPTION
### Motivation

Previously, when the generation logic threw an error, we wouldn't finalize the diagnostics collector, which in the case of the YAML file diagnostics collector meant the file would never be written, and the caller wouldn't know why the tool returned a non-0 exit code.

### Modifications

Move the finalization into every logic branch, to make sure it's always called at the end.

### Result

Now when providing `--diagnostics-output-path` to the CLI and the generation fails with an error, the diagnostics YAML file will be written correctly.

### Test Plan

Tested manually locally using another script that drives `swift-openapi-generator`.
