### PR TITLE
Fix warning in generated server code

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
@@ -98,7 +98,7 @@ struct ServerFileTranslator: FileTranslator {
             }
         let serverMethodDecls = serverMethodDeclPairs.map(\.functionDecl)
 
-        // To avoid an used variable warning, we add the server variable declaration
+        // To avoid an unused variable warning, we add the server variable declaration
         // and server method register calls to the body of the register handler declaration
         // only when there is at least one registration call.
         if !serverMethodDeclPairs.isEmpty {

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1223,6 +1223,23 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testServerRegisterHandlers_noOperation() throws {
+        try self.assertServerRegisterHandlers(
+            """
+            {}
+            """,
+            """
+            public func registerHandlers(
+                on transport: any ServerTransport,
+                serverURL: URL = .defaultOpenAPIServerURL,
+                configuration: Configuration = .init(),
+                middlewares: [any ServerMiddleware] = []
+            ) throws {
+            }
+            """
+        )
+    }
+
     func testPathWithPathItemReference() throws {
         XCTAssertThrowsError(
             try self.assertPathsTranslation(

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1185,6 +1185,44 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testServerRegisterHandlers_oneOperation() throws {
+        try self.assertServerRegisterHandlers(
+            """
+            /health:
+              get:
+                operationId: getHealth
+                responses:
+                  '200':
+                    description: A success response with a greeting.
+                    content:
+                      text/plain:
+                        schema:
+                          type: string
+            """,
+            """
+            public func registerHandlers(
+                on transport: any ServerTransport,
+                serverURL: URL = .defaultOpenAPIServerURL,
+                configuration: Configuration = .init(),
+                middlewares: [any ServerMiddleware] = []
+            ) throws {
+                let server = UniversalServer(
+                    serverURL: serverURL,
+                    handler: self,
+                    configuration: configuration,
+                    middlewares: middlewares
+                )
+                try transport.register(
+                    { try await server.getHealth(request: $0, metadata: $1) },
+                    method: .get,
+                    path: server.apiPathComponentsWithServerPrefix(["health"]),
+                    queryItemNames: []
+                )
+            }
+            """
+        )
+    }
+
     func testPathWithPathItemReference() throws {
         XCTAssertThrowsError(
             try self.assertPathsTranslation(
@@ -1594,6 +1632,23 @@ extension SnippetBasedReferenceTests {
         let paths = try YAMLDecoder().decode(OpenAPI.PathItem.Map.self, from: pathsYAML)
         let translation = try translator.translateAPIProtocol(paths)
         try XCTAssertSwiftEquivalent(translation, expectedSwift, file: file, line: line)
+    }
+
+    func assertServerRegisterHandlers(
+        _ pathsYAML: String,
+        _ expectedSwift: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let (_, _, translator) = try makeTranslators()
+        let paths = try YAMLDecoder().decode(OpenAPI.PathItem.Map.self, from: pathsYAML)
+        let operations = try OperationDescription.all(
+            from: paths,
+            in: .noComponents,
+            asSwiftSafeName: translator.swiftSafeName
+        )
+        let (registerHandlersDecl, _) = try translator.translateRegisterHandlers(operations)
+        try XCTAssertSwiftEquivalent(registerHandlersDecl, expectedSwift, file: file, line: line)
     }
 }
 


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/190.
 
### Modifications

We fix the issue buy only generating this initializer if there's at least one operation. Otherwise keep the method empty.

### Result

The warning is fixed since the `server` variable declaration is not added to the `registerHandlers` body when it's not used. 

### Test Plan

We add a test in `SnippetBasedReferenceTests.swift` called `testServerRegisterHandlers_noOperations` asserting the `server` variable delcaration is not added to the `registerHandlers` body. 