### PR TITLE
Additional 'case' blocks cannot appear after the 'default' block of a 'switch'

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
@@ -123,7 +123,6 @@ extension ClientFileTranslator {
     ) throws -> Expression {
         var cases: [SwitchCaseDescription] =
             try description
-            .operation
             .responseOutcomes
             .map { outcome in
                 try translateResponseOutcomeInClient(

--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -317,4 +317,17 @@ extension OperationDescription {
     var containsDefaultResponse: Bool {
         operation.responses.contains(key: .default)
     }
+
+    /// Returns the operation.responseOutcomes while ensuring if a `.default`
+    /// responseOutcome is present, then it is the last element in the returned array
+    var responseOutcomes: [OpenAPI.Operation.ResponseOutcome] {
+        var outcomes = operation.responseOutcomes
+        // if .default is present and not already last
+        if let index = outcomes.firstIndex(where: { $0.status == .default }), index != (outcomes.count - 1) {
+            //then we move it to be last
+            let defaultResp = outcomes.remove(at: index)
+            outcomes.append(defaultResp)
+        }
+        return outcomes
+    }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/acceptHeaderContentTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/acceptHeaderContentTypes.swift
@@ -27,7 +27,6 @@ extension FileTranslator {
     ) throws -> [ContentType] {
         let contentTypes =
             try description
-            .operation
             .responseOutcomes
             .flatMap { outcome in
                 let response = try outcome.response.resolve(in: components)

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
@@ -119,7 +119,6 @@ extension ServerFileTranslator {
     func translateServerSerializer(_ description: OperationDescription) throws -> Expression {
         var cases: [SwitchCaseDescription] =
             try description
-            .operation
             .responseOutcomes
             .map { outcome in
                 try translateResponseOutcomeInServer(

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
@@ -123,7 +123,6 @@ extension TypesFileTranslator {
 
         let documentedOutcomes =
             try description
-            .operation
             .responseOutcomes
             .map { outcome in
                 try translateResponseOutcomeInTypes(


### PR DESCRIPTION
### Motivation

BUG: https://github.com/apple/swift-openapi-generator/issues/211
This results in invalid Swift code that is not possible to compile.

### Modifications

As described by @czechboy0 in the thread linked above, a new computed property `responseOutcomes` on `OperationDescription` was added such that if a `default` is present, it is moved to the end. Other than `default`, the order is preserved.

### Result

The generated code produced is correct swift code allowing it to build.

### Test Plan

I did a manual test using the openapi.yaml that resulted in the original problem that I highlighted in the issue linked above.
