### PR TITLE
Support url form encoded bodies

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -354,6 +354,9 @@ enum Constants {
 
         /// The substring used in method names for the binary coding strategy.
         static let binary: String = "Binary"
+        
+        /// The substring used in method names for the url encoded form coding strategy.
+        static let urlEncodedForm: String = "URLEncodedForm"
     }
 
     /// Constants related to types used in many components.

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/CodingStrategy.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/CodingStrategy.swift
@@ -23,6 +23,9 @@ enum CodingStrategy: String, Equatable, Hashable, Sendable {
 
     /// A strategy that passes through the data unmodified.
     case binary
+    
+    /// A strategy using x-www-form-urlencoded.
+    case urlEncodedForm
 
     /// The name of the coding strategy in the runtime library.
     var runtimeName: String {
@@ -33,6 +36,8 @@ enum CodingStrategy: String, Equatable, Hashable, Sendable {
             return Constants.CodingStrategy.text
         case .binary:
             return Constants.CodingStrategy.binary
+        case .urlEncodedForm:
+            return Constants.CodingStrategy.urlEncodedForm
         }
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
@@ -180,6 +180,15 @@ extension FileTranslator {
                 ),
                 contentValue
             )
+        } else if let (contentKey, contentValue) = map.first(where: { $0.key.isUrlEncodedForm }) {
+            let contentType = ContentType(contentKey.typeAndSubtype)
+            chosenContent = (
+                .init(
+                    contentType: contentType,
+                    schema: contentValue.schema
+                ),
+                contentValue
+            )
         } else if !excludeBinary, let (contentKey, contentValue) = map.first(where: { $0.key.isBinary }) {
             let contentType = ContentType(contentKey.typeAndSubtype)
             chosenContent = (
@@ -250,6 +259,12 @@ extension FileTranslator {
                 contentType: contentType,
                 schema: .b(.string)
             )
+        }
+        if contentKey.isUrlEncodedForm {
+            let contentType = ContentType(contentKey.typeAndSubtype)
+            return .init(
+                contentType: contentType,
+                schema: contentValue.schema)
         }
         if !excludeBinary, contentKey.isBinary {
             let contentType = ContentType(contentKey.typeAndSubtype)

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
@@ -48,6 +48,8 @@ extension FileTranslator {
                 return "text"
             case .binary:
                 return "binary"
+            case .urlEncodedForm:
+                return "form"
             }
         }
     }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
@@ -44,6 +44,18 @@ struct ContentType: Hashable {
         /// The bytes are not further processed, they are instead passed along
         /// either to the network (requests) or to the caller (responses).
         case binary
+        
+        /// A content type for x-www-form-urlencoded.
+        ///
+        /// The top level properties of a Codable data model are encoded
+        /// as key-value pairs in the form:
+        ///
+        ///  `key1=value1&key2=value2`
+        ///
+        ///  Any nested objects are further encoded as stringified JSON objects.
+        ///
+        /// The type is encoded as a binary UTF-8 data packet.
+        case urlEncodedForm
 
         /// Creates a category from the provided type and subtype.
         ///
@@ -62,6 +74,8 @@ struct ContentType: Hashable {
                 self = .json
             } else if lowercasedType == "text" {
                 self = .text
+            } else if lowercasedType == "application" && lowercasedSubtype == "x-www-form-urlencoded" {
+                self = .urlEncodedForm
             } else {
                 self = .binary
             }
@@ -76,6 +90,8 @@ struct ContentType: Hashable {
                 return .text
             case .binary:
                 return .binary
+            case .urlEncodedForm:
+                return .urlEncodedForm
             }
         }
     }
@@ -178,6 +194,10 @@ struct ContentType: Hashable {
     var isBinary: Bool {
         category == .binary
     }
+    
+    var isUrlEncodedForm: Bool {
+        category == .urlEncodedForm
+    }
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         // MIME type equality is case-insensitive.
@@ -208,7 +228,10 @@ extension OpenAPI.ContentType {
     var isBinary: Bool {
         asGeneratorContentType.isBinary
     }
-
+    
+    var isUrlEncodedForm: Bool {
+        asGeneratorContentType.isUrlEncodedForm
+    }
     /// Returns the content type wrapped in the generator's representation
     /// of a content type, as opposed to the one from OpenAPIKit.
     var asGeneratorContentType: ContentType {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
@@ -21,7 +21,7 @@ final class Test_ContentSwiftName: Test_Core {
         let nameMaker = makeTranslator(featureFlags: []).contentSwiftName
         let cases: [(String, String)] = [
             ("application/json", "json"),
-            ("application/x-www-form-urlencoded", "binary"),
+            ("application/x-www-form-urlencoded", "form"),
             ("multipart/form-data", "binary"),
             ("text/plain", "text"),
             ("*/*", "binary"),

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
@@ -53,7 +53,7 @@ final class Test_ContentType: Test_Core {
                 ),
                 (
                     "application/x-www-form-urlencoded",
-                    .binary,
+                    .urlEncodedForm,
                     "application",
                     "x-www-form-urlencoded",
                     "application/x-www-form-urlencoded",

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -113,6 +113,9 @@ paths:
                 $ref: '#/components/schemas/Pet'
         '400':
           $ref: '#/components/responses/ErrorBadRequest'
+  /pets/create:
+    summary: Work with pets
+    description: "Create a pet with a URL form"
     post:
       summary: Create a pet using a url form
       operationId: createPetWithForm

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -113,6 +113,44 @@ paths:
                 $ref: '#/components/schemas/Pet'
         '400':
           $ref: '#/components/responses/ErrorBadRequest'
+    post:
+      summary: Create a pet using a url form
+      operationId: createPetWithForm
+      tags:
+        - pets
+      parameters:
+        - name: X-Extra-Arguments
+          in: header
+          required: false
+          description: "A description here."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeError'
+      requestBody:
+        required: true
+        description: "Create a pet with these properties"
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CreatePetRequest'
+      responses:
+        '201':
+          description: Successfully created pet
+          headers:
+            X-Extra-Arguments:
+              required: false
+              description: "A description here."
+              content:
+                application/json:
+                  schema:
+                    $ref: '#/components/schemas/CodeError'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          $ref: '#/components/responses/ErrorBadRequest'
   /pets/stats:
     get:
       operationId: getStats

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -247,11 +247,10 @@ public struct Client: APIProtocol {
             }
         )
     }
-    
     /// Create a pet using a url form
     ///
-    /// - Remark: HTTP `POST /pets`.
-    /// - Remark: Generated from `#/paths//pets/post(createPet)`.
+    /// - Remark: HTTP `POST /pets/create`.
+    /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)`.
     public func createPetWithForm(_ input: Operations.createPetWithForm.Input) async throws
         -> Operations.createPetWithForm.Output
     {
@@ -259,7 +258,10 @@ public struct Client: APIProtocol {
             input: input,
             forOperation: Operations.createPetWithForm.id,
             serializer: { input in
-                let path = try converter.renderedRequestPath(template: "/pets", parameters: [])
+                let path = try converter.renderedRequestPath(
+                    template: "/pets/create",
+                    parameters: []
+                )
                 var request: OpenAPIRuntime.Request = .init(path: path, method: .post)
                 suppressMutabilityWarning(&request)
                 try converter.setHeaderFieldAsJSON(
@@ -273,11 +275,11 @@ public struct Client: APIProtocol {
                     value: "application/json"
                 )
                 switch input.body {
-                case let .urlEncodedForm(value):
+                case let .form(value):
                     request.body = try converter.setRequiredRequestBodyAsURLEncodedForm(
                         value,
                         headerFields: &request.headerFields,
-                        contentType: "application/x-www-form-urlencoded; charset=utf-8"
+                        contentType: "application/x-www-form-urlencoded"
                     )
                 }
                 return request
@@ -343,7 +345,6 @@ public struct Client: APIProtocol {
             }
         )
     }
-    
     /// - Remark: HTTP `GET /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
     public func getStats(_ input: Operations.getStats.Input) async throws

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -247,6 +247,103 @@ public struct Client: APIProtocol {
             }
         )
     }
+    
+    /// Create a pet using a url form
+    ///
+    /// - Remark: HTTP `POST /pets`.
+    /// - Remark: Generated from `#/paths//pets/post(createPet)`.
+    public func createPetWithForm(_ input: Operations.createPetWithForm.Input) async throws
+        -> Operations.createPetWithForm.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.createPetWithForm.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(template: "/pets", parameters: [])
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .post)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsJSON(
+                    in: &request.headerFields,
+                    name: "X-Extra-Arguments",
+                    value: input.headers.X_Extra_Arguments
+                )
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                switch input.body {
+                case let .urlEncodedForm(value):
+                    request.body = try converter.setRequiredRequestBodyAsURLEncodedForm(
+                        value,
+                        headerFields: &request.headerFields,
+                        contentType: "application/x-www-form-urlencoded; charset=utf-8"
+                    )
+                }
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 201:
+                    let headers: Operations.createPetWithForm.Output.Created.Headers = .init(
+                        X_Extra_Arguments: try converter.getOptionalHeaderFieldAsJSON(
+                            in: response.headerFields,
+                            name: "X-Extra-Arguments",
+                            as: Components.Schemas.CodeError.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(
+                        in: response.headerFields
+                    )
+                    let body: Operations.createPetWithForm.Output.Created.Body
+                    if try contentType == nil
+                        || converter.isMatchingContentType(
+                            received: contentType,
+                            expectedRaw: "application/json"
+                        )
+                    {
+                        body = try converter.getResponseBodyAsJSON(
+                            Components.Schemas.Pet.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    } else {
+                        throw converter.makeUnexpectedContentTypeError(contentType: contentType)
+                    }
+                    return .created(.init(headers: headers, body: body))
+                case 400:
+                    let headers: Components.Responses.ErrorBadRequest.Headers = .init(
+                        X_Reason: try converter.getOptionalHeaderFieldAsText(
+                            in: response.headerFields,
+                            name: "X-Reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(
+                        in: response.headerFields
+                    )
+                    let body: Components.Responses.ErrorBadRequest.Body
+                    if try contentType == nil
+                        || converter.isMatchingContentType(
+                            received: contentType,
+                            expectedRaw: "application/json"
+                        )
+                    {
+                        body = try converter.getResponseBodyAsJSON(
+                            Components.Responses.ErrorBadRequest.Body.jsonPayload.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    } else {
+                        throw converter.makeUnexpectedContentTypeError(contentType: contentType)
+                    }
+                    return .badRequest(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
+    
     /// - Remark: HTTP `GET /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
     public func getStats(_ input: Operations.getStats.Input) async throws

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -1050,6 +1050,116 @@ public enum Operations {
             case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
         }
     }
+    
+    /// Create a pet using a url form
+    ///
+    /// - Remark: HTTP `POST /pets`.
+    /// - Remark: Generated from `#/paths//pets/post(createPet)`.
+    public enum createPetWithForm {
+        public static let id: String = "createPetWithForm"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                /// Creates a new `Path`.
+                public init() {}
+            }
+            public var path: Operations.createPetWithForm.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.createPetWithForm.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                public var X_Extra_Arguments: Components.Schemas.CodeError?
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - X_Extra_Arguments:
+                public init(X_Extra_Arguments: Components.Schemas.CodeError? = nil) {
+                    self.X_Extra_Arguments = X_Extra_Arguments
+                }
+            }
+            public var headers: Operations.createPetWithForm.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.createPetWithForm.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {
+                case urlEncodedForm(Components.Schemas.CreatePetRequest)
+            }
+            public var body: Operations.createPetWithForm.Input.Body
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.createPetWithForm.Input.Path = .init(),
+                query: Operations.createPetWithForm.Input.Query = .init(),
+                headers: Operations.createPetWithForm.Input.Headers = .init(),
+                cookies: Operations.createPetWithForm.Input.Cookies = .init(),
+                body: Operations.createPetWithForm.Input.Body
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Created: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    public var X_Extra_Arguments: Components.Schemas.CodeError?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - X_Extra_Arguments:
+                    public init(X_Extra_Arguments: Components.Schemas.CodeError? = nil) {
+                        self.X_Extra_Arguments = X_Extra_Arguments
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createPetWithForm.Output.Created.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.Pet)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createPetWithForm.Output.Created.Body
+                /// Creates a new `Created`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createPetWithForm.Output.Created.Headers = .init(),
+                    body: Operations.createPetWithForm.Output.Created.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// Successfully created pet
+            ///
+            /// - Remark: Generated from `#/paths//pets/post(createPet)/responses/201`.
+            ///
+            /// HTTP response code: `201 created`.
+            case created(Operations.createPetWithForm.Output.Created)
+            /// Bad request
+            ///
+            /// - Remark: Generated from `#/paths//pets/post(createPet)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Components.Responses.ErrorBadRequest)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
     /// - Remark: HTTP `GET /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
     public enum getStats {

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -20,6 +20,12 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `POST /pets`.
     /// - Remark: Generated from `#/paths//pets/post(createPet)`.
     func createPet(_ input: Operations.createPet.Input) async throws -> Operations.createPet.Output
+    /// Create a pet using a url form
+    ///
+    /// - Remark: HTTP `POST /pets/create`.
+    /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)`.
+    func createPetWithForm(_ input: Operations.createPetWithForm.Input) async throws
+        -> Operations.createPetWithForm.Output
     /// - Remark: HTTP `GET /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
     func getStats(_ input: Operations.getStats.Input) async throws -> Operations.getStats.Output
@@ -1050,11 +1056,10 @@ public enum Operations {
             case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
         }
     }
-    
     /// Create a pet using a url form
     ///
-    /// - Remark: HTTP `POST /pets`.
-    /// - Remark: Generated from `#/paths//pets/post(createPet)`.
+    /// - Remark: HTTP `POST /pets/create`.
+    /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)`.
     public enum createPetWithForm {
         public static let id: String = "createPetWithForm"
         public struct Input: Sendable, Equatable, Hashable {
@@ -1085,7 +1090,7 @@ public enum Operations {
             }
             public var cookies: Operations.createPetWithForm.Input.Cookies
             @frozen public enum Body: Sendable, Equatable, Hashable {
-                case urlEncodedForm(Components.Schemas.CreatePetRequest)
+                case form(Components.Schemas.CreatePetRequest)
             }
             public var body: Operations.createPetWithForm.Input.Body
             /// Creates a new `Input`.
@@ -1144,13 +1149,13 @@ public enum Operations {
             }
             /// Successfully created pet
             ///
-            /// - Remark: Generated from `#/paths//pets/post(createPet)/responses/201`.
+            /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)/responses/201`.
             ///
             /// HTTP response code: `201 created`.
             case created(Operations.createPetWithForm.Output.Created)
             /// Bad request
             ///
-            /// - Remark: Generated from `#/paths//pets/post(createPet)/responses/400`.
+            /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)/responses/400`.
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Components.Responses.ErrorBadRequest)

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Client.swift
@@ -247,6 +247,104 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// Create a pet using a url form
+    ///
+    /// - Remark: HTTP `POST /pets/create`.
+    /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)`.
+    public func createPetWithForm(_ input: Operations.createPetWithForm.Input) async throws
+        -> Operations.createPetWithForm.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.createPetWithForm.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/pets/create",
+                    parameters: []
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .post)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsJSON(
+                    in: &request.headerFields,
+                    name: "X-Extra-Arguments",
+                    value: input.headers.X_Extra_Arguments
+                )
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                switch input.body {
+                case let .form(value):
+                    request.body = try converter.setRequiredRequestBodyAsURLEncodedForm(
+                        value,
+                        headerFields: &request.headerFields,
+                        contentType: "application/x-www-form-urlencoded"
+                    )
+                }
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 201:
+                    let headers: Operations.createPetWithForm.Output.Created.Headers = .init(
+                        X_Extra_Arguments: try converter.getOptionalHeaderFieldAsJSON(
+                            in: response.headerFields,
+                            name: "X-Extra-Arguments",
+                            as: Components.Schemas.CodeError.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(
+                        in: response.headerFields
+                    )
+                    let body: Operations.createPetWithForm.Output.Created.Body
+                    if try contentType == nil
+                        || converter.isMatchingContentType(
+                            received: contentType,
+                            expectedRaw: "application/json"
+                        )
+                    {
+                        body = try converter.getResponseBodyAsJSON(
+                            Components.Schemas.Pet.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    } else {
+                        throw converter.makeUnexpectedContentTypeError(contentType: contentType)
+                    }
+                    return .created(.init(headers: headers, body: body))
+                case 400:
+                    let headers: Components.Responses.ErrorBadRequest.Headers = .init(
+                        X_Reason: try converter.getOptionalHeaderFieldAsText(
+                            in: response.headerFields,
+                            name: "X-Reason",
+                            as: Swift.String.self
+                        )
+                    )
+                    let contentType = converter.extractContentTypeIfPresent(
+                        in: response.headerFields
+                    )
+                    let body: Components.Responses.ErrorBadRequest.Body
+                    if try contentType == nil
+                        || converter.isMatchingContentType(
+                            received: contentType,
+                            expectedRaw: "application/json"
+                        )
+                    {
+                        body = try converter.getResponseBodyAsJSON(
+                            Components.Responses.ErrorBadRequest.Body.jsonPayload.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    } else {
+                        throw converter.makeUnexpectedContentTypeError(contentType: contentType)
+                    }
+                    return .badRequest(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
     /// - Remark: HTTP `GET /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
     public func getStats(_ input: Operations.getStats.Input) async throws

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
@@ -20,6 +20,12 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `POST /pets`.
     /// - Remark: Generated from `#/paths//pets/post(createPet)`.
     func createPet(_ input: Operations.createPet.Input) async throws -> Operations.createPet.Output
+    /// Create a pet using a url form
+    ///
+    /// - Remark: HTTP `POST /pets/create`.
+    /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)`.
+    func createPetWithForm(_ input: Operations.createPetWithForm.Input) async throws
+        -> Operations.createPetWithForm.Output
     /// - Remark: HTTP `GET /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
     func getStats(_ input: Operations.getStats.Input) async throws -> Operations.getStats.Output
@@ -1041,6 +1047,115 @@ public enum Operations {
             /// Bad request
             ///
             /// - Remark: Generated from `#/paths//pets/post(createPet)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Components.Responses.ErrorBadRequest)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// Create a pet using a url form
+    ///
+    /// - Remark: HTTP `POST /pets/create`.
+    /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)`.
+    public enum createPetWithForm {
+        public static let id: String = "createPetWithForm"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                /// Creates a new `Path`.
+                public init() {}
+            }
+            public var path: Operations.createPetWithForm.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.createPetWithForm.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                public var X_Extra_Arguments: Components.Schemas.CodeError?
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - X_Extra_Arguments:
+                public init(X_Extra_Arguments: Components.Schemas.CodeError? = nil) {
+                    self.X_Extra_Arguments = X_Extra_Arguments
+                }
+            }
+            public var headers: Operations.createPetWithForm.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.createPetWithForm.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {
+                case form(Components.Schemas.CreatePetRequest)
+            }
+            public var body: Operations.createPetWithForm.Input.Body
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.createPetWithForm.Input.Path = .init(),
+                query: Operations.createPetWithForm.Input.Query = .init(),
+                headers: Operations.createPetWithForm.Input.Headers = .init(),
+                cookies: Operations.createPetWithForm.Input.Cookies = .init(),
+                body: Operations.createPetWithForm.Input.Body
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Created: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    public var X_Extra_Arguments: Components.Schemas.CodeError?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - X_Extra_Arguments:
+                    public init(X_Extra_Arguments: Components.Schemas.CodeError? = nil) {
+                        self.X_Extra_Arguments = X_Extra_Arguments
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createPetWithForm.Output.Created.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.Pet)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createPetWithForm.Output.Created.Body
+                /// Creates a new `Created`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createPetWithForm.Output.Created.Headers = .init(),
+                    body: Operations.createPetWithForm.Output.Created.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// Successfully created pet
+            ///
+            /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)/responses/201`.
+            ///
+            /// HTTP response code: `201 created`.
+            case created(Operations.createPetWithForm.Output.Created)
+            /// Bad request
+            ///
+            /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)/responses/400`.
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Components.Responses.ErrorBadRequest)

--- a/Tests/PetstoreConsumerTests/TestClient.swift
+++ b/Tests/PetstoreConsumerTests/TestClient.swift
@@ -15,7 +15,6 @@ import OpenAPIRuntime
 import Foundation
 
 struct TestClient: APIProtocol {
-
     typealias ListPetsSignature = @Sendable (Operations.listPets.Input) async throws -> Operations.listPets.Output
     var listPetsBlock: ListPetsSignature?
     func listPets(
@@ -33,6 +32,17 @@ struct TestClient: APIProtocol {
         _ input: Operations.createPet.Input
     ) async throws -> Operations.createPet.Output {
         guard let block = createPetBlock else {
+            throw UnspecifiedBlockError()
+        }
+        return try await block(input)
+    }
+    
+    typealias CreatePetWithFormSignature = @Sendable (Operations.createPetWithForm.Input) async throws -> Operations.createPetWithForm.Output
+    var createPetWithFormBlock: CreatePetWithFormSignature?
+    func createPetWithForm(
+        _ input: Operations.createPetWithForm.Input
+    ) async throws -> Operations.createPetWithForm.Output {
+        guard let block = createPetWithFormBlock else {
             throw UnspecifiedBlockError()
         }
         return try await block(input)

--- a/Tests/PetstoreConsumerTestsFFMultipleContentTypes/TestClient.swift
+++ b/Tests/PetstoreConsumerTestsFFMultipleContentTypes/TestClient.swift
@@ -37,6 +37,18 @@ struct TestClient: APIProtocol {
         }
         return try await block(input)
     }
+    
+    
+    typealias CreatePetWithFormSignature = @Sendable (Operations.createPetWithForm.Input) async throws -> Operations.createPetWithForm.Output
+    var createPetWithFormBlock: CreatePetWithFormSignature?
+    func createPetWithForm(
+        _ input: Operations.createPetWithForm.Input
+    ) async throws -> Operations.createPetWithForm.Output {
+        guard let block = createPetWithFormBlock else {
+            throw UnspecifiedBlockError()
+        }
+        return try await block(input)
+    }
 
     typealias GetStatsSignature = @Sendable (Operations.getStats.Input) async throws -> Operations.getStats.Output
     var getStatsBlock: GetStatsSignature?


### PR DESCRIPTION
### Motivation

Opening this as a preliminary approach to adding support for url encoded forms #182.

I notice that we're probably going to want to take a different approach to this implementation by first building out a custom URLFormEncoder (#192), so this might be mostly redundant at this point, but wanted to at least document this here as my first contribution to the project.

It may be that work on #192 can be merged into the `Converter` methods in the associated [runtime changes](https://github.com/apple/swift-openapi-runtime/pull/39) 


### Modifications

Add a new `urlEncodedForm` content type to support type safe x-www-form-urlencoded requests.

### Result

Url form requests will take a Codable object type, rather than a raw Data input

### Test Plan

- Updated and passed reference tests with example url form request
- Not yet added additional unit tests as this PR is only intended as a draft for feedback
