### PR TITLE
Ignore inline schemas in oneOf with discriminator

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
@@ -124,9 +124,17 @@ extension FileTranslator {
         discriminator: OpenAPI.Discriminator?,
         schemas: [JSONSchema]
     ) throws -> Declaration {
+        // > When using the discriminator, inline schemas will not be considered.
+        // > — https://spec.openapis.org/oas/v3.0.3#discriminator-object
+        let includedSchemas: [JSONSchema]
+        if discriminator != nil {
+            includedSchemas = schemas.filter(\.isReference)
+        } else {
+            includedSchemas = schemas
+        }
 
         let cases: [(String, Comment?, TypeUsage, [Declaration])] =
-            try schemas
+            try includedSchemas
             .enumerated()
             .map { index, schema in
                 let key = "case\(index+1)"

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
@@ -157,13 +157,12 @@ extension FileTranslator {
                     schema: schema
                 )
             }
-            // If a discriminator is provided, only refs to object/allOf of
-            // object schemas are allowed.
-            // Otherwise, any schema is allowed.
             guard context.discriminator != nil else {
                 return try areSchemasSupported(schemas)
             }
-            return try areRefsToObjectishSchemaAndSupported(schemas)
+            // > When using the discriminator, inline schemas will not be considered.
+            // > — https://spec.openapis.org/oas/v3.0.3#discriminator-object
+            return try areRefsToObjectishSchemaAndSupported(schemas.filter(\.isReference))
         case .not:
             return .unsupported(
                 reason: .schemaType,

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
@@ -71,10 +71,12 @@ class Test_isSchemaSupported: XCTestCase {
             .array(items: .string),
         ]),
 
-        // oneOf with a discriminator with two objectish schemas
+        // oneOf with a discriminator with two objectish schemas and two (ignored) inline schemas
         .one(
             of: .reference(.component(named: "MyObj")),
             .reference(.component(named: "MyObj2")),
+            .object,
+            .boolean,
             discriminator: .init(propertyName: "foo")
         ),
 
@@ -120,9 +122,6 @@ class Test_isSchemaSupported: XCTestCase {
             .one(of: .reference(.internal(.component(name: "Foo"))), discriminator: .init(propertyName: "foo")),
             .notObjectish
         ),
-
-        // a oneOf with a discriminator with an inline subschema
-        (.one(of: .object, discriminator: .init(propertyName: "foo")), .notRef),
     ]
     func testUnsupportedTypes() throws {
         let translator = self.translator


### PR DESCRIPTION
### Motivation

Currently, when provided with a `oneOf` with a `discriminator`, the generator will fail if any of the schemas are not references. However, the OpenAPI specification states that inline schemas should be ignored when using a discriminator:

> When using the discriminator, inline schemas will not be considered.
> — https://spec.openapis.org/oas/v3.0.3#discriminator-object

The generator shouldn't fail when presented with a spec-compliant OpenAPI document, however misguided it might be.

### Modifications

Filter out inline schemas during schema validation and translation.

### Result

Can handle documents with `oneOf` types with a discriminator, containing inline schemas.

### Test Plan

- Updated unit tests for supported/unsupported schemas.
- Updated snippet test with an example, which failed before this patch.

### Resolves

- Fixes #181 