### PR TITLE
SOAR-0002 implementation

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
@@ -21,24 +21,37 @@ extension FileTranslator {
     /// - Parameter contentType: The content type for which to compute the name.
     func contentSwiftName(_ contentType: ContentType) -> String {
         if config.featureFlags.contains(.multipleContentTypes) {
-            let rawMIMEType = contentType.lowercasedTypeAndSubtype
-            switch rawMIMEType {
+            switch contentType.lowercasedTypeAndSubtype {
             case "application/json":
                 return "json"
             case "application/x-www-form-urlencoded":
-                return "form"
+                return "urlEncodedForm"
             case "multipart/form-data":
-                return "multipart"
+                return "multipartForm"
             case "text/plain":
-                return "text"
+                return "plainText"
             case "*/*":
                 return "any"
             case "application/xml":
                 return "xml"
             case "application/octet-stream":
                 return "binary"
+            case "text/html":
+                return "html"
+            case "application/yaml":
+                return "yaml"
+            case "text/csv":
+                return "csv"
+            case "image/png":
+                return "png"
+            case "application/pdf":
+                return "pdf"
+            case "image/jpeg":
+                return "jpeg"
             default:
-                return swiftSafeName(for: rawMIMEType)
+                let safedType = swiftSafeName(for: contentType.originallyCasedType)
+                let safedSubtype = swiftSafeName(for: contentType.originallyCasedSubtype)
+                return "\(safedType)_\(safedSubtype)"
             }
         } else {
             switch contentType.category {

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
@@ -50,12 +50,9 @@ struct ContentType: Hashable {
         /// First checks if the provided content type is a JSON, then text,
         /// and uses binary if none of the two match.
         /// - Parameters:
-        ///   - type: The first component of the MIME type.
-        ///   - subtype: The second component of the MIME type.
-        init(type: String, subtype: String) {
-            let lowercasedType = type.lowercased()
-            let lowercasedSubtype = subtype.lowercased()
-
+        ///   - lowercasedType: The first component of the MIME type.
+        ///   - lowercasedSubtype: The second component of the MIME type.
+        fileprivate init(lowercasedType: String, lowercasedSubtype: String) {
             // https://json-schema.org/draft/2020-12/json-schema-core.html#section-4.2
             if (lowercasedType == "application" && lowercasedSubtype == "json") || lowercasedSubtype.hasSuffix("+json")
             {
@@ -82,27 +79,33 @@ struct ContentType: Hashable {
 
     /// The mapped content type category.
     var category: Category {
-        Category(type: type, subtype: subtype)
+        Category(lowercasedType: lowercasedType, lowercasedSubtype: lowercasedSubtype)
     }
 
     /// The first component of the MIME type.
-    private let type: String
+    ///
+    /// Preserves the casing from the input, do not use this
+    /// for equality comparisons, use `lowercasedType` instead.
+    let originallyCasedType: String
 
     /// The first component of the MIME type, as a lowercase string.
     ///
     /// The raw value in its original casing is only provided by `rawTypeAndSubtype`.
     var lowercasedType: String {
-        type.lowercased()
+        originallyCasedType.lowercased()
     }
 
     /// The second component of the MIME type.
-    private let subtype: String
+    ///
+    /// Preserves the casing from the input, do not use this
+    /// for equality comparisons, use `lowercasedSubtype` instead.
+    let originallyCasedSubtype: String
 
     /// The second component of the MIME type, as a lowercase string.
     ///
     /// The raw value in its original casing is only provided by `originallyCasedTypeAndSubtype`.
     var lowercasedSubtype: String {
-        subtype.lowercased()
+        originallyCasedSubtype.lowercased()
     }
 
     /// Creates a new content type by parsing the specified MIME type.
@@ -122,15 +125,15 @@ struct ContentType: Hashable {
             typeAndSubtype.count == 2,
             "Invalid ContentType string, must have 2 components separated by a slash."
         )
-        self.type = typeAndSubtype[0]
-        self.subtype = typeAndSubtype[1]
+        self.originallyCasedType = typeAndSubtype[0]
+        self.originallyCasedSubtype = typeAndSubtype[1]
     }
 
     /// Returns the type and subtype as a "<type>/<subtype>" string.
     ///
     /// Respects the original casing provided as input.
     var originallyCasedTypeAndSubtype: String {
-        "\(type)/\(subtype)"
+        "\(originallyCasedType)/\(originallyCasedSubtype)"
     }
 
     /// Returns the type and subtype as a "<type>/<subtype>" string.

--- a/Tests/OpenAPIGeneratorCoreTests/Extensions/Test_String.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Extensions/Test_String.swift
@@ -83,6 +83,10 @@ final class Test_String: Test_Core {
 
             // Non Latin Characters
             ("$مرحبا", "_dollar_مرحبا"),
+
+            // Content type components
+            ("application", "application"),
+            ("vendor1+json", "vendor1_plus_json"),
         ]
         let translator = makeTranslator(featureFlags: [.proposal0001])
         let asSwiftSafeName: (String) -> String = translator.swiftSafeName

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
@@ -34,16 +34,30 @@ final class Test_ContentSwiftName: Test_Core {
     }
 
     func testProposed_multipleContentTypes() throws {
-        let nameMaker = makeTranslator(featureFlags: [.multipleContentTypes]).contentSwiftName
+        let nameMaker = makeTranslator(featureFlags: [
+            .proposal0001,
+            .multipleContentTypes,
+        ])
+        .contentSwiftName
         let cases: [(String, String)] = [
+
+            // Short names.
             ("application/json", "json"),
-            ("application/x-www-form-urlencoded", "form"),
-            ("multipart/form-data", "multipart"),
-            ("text/plain", "text"),
+            ("application/x-www-form-urlencoded", "urlEncodedForm"),
+            ("multipart/form-data", "multipartForm"),
+            ("text/plain", "plainText"),
             ("*/*", "any"),
             ("application/xml", "xml"),
             ("application/octet-stream", "binary"),
-            ("application/myformat+json", "application_myformat_json"),
+            ("text/html", "html"),
+            ("application/yaml", "yaml"),
+            ("text/csv", "csv"),
+            ("image/png", "png"),
+            ("application/pdf", "pdf"),
+            ("image/jpeg", "jpeg"),
+
+            // Generic names.
+            ("application/myformat+json", "application_myformat_plus_json"),
             ("foo/bar", "foo_bar"),
         ]
         try _testIdentifiers(cases: cases, nameMaker: nameMaker)

--- a/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
@@ -59,7 +59,10 @@ class FileBasedReferenceTests: XCTestCase {
                 name: .petstore,
                 customDirectoryName: "Petstore_FF_MultipleContentTypes"
             ),
-            featureFlags: [.multipleContentTypes]
+            featureFlags: [
+                .multipleContentTypes,
+                .proposal0001,
+            ]
         )
     }
 

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Client.swift
@@ -74,7 +74,7 @@ public struct Client: APIProtocol {
                 try converter.setHeaderFieldAsText(
                     in: &request.headerFields,
                     name: "My-Request-UUID",
-                    value: input.headers.My_Request_UUID
+                    value: input.headers.My_hyphen_Request_hyphen_UUID
                 )
                 try converter.setQueryItemAsText(
                     in: &request,
@@ -94,12 +94,12 @@ public struct Client: APIProtocol {
                 switch response.statusCode {
                 case 200:
                     let headers: Operations.listPets.Output.Ok.Headers = .init(
-                        My_Response_UUID: try converter.getRequiredHeaderFieldAsText(
+                        My_hyphen_Response_hyphen_UUID: try converter.getRequiredHeaderFieldAsText(
                             in: response.headerFields,
                             name: "My-Response-UUID",
                             as: Swift.String.self
                         ),
-                        My_Tracing_Header: try converter.getOptionalHeaderFieldAsText(
+                        My_hyphen_Tracing_hyphen_Header: try converter.getOptionalHeaderFieldAsText(
                             in: response.headerFields,
                             name: "My-Tracing-Header",
                             as: Components.Headers.TracingHeader.self
@@ -169,7 +169,7 @@ public struct Client: APIProtocol {
                 try converter.setHeaderFieldAsJSON(
                     in: &request.headerFields,
                     name: "X-Extra-Arguments",
-                    value: input.headers.X_Extra_Arguments
+                    value: input.headers.X_hyphen_Extra_hyphen_Arguments
                 )
                 try converter.setHeaderFieldAsText(
                     in: &request.headerFields,
@@ -190,7 +190,7 @@ public struct Client: APIProtocol {
                 switch response.statusCode {
                 case 201:
                     let headers: Operations.createPet.Output.Created.Headers = .init(
-                        X_Extra_Arguments: try converter.getOptionalHeaderFieldAsJSON(
+                        X_hyphen_Extra_hyphen_Arguments: try converter.getOptionalHeaderFieldAsJSON(
                             in: response.headerFields,
                             name: "X-Extra-Arguments",
                             as: Components.Schemas.CodeError.self
@@ -217,7 +217,7 @@ public struct Client: APIProtocol {
                     return .created(.init(headers: headers, body: body))
                 case 400:
                     let headers: Components.Responses.ErrorBadRequest.Headers = .init(
-                        X_Reason: try converter.getOptionalHeaderFieldAsText(
+                        X_hyphen_Reason: try converter.getOptionalHeaderFieldAsText(
                             in: response.headerFields,
                             name: "X-Reason",
                             as: Swift.String.self
@@ -295,7 +295,7 @@ public struct Client: APIProtocol {
                         body = try converter.getResponseBodyAsText(
                             Swift.String.self,
                             from: response.body,
-                            transforming: { value in .text(value) }
+                            transforming: { value in .plainText(value) }
                         )
                     } else if try converter.isMatchingContentType(
                         received: contentType,
@@ -337,7 +337,7 @@ public struct Client: APIProtocol {
                         headerFields: &request.headerFields,
                         contentType: "application/json; charset=utf-8"
                     )
-                case let .text(value):
+                case let .plainText(value):
                     request.body = try converter.setRequiredRequestBodyAsText(
                         value,
                         headerFields: &request.headerFields,
@@ -543,7 +543,7 @@ public struct Client: APIProtocol {
                         body = try converter.getResponseBodyAsText(
                             Swift.String.self,
                             from: response.body,
-                            transforming: { value in .text(value) }
+                            transforming: { value in .plainText(value) }
                         )
                     } else {
                         throw converter.makeUnexpectedContentTypeError(contentType: contentType)

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Server.swift
@@ -111,11 +111,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                         style: .form,
                         explode: true,
                         name: "since",
-                        as: Components.Parameters.query_born_since.self
+                        as: Components.Parameters.query_period_born_hyphen_since.self
                     )
                 )
                 let headers: Operations.listPets.Input.Headers = .init(
-                    My_Request_UUID: try converter.getOptionalHeaderFieldAsText(
+                    My_hyphen_Request_hyphen_UUID: try converter.getOptionalHeaderFieldAsText(
                         in: request.headerFields,
                         name: "My-Request-UUID",
                         as: Swift.String.self
@@ -139,12 +139,12 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     try converter.setHeaderFieldAsText(
                         in: &response.headerFields,
                         name: "My-Response-UUID",
-                        value: value.headers.My_Response_UUID
+                        value: value.headers.My_hyphen_Response_hyphen_UUID
                     )
                     try converter.setHeaderFieldAsText(
                         in: &response.headerFields,
                         name: "My-Tracing-Header",
-                        value: value.headers.My_Tracing_Header
+                        value: value.headers.My_hyphen_Tracing_hyphen_Header
                     )
                     switch value.body {
                     case let .json(value):
@@ -193,7 +193,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
             deserializer: { request, metadata in let path: Operations.createPet.Input.Path = .init()
                 let query: Operations.createPet.Input.Query = .init()
                 let headers: Operations.createPet.Input.Headers = .init(
-                    X_Extra_Arguments: try converter.getOptionalHeaderFieldAsJSON(
+                    X_hyphen_Extra_hyphen_Arguments: try converter.getOptionalHeaderFieldAsJSON(
                         in: request.headerFields,
                         name: "X-Extra-Arguments",
                         as: Components.Schemas.CodeError.self
@@ -233,7 +233,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     try converter.setHeaderFieldAsJSON(
                         in: &response.headerFields,
                         name: "X-Extra-Arguments",
-                        value: value.headers.X_Extra_Arguments
+                        value: value.headers.X_hyphen_Extra_hyphen_Arguments
                     )
                     switch value.body {
                     case let .json(value):
@@ -255,7 +255,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     try converter.setHeaderFieldAsText(
                         in: &response.headerFields,
                         name: "X-Reason",
-                        value: value.headers.X_Reason
+                        value: value.headers.X_hyphen_Reason
                     )
                     switch value.body {
                     case let .json(value):
@@ -312,7 +312,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                             headerFields: &response.headerFields,
                             contentType: "application/json; charset=utf-8"
                         )
-                    case let .text(value):
+                    case let .plainText(value):
                         try converter.validateAcceptIfPresent(
                             "text/plain",
                             in: request.headerFields
@@ -371,7 +371,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     body = try converter.getRequiredRequestBodyAsText(
                         Swift.String.self,
                         from: request.body,
-                        transforming: { value in .text(value) }
+                        transforming: { value in .plainText(value) }
                     )
                 } else if try converter.isMatchingContentType(
                     received: contentType,
@@ -530,7 +530,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     petId: try converter.getPathParameterAsText(
                         in: metadata.pathParameters,
                         name: "petId",
-                        as: Components.Parameters.path_petId.self
+                        as: Components.Parameters.path_period_petId.self
                     )
                 )
                 let query: Operations.uploadAvatarForPet.Input.Query = .init()
@@ -601,7 +601,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     var response = Response(statusCode: 500)
                     suppressMutabilityWarning(&response)
                     switch value.body {
-                    case let .text(value):
+                    case let .plainText(value):
                         try converter.validateAcceptIfPresent(
                             "text/plain",
                             in: request.headerFields

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
@@ -106,7 +106,7 @@ public enum Components {
             case dog
             case ELEPHANT
             case BIG_ELEPHANT_1
-            case _nake
+            case _dollar_nake
             case _public
             /// Parsed a raw value that was not defined in the OpenAPI document.
             case undocumented(String)
@@ -116,7 +116,7 @@ public enum Components {
                 case "dog": self = .dog
                 case "ELEPHANT": self = .ELEPHANT
                 case "BIG_ELEPHANT_1": self = .BIG_ELEPHANT_1
-                case "$nake": self = ._nake
+                case "$nake": self = ._dollar_nake
                 case "public": self = ._public
                 default: self = .undocumented(rawValue)
                 }
@@ -128,12 +128,12 @@ public enum Components {
                 case .dog: return "dog"
                 case .ELEPHANT: return "ELEPHANT"
                 case .BIG_ELEPHANT_1: return "BIG_ELEPHANT_1"
-                case ._nake: return "$nake"
+                case ._dollar_nake: return "$nake"
                 case ._public: return "public"
                 }
             }
             public static var allCases: [PetKind] {
-                [.cat, .dog, .ELEPHANT, .BIG_ELEPHANT_1, ._nake, ._public]
+                [.cat, .dog, .ELEPHANT, .BIG_ELEPHANT_1, ._dollar_nake, ._public]
             }
         }
         /// - Remark: Generated from `#/components/schemas/CreatePetRequest`.
@@ -172,7 +172,7 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/Error/code`.
             public var code: Swift.Int32
             /// - Remark: Generated from `#/components/schemas/Error/me$sage`.
-            public var me_sage: Swift.String
+            public var me_dollar_sage: Swift.String
             /// Extra information about the error.
             ///
             /// - Remark: Generated from `#/components/schemas/Error/extraInfo`.
@@ -201,23 +201,23 @@ public enum Components {
             ///
             /// - Parameters:
             ///   - code:
-            ///   - me_sage:
+            ///   - me_dollar_sage:
             ///   - extraInfo: Extra information about the error.
             ///   - userData: Custom user-provided key-value pairs.
             public init(
                 code: Swift.Int32,
-                me_sage: Swift.String,
+                me_dollar_sage: Swift.String,
                 extraInfo: Components.Schemas._Error.extraInfoPayload? = nil,
                 userData: OpenAPIRuntime.OpenAPIObjectContainer? = nil
             ) {
                 self.code = code
-                self.me_sage = me_sage
+                self.me_dollar_sage = me_dollar_sage
                 self.extraInfo = extraInfo
                 self.userData = userData
             }
             public enum CodingKeys: String, CodingKey {
                 case code
-                case me_sage = "me$sage"
+                case me_dollar_sage = "me$sage"
                 case extraInfo
                 case userData
             }
@@ -624,15 +624,15 @@ public enum Components {
         /// Supply this parameter to filter pets born since the provided date.
         ///
         /// - Remark: Generated from `#/components/parameters/query.born-since`.
-        public typealias query_born_since = Components.Schemas.DOB
+        public typealias query_period_born_hyphen_since = Components.Schemas.DOB
         /// The id of the pet to retrieve
         ///
         /// - Remark: Generated from `#/components/parameters/path.petId`.
-        public typealias path_petId = Swift.Int64
+        public typealias path_period_petId = Swift.Int64
         /// A deprecated header parameter
         ///
         /// - Remark: Generated from `#/components/parameters/header.deprecatedHeader`.
-        public typealias header_deprecatedHeader = Swift.String
+        public typealias header_period_deprecatedHeader = Swift.String
     }
     /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
     public enum RequestBodies {
@@ -673,12 +673,14 @@ public enum Components {
     public enum Responses {
         public struct ErrorBadRequest: Sendable, Equatable, Hashable {
             public struct Headers: Sendable, Equatable, Hashable {
-                public var X_Reason: Swift.String?
+                public var X_hyphen_Reason: Swift.String?
                 /// Creates a new `Headers`.
                 ///
                 /// - Parameters:
-                ///   - X_Reason:
-                public init(X_Reason: Swift.String? = nil) { self.X_Reason = X_Reason }
+                ///   - X_hyphen_Reason:
+                public init(X_hyphen_Reason: Swift.String? = nil) {
+                    self.X_hyphen_Reason = X_hyphen_Reason
+                }
             }
             /// Received HTTP response headers
             public var headers: Components.Responses.ErrorBadRequest.Headers
@@ -803,7 +805,7 @@ public enum Operations {
                 public typealias feedsPayload = [Operations.listPets.Input.Query
                     .feedsPayloadPayload]
                 public var feeds: Operations.listPets.Input.Query.feedsPayload?
-                public var since: Components.Parameters.query_born_since?
+                public var since: Components.Parameters.query_period_born_hyphen_since?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
@@ -815,7 +817,7 @@ public enum Operations {
                     limit: Swift.Int32? = nil,
                     habitat: Operations.listPets.Input.Query.habitatPayload? = nil,
                     feeds: Operations.listPets.Input.Query.feedsPayload? = nil,
-                    since: Components.Parameters.query_born_since? = nil
+                    since: Components.Parameters.query_period_born_hyphen_since? = nil
                 ) {
                     self.limit = limit
                     self.habitat = habitat
@@ -825,13 +827,13 @@ public enum Operations {
             }
             public var query: Operations.listPets.Input.Query
             public struct Headers: Sendable, Equatable, Hashable {
-                public var My_Request_UUID: Swift.String?
+                public var My_hyphen_Request_hyphen_UUID: Swift.String?
                 /// Creates a new `Headers`.
                 ///
                 /// - Parameters:
-                ///   - My_Request_UUID:
-                public init(My_Request_UUID: Swift.String? = nil) {
-                    self.My_Request_UUID = My_Request_UUID
+                ///   - My_hyphen_Request_hyphen_UUID:
+                public init(My_hyphen_Request_hyphen_UUID: Swift.String? = nil) {
+                    self.My_hyphen_Request_hyphen_UUID = My_hyphen_Request_hyphen_UUID
                 }
             }
             public var headers: Operations.listPets.Input.Headers
@@ -867,19 +869,19 @@ public enum Operations {
         @frozen public enum Output: Sendable, Equatable, Hashable {
             public struct Ok: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
-                    public var My_Response_UUID: Swift.String
-                    public var My_Tracing_Header: Components.Headers.TracingHeader?
+                    public var My_hyphen_Response_hyphen_UUID: Swift.String
+                    public var My_hyphen_Tracing_hyphen_Header: Components.Headers.TracingHeader?
                     /// Creates a new `Headers`.
                     ///
                     /// - Parameters:
-                    ///   - My_Response_UUID:
-                    ///   - My_Tracing_Header:
+                    ///   - My_hyphen_Response_hyphen_UUID:
+                    ///   - My_hyphen_Tracing_hyphen_Header:
                     public init(
-                        My_Response_UUID: Swift.String,
-                        My_Tracing_Header: Components.Headers.TracingHeader? = nil
+                        My_hyphen_Response_hyphen_UUID: Swift.String,
+                        My_hyphen_Tracing_hyphen_Header: Components.Headers.TracingHeader? = nil
                     ) {
-                        self.My_Response_UUID = My_Response_UUID
-                        self.My_Tracing_Header = My_Tracing_Header
+                        self.My_hyphen_Response_hyphen_UUID = My_hyphen_Response_hyphen_UUID
+                        self.My_hyphen_Tracing_hyphen_Header = My_hyphen_Tracing_hyphen_Header
                     }
                 }
                 /// Received HTTP response headers
@@ -959,13 +961,13 @@ public enum Operations {
             }
             public var query: Operations.createPet.Input.Query
             public struct Headers: Sendable, Equatable, Hashable {
-                public var X_Extra_Arguments: Components.Schemas.CodeError?
+                public var X_hyphen_Extra_hyphen_Arguments: Components.Schemas.CodeError?
                 /// Creates a new `Headers`.
                 ///
                 /// - Parameters:
-                ///   - X_Extra_Arguments:
-                public init(X_Extra_Arguments: Components.Schemas.CodeError? = nil) {
-                    self.X_Extra_Arguments = X_Extra_Arguments
+                ///   - X_hyphen_Extra_hyphen_Arguments:
+                public init(X_hyphen_Extra_hyphen_Arguments: Components.Schemas.CodeError? = nil) {
+                    self.X_hyphen_Extra_hyphen_Arguments = X_hyphen_Extra_hyphen_Arguments
                 }
             }
             public var headers: Operations.createPet.Input.Headers
@@ -1003,14 +1005,14 @@ public enum Operations {
         @frozen public enum Output: Sendable, Equatable, Hashable {
             public struct Created: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
-                    public var X_Extra_Arguments: Components.Schemas.CodeError?
+                    public var X_hyphen_Extra_hyphen_Arguments: Components.Schemas.CodeError?
                     /// Creates a new `Headers`.
                     ///
                     /// - Parameters:
-                    ///   - X_Extra_Arguments:
-                    public init(X_Extra_Arguments: Components.Schemas.CodeError? = nil) {
-                        self.X_Extra_Arguments = X_Extra_Arguments
-                    }
+                    ///   - X_hyphen_Extra_hyphen_Arguments:
+                    public init(
+                        X_hyphen_Extra_hyphen_Arguments: Components.Schemas.CodeError? = nil
+                    ) { self.X_hyphen_Extra_hyphen_Arguments = X_hyphen_Extra_hyphen_Arguments }
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.createPet.Output.Created.Headers
@@ -1109,7 +1111,7 @@ public enum Operations {
                 public var headers: Operations.getStats.Output.Ok.Headers
                 @frozen public enum Body: Sendable, Equatable, Hashable {
                     case json(Components.Schemas.PetStats)
-                    case text(Swift.String)
+                    case plainText(Swift.String)
                     case binary(Foundation.Data)
                 }
                 /// Received HTTP response body
@@ -1166,7 +1168,7 @@ public enum Operations {
             public var cookies: Operations.postStats.Input.Cookies
             @frozen public enum Body: Sendable, Equatable, Hashable {
                 case json(Components.Schemas.PetStats)
-                case text(Swift.String)
+                case plainText(Swift.String)
                 case binary(Foundation.Data)
             }
             public var body: Operations.postStats.Input.Body
@@ -1453,12 +1455,12 @@ public enum Operations {
         public static let id: String = "uploadAvatarForPet"
         public struct Input: Sendable, Equatable, Hashable {
             public struct Path: Sendable, Equatable, Hashable {
-                public var petId: Components.Parameters.path_petId
+                public var petId: Components.Parameters.path_period_petId
                 /// Creates a new `Path`.
                 ///
                 /// - Parameters:
                 ///   - petId:
-                public init(petId: Components.Parameters.path_petId) { self.petId = petId }
+                public init(petId: Components.Parameters.path_period_petId) { self.petId = petId }
             }
             public var path: Operations.uploadAvatarForPet.Input.Path
             public struct Query: Sendable, Equatable, Hashable {
@@ -1569,7 +1571,9 @@ public enum Operations {
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.InternalServerError.Headers
-                @frozen public enum Body: Sendable, Equatable, Hashable { case text(Swift.String) }
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case plainText(Swift.String)
+                }
                 /// Received HTTP response body
                 public var body: Operations.uploadAvatarForPet.Output.InternalServerError.Body
                 /// Creates a new `InternalServerError`.

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -751,7 +751,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
         )
         try self.assertResponsesTranslation(
-            featureFlags: [.multipleContentTypes],
+            featureFlags: [
+                .multipleContentTypes,
+                .proposal0001,
+            ],
             """
             responses:
               MultipleContentTypes:
@@ -770,7 +773,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public var headers: Components.Responses.MultipleContentTypes.Headers
                     @frozen public enum Body: Sendable, Equatable, Hashable {
                         case json(Swift.Int)
-                        case text(Swift.String)
+                        case plainText(Swift.String)
                         case binary(Foundation.Data)
                     }
                     public var body: Components.Responses.MultipleContentTypes.Body
@@ -921,7 +924,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
         )
         try self.assertRequestBodiesTranslation(
-            featureFlags: [.multipleContentTypes],
+            featureFlags: [
+                .multipleContentTypes,
+                .proposal0001,
+            ],
             """
             requestBodies:
               MyResponseBody:
@@ -936,7 +942,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             public enum RequestBodies {
                 @frozen public enum MyResponseBody: Sendable, Equatable, Hashable {
                     case json(Components.Schemas.MyBody)
-                    case text(Swift.String)
+                    case plainText(Swift.String)
                     case binary(Foundation.Data)
                 }
             }

--- a/Tests/PetstoreConsumerTestsFFMultipleContentTypes/Test_Client.swift
+++ b/Tests/PetstoreConsumerTestsFFMultipleContentTypes/Test_Client.swift
@@ -54,7 +54,7 @@ final class Test_Client: XCTestCase {
             return
         }
         switch value.body {
-        case .text(let stats):
+        case .plainText(let stats):
             XCTAssertEqual(stats, "count is 1")
         default:
             XCTFail("Unexpected content type")
@@ -112,7 +112,7 @@ final class Test_Client: XCTestCase {
             return .init(statusCode: 202)
         }
         let response = try await client.postStats(
-            .init(body: .text("count is 1"))
+            .init(body: .plainText("count is 1"))
         )
         guard case .accepted = response else {
             XCTFail("Unexpected response: \(response)")

--- a/Tests/PetstoreConsumerTestsFFMultipleContentTypes/Test_Server.swift
+++ b/Tests/PetstoreConsumerTestsFFMultipleContentTypes/Test_Server.swift
@@ -32,7 +32,7 @@ final class Test_Server: XCTestCase {
     func testGetStats_200_text() async throws {
         client = .init(
             getStatsBlock: { input in
-                return .ok(.init(body: .text("count is 1")))
+                return .ok(.init(body: .plainText("count is 1")))
             }
         )
         let response = try await server.getStats(
@@ -94,7 +94,7 @@ final class Test_Server: XCTestCase {
     func testPostStats_202_text() async throws {
         client = .init(
             postStatsBlock: { input in
-                guard case let .text(stats) = input.body else {
+                guard case let .plainText(stats) = input.body else {
                     throw TestError.unexpectedValue(input.body)
                 }
                 XCTAssertEqual(stats, "count is 1")

--- a/Tests/PetstoreConsumerTestsFFMultipleContentTypes/Test_Types.swift
+++ b/Tests/PetstoreConsumerTestsFFMultipleContentTypes/Test_Types.swift
@@ -25,7 +25,7 @@ final class Test_Types: XCTestCase {
     func testStructCodingKeys() throws {
         let cases: [(Components.Schemas._Error.CodingKeys, String)] = [
             (.code, "code"),
-            (.me_sage, "me$sage"),
+            (.me_dollar_sage, "me$sage"),
         ]
         for (value, rawValue) in cases {
             XCTAssertEqual(value.rawValue, rawValue)
@@ -35,7 +35,7 @@ final class Test_Types: XCTestCase {
     func testEnumCoding() throws {
         let cases: [(Components.Schemas.PetKind, String)] = [
             (.cat, "cat"),
-            (._nake, "$nake"),
+            (._dollar_nake, "$nake"),
         ]
         for (value, rawValue) in cases {
             XCTAssertEqual(value.rawValue, rawValue)


### PR DESCRIPTION
### Motivation

Implements the approved SOAR-0002 proposal: https://github.com/apple/swift-openapi-generator/pull/170

### Modifications

- updates the function that computes content type names to be in line with v3 of SOAR-0002
- refactors the `ContentType` type a bit to make it harder to accidentally perform case-sensitive comparions where case-insensitive ones are required

### Result

When an adopter passes the `multipleContentTypes` feature flag, they'll get the new logic as described in SOAR-0002.

### Test Plan

- adapted unit tests for the `contentSwiftName` function
- enabled the `proposal0001` feature flag as well, since they will be enabled together in 0.2.0, so makes sense to test the new world together
- this lead to a few more updates needed in the reference tests that weren't caused by 0.2.0 alone
