### PR TITLE
Enable strict concurrency checking in CI

### DIFF
--- a/Sources/PetstoreConsumerTestCore/Common.swift
+++ b/Sources/PetstoreConsumerTestCore/Common.swift
@@ -14,10 +14,10 @@
 import OpenAPIRuntime
 import Foundation
 
-public enum TestError: Swift.Error, LocalizedError, CustomStringConvertible {
+public enum TestError: Swift.Error, LocalizedError, CustomStringConvertible, Sendable {
     case noHandlerFound(method: HTTPMethod, path: [RouterPathComponent])
     case invalidURLString(String)
-    case unexpectedValue(Any)
+    case unexpectedValue(any Sendable)
     case unexpectedMissingRequestBody
 
     public var description: String {

--- a/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
+++ b/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
@@ -18,7 +18,7 @@ import OpenAPIKit30
 public struct Diagnostic: Error, Codable {
 
     /// Describes the severity of a diagnostic.
-    public enum Severity: String, Codable {
+    public enum Severity: String, Codable, Sendable {
 
         /// An informative message, does not represent an issue.
         case note
@@ -38,7 +38,7 @@ public struct Diagnostic: Error, Codable {
     public var message: String
 
     /// Describes the source file that triggered a diagnostic.
-    public struct Location: Codable {
+    public struct Location: Codable, Sendable {
         /// The absolute path to a specific source file that triggered the diagnostic.
         public var filePath: String
 
@@ -333,7 +333,7 @@ public struct StdErrPrintingDiagnosticCollector: DiagnosticCollector {
     public init() {}
 
     public func emit(_ diagnostic: Diagnostic) {
-        print(diagnostic.description, to: &stdErrHandle)
+        stdErrHandle.write(diagnostic.description)
     }
 }
 

--- a/Sources/_OpenAPIGeneratorCore/Extensions/Foundation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/Foundation.swift
@@ -47,7 +47,7 @@ extension InMemoryOutputFile {
 }
 
 /// File handle to stderr.
-var stdErrHandle = FileHandle.standardError
+let stdErrHandle = FileHandle.standardError
 
 extension FileHandle: TextOutputStream {
     public func write(_ string: String) {

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -20,6 +20,7 @@ services:
       #
       # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: *image

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -19,6 +19,7 @@ services:
       #
       # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: *image

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -20,6 +20,7 @@ services:
       #
       # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: *image

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-}"
+    command: /bin/bash -xcl "swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${STRICT_CONCURRENCY_ARG-}"
 
   shell:
     <<: *common


### PR DESCRIPTION
### Motivation

To further avoid concurrency bugs, enable complete concurrency checking in CI.

### Modifications

Added the compiler flag to the docker-compose scripts, even though it won't fail the CI when new warnings are introduced, as we can't enable warnings-as-errors yet.

Adapted the code to be more concurrency safe.

### Result

The project passes the complete concurrency checking.

### Test Plan

Locally built without any warnings with the flag enabled.
