### PR TITLE
Remove redundant Equatable conformances in code generation

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
+++ b/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
@@ -25,7 +25,7 @@
 /// enabled unconditionally on main and the feature flag removed, and version
 /// 0.2 is tagged. (This is for pre-1.0 versioning, would be 1.0 and 2.0 after
 /// 1.0 is released.)
-public enum FeatureFlag: String, Hashable, Equatable, Codable, CaseIterable {
+public enum FeatureFlag: String, Hashable, Codable, CaseIterable {
 
     /// Multiple request and response body content types.
     ///

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -127,7 +127,6 @@ enum Constants {
         /// The types that every struct conforms to.
         static let conformances: [String] = [
             "Codable",
-            "Equatable",
             "Hashable",
             "Sendable",
         ]
@@ -154,7 +153,6 @@ enum Constants {
         /// The types that every enum conforms to.
         static let conformances: [String] = [
             "Codable",
-            "Equatable",
             "Hashable",
             "Sendable",
             "_AutoLosslessStringConvertible",
@@ -208,7 +206,6 @@ enum Constants {
             /// The types that the body conforms to.
             static let conformances: [String] = [
                 "Sendable",
-                "Equatable",
                 "Hashable",
             ]
         }
@@ -225,7 +222,6 @@ enum Constants {
             /// The types that the Input type conforms to.
             static let conformances: [String] = [
                 "Sendable",
-                "Equatable",
                 "Hashable",
             ]
         }
@@ -239,7 +235,6 @@ enum Constants {
             /// The types that the Output type conforms to.
             static let conformances: [String] = [
                 "Sendable",
-                "Equatable",
                 "Hashable",
             ]
 
@@ -249,7 +244,6 @@ enum Constants {
                 /// The types that the Payload type conforms to.
                 static let conformances: [String] = [
                     "Sendable",
-                    "Equatable",
                     "Hashable",
                 ]
 
@@ -272,7 +266,6 @@ enum Constants {
                     /// The types that the Headers type conforms to.
                     static let conformances: [String] = [
                         "Sendable",
-                        "Equatable",
                         "Hashable",
                     ]
                 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/CodingStrategy.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/CodingStrategy.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Describes the underlying coding strategy.
-enum CodingStrategy: String, Equatable, Hashable, Sendable {
+enum CodingStrategy: String, Hashable, Sendable {
 
     /// A strategy using JSONEncoder/JSONDecoder.
     case json

--- a/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
@@ -146,7 +146,7 @@ class FileBasedReferenceTests: XCTestCase {
         }
     }
 
-    struct ReferenceProject: Hashable, Equatable {
+    struct ReferenceProject: Hashable {
         var name: ReferenceProjectName
         var customDirectoryName: String? = nil
 

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -57,7 +57,7 @@ public enum Components {
         /// Pet metadata
         ///
         /// - Remark: Generated from `#/components/schemas/Pet`.
-        public struct Pet: Codable, Equatable, Hashable, Sendable {
+        public struct Pet: Codable, Hashable, Sendable {
             /// Pet id
             ///
             /// - Remark: Generated from `#/components/schemas/Pet/id`.
@@ -99,7 +99,7 @@ public enum Components {
         ///
         /// - Remark: Generated from `#/components/schemas/PetKind`.
         @frozen
-        public enum PetKind: RawRepresentable, Codable, Equatable, Hashable, Sendable,
+        public enum PetKind: RawRepresentable, Codable, Hashable, Sendable,
             _AutoLosslessStringConvertible, CaseIterable
         {
             case cat
@@ -137,7 +137,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/CreatePetRequest`.
-        public struct CreatePetRequest: Codable, Equatable, Hashable, Sendable {
+        public struct CreatePetRequest: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/CreatePetRequest/name`.
             public var name: Swift.String
             /// - Remark: Generated from `#/components/schemas/CreatePetRequest/kind`.
@@ -168,7 +168,7 @@ public enum Components {
         /// - Remark: Generated from `#/components/schemas/Pets`.
         public typealias Pets = [Components.Schemas.Pet]
         /// - Remark: Generated from `#/components/schemas/Error`.
-        public struct _Error: Codable, Equatable, Hashable, Sendable {
+        public struct _Error: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/Error/code`.
             public var code: Swift.Int32
             /// - Remark: Generated from `#/components/schemas/Error/me$sage`.
@@ -176,7 +176,7 @@ public enum Components {
             /// Extra information about the error.
             ///
             /// - Remark: Generated from `#/components/schemas/Error/extraInfo`.
-            public struct extraInfoPayload: Codable, Equatable, Hashable, Sendable {
+            public struct extraInfoPayload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/Error/extraInfo/value1`.
                 public var value1: Components.Schemas.ExtraInfo
                 /// Creates a new `extraInfoPayload`.
@@ -223,10 +223,10 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/PetFeeding`.
-        public struct PetFeeding: Codable, Equatable, Hashable, Sendable {
+        public struct PetFeeding: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/PetFeeding/schedule`.
             @frozen
-            public enum schedulePayload: RawRepresentable, Codable, Equatable, Hashable, Sendable,
+            public enum schedulePayload: RawRepresentable, Codable, Hashable, Sendable,
                 _AutoLosslessStringConvertible, CaseIterable
             {
                 case hourly
@@ -268,7 +268,7 @@ public enum Components {
         /// - Remark: Generated from `#/components/schemas/ExtraInfo`.
         public typealias ExtraInfo = Swift.String
         /// - Remark: Generated from `#/components/schemas/NoAdditionalProperties`.
-        public struct NoAdditionalProperties: Codable, Equatable, Hashable, Sendable {
+        public struct NoAdditionalProperties: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/NoAdditionalProperties/foo`.
             public var foo: Swift.String?
             /// Creates a new `NoAdditionalProperties`.
@@ -284,7 +284,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/AnyAdditionalProperties`.
-        public struct AnyAdditionalProperties: Codable, Equatable, Hashable, Sendable {
+        public struct AnyAdditionalProperties: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/AnyAdditionalProperties/foo`.
             public var foo: Swift.String?
             /// A container of undocumented properties.
@@ -314,7 +314,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/TypedAdditionalProperties`.
-        public struct TypedAdditionalProperties: Codable, Equatable, Hashable, Sendable {
+        public struct TypedAdditionalProperties: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/TypedAdditionalProperties/foo`.
             public var foo: Swift.String?
             /// A container of undocumented properties.
@@ -344,7 +344,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/CodeError`.
-        public struct CodeError: Codable, Equatable, Hashable, Sendable {
+        public struct CodeError: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/CodeError/code`.
             public var code: Swift.Int
             /// Creates a new `CodeError`.
@@ -355,9 +355,9 @@ public enum Components {
             public enum CodingKeys: String, CodingKey { case code }
         }
         /// - Remark: Generated from `#/components/schemas/AllOfObjects`.
-        public struct AllOfObjects: Codable, Equatable, Hashable, Sendable {
+        public struct AllOfObjects: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1`.
-            public struct Value1Payload: Codable, Equatable, Hashable, Sendable {
+            public struct Value1Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1/message`.
                 public var message: Swift.String
                 /// Creates a new `Value1Payload`.
@@ -393,9 +393,9 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/AnyOfObjects`.
-        public struct AnyOfObjects: Codable, Equatable, Hashable, Sendable {
+        public struct AnyOfObjects: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1`.
-            public struct Value1Payload: Codable, Equatable, Hashable, Sendable {
+            public struct Value1Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1/message`.
                 public var message: Swift.String
                 /// Creates a new `Value1Payload`.
@@ -436,7 +436,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/OneOfAny`.
-        @frozen public enum OneOfAny: Codable, Equatable, Hashable, Sendable {
+        @frozen public enum OneOfAny: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/OneOfAny/case1`.
             case case1(Swift.String)
             /// - Remark: Generated from `#/components/schemas/OneOfAny/case2`.
@@ -444,7 +444,7 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/OneOfAny/case3`.
             case CodeError(Components.Schemas.CodeError)
             /// - Remark: Generated from `#/components/schemas/OneOfAny/case4`.
-            public struct Case4Payload: Codable, Equatable, Hashable, Sendable {
+            public struct Case4Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/OneOfAny/case4/message`.
                 public var message: Swift.String
                 /// Creates a new `Case4Payload`.
@@ -490,7 +490,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/PetExercise`.
-        public struct PetExercise: Codable, Equatable, Hashable, Sendable {
+        public struct PetExercise: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/PetExercise/kind`.
             public var kind: Swift.String
             /// Creates a new `PetExercise`.
@@ -501,7 +501,7 @@ public enum Components {
             public enum CodingKeys: String, CodingKey { case kind }
         }
         /// - Remark: Generated from `#/components/schemas/Walk`.
-        public struct Walk: Codable, Equatable, Hashable, Sendable {
+        public struct Walk: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/Walk/kind`.
             public var kind: Swift.String
             /// - Remark: Generated from `#/components/schemas/Walk/length`.
@@ -521,11 +521,11 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/MessagedExercise`.
-        public struct MessagedExercise: Codable, Equatable, Hashable, Sendable {
+        public struct MessagedExercise: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/MessagedExercise/value1`.
             public var value1: Components.Schemas.PetExercise
             /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2`.
-            public struct Value2Payload: Codable, Equatable, Hashable, Sendable {
+            public struct Value2Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2/message`.
                 public var message: Swift.String
                 /// Creates a new `Value2Payload`.
@@ -559,7 +559,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator`.
-        @frozen public enum OneOfObjectsWithDiscriminator: Codable, Equatable, Hashable, Sendable {
+        @frozen public enum OneOfObjectsWithDiscriminator: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/case1`.
             case Walk(Components.Schemas.Walk)
             /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/case2`.
@@ -588,8 +588,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/DeprecatedObject`.
-        @available(*, deprecated)
-        public struct DeprecatedObject: Codable, Equatable, Hashable, Sendable {
+        @available(*, deprecated) public struct DeprecatedObject: Codable, Hashable, Sendable {
             /// Creates a new `DeprecatedObject`.
             public init() {}
             public init(from decoder: any Decoder) throws {
@@ -597,7 +596,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/ObjectWithDeprecatedProperty`.
-        public struct ObjectWithDeprecatedProperty: Codable, Equatable, Hashable, Sendable {
+        public struct ObjectWithDeprecatedProperty: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/ObjectWithDeprecatedProperty/message`.
             @available(*, deprecated) public var message: Swift.String?
             /// Creates a new `ObjectWithDeprecatedProperty`.
@@ -608,7 +607,7 @@ public enum Components {
             public enum CodingKeys: String, CodingKey { case message }
         }
         /// - Remark: Generated from `#/components/schemas/PetStats`.
-        public struct PetStats: Codable, Equatable, Hashable, Sendable {
+        public struct PetStats: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/PetStats/count`.
             public var count: Swift.Int
             /// Creates a new `PetStats`.
@@ -637,9 +636,9 @@ public enum Components {
     /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
     public enum RequestBodies {
         /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest`.
-        @frozen public enum UpdatePetRequest: Sendable, Equatable, Hashable {
+        @frozen public enum UpdatePetRequest: Sendable, Hashable {
             /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json`.
-            public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+            public struct jsonPayload: Codable, Hashable, Sendable {
                 /// Pet name
                 ///
                 /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json/name`.
@@ -675,9 +674,9 @@ public enum Components {
     }
     /// Types generated from the `#/components/responses` section of the OpenAPI document.
     public enum Responses {
-        public struct ErrorBadRequest: Sendable, Equatable, Hashable {
+        public struct ErrorBadRequest: Sendable, Hashable {
             /// - Remark: Generated from `#/components/responses/ErrorBadRequest/headers`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// A description here.
                 ///
                 /// - Remark: Generated from `#/components/responses/ErrorBadRequest/headers/X-Reason`.
@@ -691,9 +690,9 @@ public enum Components {
             /// Received HTTP response headers
             public var headers: Components.Responses.ErrorBadRequest.Headers
             /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Hashable {
                 /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/json`.
-                public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                public struct jsonPayload: Codable, Hashable, Sendable {
                     /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/json/code`.
                     public var code: Swift.Int
                     /// Creates a new `jsonPayload`.
@@ -741,23 +740,23 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/get(listPets)`.
     public enum listPets {
         public static let id: String = "listPets"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/GET/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.listPets.Input.Path
             /// - Remark: Generated from `#/paths/pets/GET/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// How many items to return at one time (max 100)
                 ///
                 /// - Remark: Generated from `#/paths/pets/GET/query/limit`.
                 public var limit: Swift.Int32?
                 /// - Remark: Generated from `#/paths/pets/GET/query/habitat`.
                 @frozen
-                public enum habitatPayload: RawRepresentable, Codable, Equatable, Hashable,
-                    Sendable, _AutoLosslessStringConvertible, CaseIterable
+                public enum habitatPayload: RawRepresentable, Codable, Hashable, Sendable,
+                    _AutoLosslessStringConvertible, CaseIterable
                 {
                     case water
                     case land
@@ -789,8 +788,8 @@ public enum Operations {
                 public var habitat: Operations.listPets.Input.Query.habitatPayload?
                 /// - Remark: Generated from `#/paths/pets/GET/query/feedsPayload`.
                 @frozen
-                public enum feedsPayloadPayload: RawRepresentable, Codable, Equatable, Hashable,
-                    Sendable, _AutoLosslessStringConvertible, CaseIterable
+                public enum feedsPayloadPayload: RawRepresentable, Codable, Hashable, Sendable,
+                    _AutoLosslessStringConvertible, CaseIterable
                 {
                     case omnivore
                     case carnivore
@@ -847,7 +846,7 @@ public enum Operations {
             }
             public var query: Operations.listPets.Input.Query
             /// - Remark: Generated from `#/paths/pets/GET/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Request identifier
                 ///
                 /// - Remark: Generated from `#/paths/pets/GET/header/My-Request-UUID`.
@@ -862,13 +861,13 @@ public enum Operations {
             }
             public var headers: Operations.listPets.Input.Headers
             /// - Remark: Generated from `#/paths/pets/GET/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.listPets.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/GET/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            @frozen public enum Body: Sendable, Hashable {}
             public var body: Operations.listPets.Input.Body?
             /// Creates a new `Input`.
             ///
@@ -892,10 +891,10 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Ok: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/GET/responses/200/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Response identifier
                     ///
                     /// - Remark: Generated from `#/paths/pets/GET/responses/200/headers/My-Response-UUID`.
@@ -920,7 +919,7 @@ public enum Operations {
                 /// Received HTTP response headers
                 public var headers: Operations.listPets.Output.Ok.Headers
                 /// - Remark: Generated from `#/paths/pets/GET/responses/200/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/GET/responses/200/content/application\/json`.
                     case json(Components.Schemas.Pets)
                 }
@@ -945,16 +944,16 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.listPets.Output.Ok)
-            public struct Default: Sendable, Equatable, Hashable {
+            public struct Default: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/GET/responses/default/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.listPets.Output.Default.Headers
                 /// - Remark: Generated from `#/paths/pets/GET/responses/default/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/GET/responses/default/content/application\/json`.
                     case json(Components.Schemas._Error)
                 }
@@ -987,21 +986,21 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/post(createPet)`.
     public enum createPet {
         public static let id: String = "createPet"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/POST/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.createPet.Input.Path
             /// - Remark: Generated from `#/paths/pets/POST/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.createPet.Input.Query
             /// - Remark: Generated from `#/paths/pets/POST/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// A description here.
                 ///
                 /// - Remark: Generated from `#/paths/pets/POST/header/X-Extra-Arguments`.
@@ -1016,13 +1015,13 @@ public enum Operations {
             }
             public var headers: Operations.createPet.Input.Headers
             /// - Remark: Generated from `#/paths/pets/POST/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.createPet.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/POST/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/POST/requestBody/content/application\/json`.
                 case json(Components.Schemas.CreatePetRequest)
             }
@@ -1049,10 +1048,10 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Created: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Created: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/POST/responses/201/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// A description here.
                     ///
                     /// - Remark: Generated from `#/paths/pets/POST/responses/201/headers/X-Extra-Arguments`.
@@ -1068,7 +1067,7 @@ public enum Operations {
                 /// Received HTTP response headers
                 public var headers: Operations.createPet.Output.Created.Headers
                 /// - Remark: Generated from `#/paths/pets/POST/responses/201/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/POST/responses/201/content/application\/json`.
                     case json(Components.Schemas.Pet)
                 }
@@ -1109,33 +1108,33 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
     public enum getStats {
         public static let id: String = "getStats"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/stats/GET/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.getStats.Input.Path
             /// - Remark: Generated from `#/paths/pets/stats/GET/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.getStats.Input.Query
             /// - Remark: Generated from `#/paths/pets/stats/GET/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.getStats.Input.Headers
             /// - Remark: Generated from `#/paths/pets/stats/GET/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.getStats.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/stats/GET/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            @frozen public enum Body: Sendable, Hashable {}
             public var body: Operations.getStats.Input.Body?
             /// Creates a new `Input`.
             ///
@@ -1159,17 +1158,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Ok: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/stats/GET/responses/200/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.getStats.Output.Ok.Headers
                 /// - Remark: Generated from `#/paths/pets/stats/GET/responses/200/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/stats/GET/responses/200/content/application\/json`.
                     case json(Components.Schemas.PetStats)
                 }
@@ -1204,33 +1203,33 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/stats/post(postStats)`.
     public enum postStats {
         public static let id: String = "postStats"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/stats/POST/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.postStats.Input.Path
             /// - Remark: Generated from `#/paths/pets/stats/POST/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.postStats.Input.Query
             /// - Remark: Generated from `#/paths/pets/stats/POST/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.postStats.Input.Headers
             /// - Remark: Generated from `#/paths/pets/stats/POST/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.postStats.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/stats/POST/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/stats/POST/requestBody/content/application\/json`.
                 case json(Components.Schemas.PetStats)
             }
@@ -1257,17 +1256,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Accepted: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Accepted: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/stats/POST/responses/202/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.postStats.Output.Accepted.Headers
                 /// - Remark: Generated from `#/paths/pets/stats/POST/responses/202/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                @frozen public enum Body: Sendable, Hashable {}
                 /// Received HTTP response body
                 public var body: Operations.postStats.Output.Accepted.Body?
                 /// Creates a new `Accepted`.
@@ -1299,33 +1298,33 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
     public enum probe {
         public static let id: String = "probe"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/probe/POST/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.probe.Input.Path
             /// - Remark: Generated from `#/paths/probe/POST/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.probe.Input.Query
             /// - Remark: Generated from `#/paths/probe/POST/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.probe.Input.Headers
             /// - Remark: Generated from `#/paths/probe/POST/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.probe.Input.Cookies
             /// - Remark: Generated from `#/paths/probe/POST/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            @frozen public enum Body: Sendable, Hashable {}
             public var body: Operations.probe.Input.Body?
             /// Creates a new `Input`.
             ///
@@ -1349,17 +1348,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct NoContent: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct NoContent: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/probe/POST/responses/204/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.probe.Output.NoContent.Headers
                 /// - Remark: Generated from `#/paths/probe/POST/responses/204/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                @frozen public enum Body: Sendable, Hashable {}
                 /// Received HTTP response body
                 public var body: Operations.probe.Output.NoContent.Body?
                 /// Creates a new `NoContent`.
@@ -1393,9 +1392,9 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/{petId}/patch(updatePet)`.
     public enum updatePet {
         public static let id: String = "updatePet"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Id of the pet
                 ///
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/path/petId`.
@@ -1408,19 +1407,19 @@ public enum Operations {
             }
             public var path: Operations.updatePet.Input.Path
             /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.updatePet.Input.Query
             /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.updatePet.Input.Headers
             /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
@@ -1448,17 +1447,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct NoContent: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct NoContent: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/204/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.updatePet.Output.NoContent.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/204/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                @frozen public enum Body: Sendable, Hashable {}
                 /// Received HTTP response body
                 public var body: Operations.updatePet.Output.NoContent.Body?
                 /// Creates a new `NoContent`.
@@ -1480,18 +1479,18 @@ public enum Operations {
             ///
             /// HTTP response code: `204 noContent`.
             case noContent(Operations.updatePet.Output.NoContent)
-            public struct BadRequest: Sendable, Equatable, Hashable {
+            public struct BadRequest: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/400/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.updatePet.Output.BadRequest.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/400/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/400/content/json`.
-                    public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                    public struct jsonPayload: Codable, Hashable, Sendable {
                         /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/400/content/json/message`.
                         public var message: Swift.String
                         /// Creates a new `jsonPayload`.
@@ -1537,9 +1536,9 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/{petId}/avatar/put(uploadAvatarForPet)`.
     public enum uploadAvatarForPet {
         public static let id: String = "uploadAvatarForPet"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// The id of the pet to retrieve
                 ///
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/path/petId`.
@@ -1552,25 +1551,25 @@ public enum Operations {
             }
             public var path: Operations.uploadAvatarForPet.Input.Path
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.uploadAvatarForPet.Input.Query
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.uploadAvatarForPet.Input.Headers
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.uploadAvatarForPet.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/requestBody/content/application\/octet-stream`.
                 case binary(Foundation.Data)
             }
@@ -1597,17 +1596,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Ok: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/200/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.Ok.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/200/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/200/content/application\/octet-stream`.
                     case binary(Foundation.Data)
                 }
@@ -1632,16 +1631,16 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.uploadAvatarForPet.Output.Ok)
-            public struct PreconditionFailed: Sendable, Equatable, Hashable {
+            public struct PreconditionFailed: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/412/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.PreconditionFailed.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/412/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/412/content/application\/json`.
                     case json(Swift.String)
                 }
@@ -1667,16 +1666,16 @@ public enum Operations {
             ///
             /// HTTP response code: `412 preconditionFailed`.
             case preconditionFailed(Operations.uploadAvatarForPet.Output.PreconditionFailed)
-            public struct InternalServerError: Sendable, Equatable, Hashable {
+            public struct InternalServerError: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/500/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.InternalServerError.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/500/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/500/content/text\/plain`.
                     case text(Swift.String)
                 }

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
@@ -57,7 +57,7 @@ public enum Components {
         /// Pet metadata
         ///
         /// - Remark: Generated from `#/components/schemas/Pet`.
-        public struct Pet: Codable, Equatable, Hashable, Sendable {
+        public struct Pet: Codable, Hashable, Sendable {
             /// Pet id
             ///
             /// - Remark: Generated from `#/components/schemas/Pet/id`.
@@ -99,8 +99,8 @@ public enum Components {
         ///
         /// - Remark: Generated from `#/components/schemas/PetKind`.
         @frozen
-        public enum PetKind: String, Codable, Equatable, Hashable, Sendable,
-            _AutoLosslessStringConvertible, CaseIterable
+        public enum PetKind: String, Codable, Hashable, Sendable, _AutoLosslessStringConvertible,
+            CaseIterable
         {
             case cat = "cat"
             case dog = "dog"
@@ -110,7 +110,7 @@ public enum Components {
             case _public = "public"
         }
         /// - Remark: Generated from `#/components/schemas/CreatePetRequest`.
-        public struct CreatePetRequest: Codable, Equatable, Hashable, Sendable {
+        public struct CreatePetRequest: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/CreatePetRequest/name`.
             public var name: Swift.String
             /// - Remark: Generated from `#/components/schemas/CreatePetRequest/kind`.
@@ -141,7 +141,7 @@ public enum Components {
         /// - Remark: Generated from `#/components/schemas/Pets`.
         public typealias Pets = [Components.Schemas.Pet]
         /// - Remark: Generated from `#/components/schemas/Error`.
-        public struct _Error: Codable, Equatable, Hashable, Sendable {
+        public struct _Error: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/Error/code`.
             public var code: Swift.Int32
             /// - Remark: Generated from `#/components/schemas/Error/me$sage`.
@@ -149,7 +149,7 @@ public enum Components {
             /// Extra information about the error.
             ///
             /// - Remark: Generated from `#/components/schemas/Error/extraInfo`.
-            public struct extraInfoPayload: Codable, Equatable, Hashable, Sendable {
+            public struct extraInfoPayload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/Error/extraInfo/value1`.
                 public var value1: Components.Schemas.ExtraInfo
                 /// Creates a new `extraInfoPayload`.
@@ -196,10 +196,10 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/PetFeeding`.
-        public struct PetFeeding: Codable, Equatable, Hashable, Sendable {
+        public struct PetFeeding: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/PetFeeding/schedule`.
             @frozen
-            public enum schedulePayload: String, Codable, Equatable, Hashable, Sendable,
+            public enum schedulePayload: String, Codable, Hashable, Sendable,
                 _AutoLosslessStringConvertible, CaseIterable
             {
                 case hourly = "hourly"
@@ -222,7 +222,7 @@ public enum Components {
         /// - Remark: Generated from `#/components/schemas/ExtraInfo`.
         public typealias ExtraInfo = Swift.String
         /// - Remark: Generated from `#/components/schemas/NoAdditionalProperties`.
-        public struct NoAdditionalProperties: Codable, Equatable, Hashable, Sendable {
+        public struct NoAdditionalProperties: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/NoAdditionalProperties/foo`.
             public var foo: Swift.String?
             /// Creates a new `NoAdditionalProperties`.
@@ -238,7 +238,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/AnyAdditionalProperties`.
-        public struct AnyAdditionalProperties: Codable, Equatable, Hashable, Sendable {
+        public struct AnyAdditionalProperties: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/AnyAdditionalProperties/foo`.
             public var foo: Swift.String?
             /// A container of undocumented properties.
@@ -268,7 +268,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/TypedAdditionalProperties`.
-        public struct TypedAdditionalProperties: Codable, Equatable, Hashable, Sendable {
+        public struct TypedAdditionalProperties: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/TypedAdditionalProperties/foo`.
             public var foo: Swift.String?
             /// A container of undocumented properties.
@@ -298,7 +298,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/CodeError`.
-        public struct CodeError: Codable, Equatable, Hashable, Sendable {
+        public struct CodeError: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/CodeError/code`.
             public var code: Swift.Int
             /// Creates a new `CodeError`.
@@ -309,9 +309,9 @@ public enum Components {
             public enum CodingKeys: String, CodingKey { case code }
         }
         /// - Remark: Generated from `#/components/schemas/AllOfObjects`.
-        public struct AllOfObjects: Codable, Equatable, Hashable, Sendable {
+        public struct AllOfObjects: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1`.
-            public struct Value1Payload: Codable, Equatable, Hashable, Sendable {
+            public struct Value1Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1/message`.
                 public var message: Swift.String
                 /// Creates a new `Value1Payload`.
@@ -347,9 +347,9 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/AnyOfObjects`.
-        public struct AnyOfObjects: Codable, Equatable, Hashable, Sendable {
+        public struct AnyOfObjects: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1`.
-            public struct Value1Payload: Codable, Equatable, Hashable, Sendable {
+            public struct Value1Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1/message`.
                 public var message: Swift.String
                 /// Creates a new `Value1Payload`.
@@ -390,7 +390,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/OneOfAny`.
-        @frozen public enum OneOfAny: Codable, Equatable, Hashable, Sendable {
+        @frozen public enum OneOfAny: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/OneOfAny/case1`.
             case case1(Swift.String)
             /// - Remark: Generated from `#/components/schemas/OneOfAny/case2`.
@@ -398,7 +398,7 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/OneOfAny/case3`.
             case CodeError(Components.Schemas.CodeError)
             /// - Remark: Generated from `#/components/schemas/OneOfAny/case4`.
-            public struct Case4Payload: Codable, Equatable, Hashable, Sendable {
+            public struct Case4Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/OneOfAny/case4/message`.
                 public var message: Swift.String
                 /// Creates a new `Case4Payload`.
@@ -442,7 +442,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/PetExercise`.
-        public struct PetExercise: Codable, Equatable, Hashable, Sendable {
+        public struct PetExercise: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/PetExercise/kind`.
             public var kind: Swift.String
             /// Creates a new `PetExercise`.
@@ -453,7 +453,7 @@ public enum Components {
             public enum CodingKeys: String, CodingKey { case kind }
         }
         /// - Remark: Generated from `#/components/schemas/Walk`.
-        public struct Walk: Codable, Equatable, Hashable, Sendable {
+        public struct Walk: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/Walk/kind`.
             public var kind: Swift.String
             /// - Remark: Generated from `#/components/schemas/Walk/length`.
@@ -473,11 +473,11 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/MessagedExercise`.
-        public struct MessagedExercise: Codable, Equatable, Hashable, Sendable {
+        public struct MessagedExercise: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/MessagedExercise/value1`.
             public var value1: Components.Schemas.PetExercise
             /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2`.
-            public struct Value2Payload: Codable, Equatable, Hashable, Sendable {
+            public struct Value2Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2/message`.
                 public var message: Swift.String
                 /// Creates a new `Value2Payload`.
@@ -511,7 +511,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator`.
-        @frozen public enum OneOfObjectsWithDiscriminator: Codable, Equatable, Hashable, Sendable {
+        @frozen public enum OneOfObjectsWithDiscriminator: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/case1`.
             case Walk(Components.Schemas.Walk)
             /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/case2`.
@@ -538,8 +538,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/DeprecatedObject`.
-        @available(*, deprecated)
-        public struct DeprecatedObject: Codable, Equatable, Hashable, Sendable {
+        @available(*, deprecated) public struct DeprecatedObject: Codable, Hashable, Sendable {
             /// Creates a new `DeprecatedObject`.
             public init() {}
             public init(from decoder: any Decoder) throws {
@@ -547,7 +546,7 @@ public enum Components {
             }
         }
         /// - Remark: Generated from `#/components/schemas/ObjectWithDeprecatedProperty`.
-        public struct ObjectWithDeprecatedProperty: Codable, Equatable, Hashable, Sendable {
+        public struct ObjectWithDeprecatedProperty: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/ObjectWithDeprecatedProperty/message`.
             @available(*, deprecated) public var message: Swift.String?
             /// Creates a new `ObjectWithDeprecatedProperty`.
@@ -558,7 +557,7 @@ public enum Components {
             public enum CodingKeys: String, CodingKey { case message }
         }
         /// - Remark: Generated from `#/components/schemas/PetStats`.
-        public struct PetStats: Codable, Equatable, Hashable, Sendable {
+        public struct PetStats: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/PetStats/count`.
             public var count: Swift.Int
             /// Creates a new `PetStats`.
@@ -587,9 +586,9 @@ public enum Components {
     /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
     public enum RequestBodies {
         /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest`.
-        @frozen public enum UpdatePetRequest: Sendable, Equatable, Hashable {
+        @frozen public enum UpdatePetRequest: Sendable, Hashable {
             /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json`.
-            public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+            public struct jsonPayload: Codable, Hashable, Sendable {
                 /// Pet name
                 ///
                 /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json/name`.
@@ -625,9 +624,9 @@ public enum Components {
     }
     /// Types generated from the `#/components/responses` section of the OpenAPI document.
     public enum Responses {
-        public struct ErrorBadRequest: Sendable, Equatable, Hashable {
+        public struct ErrorBadRequest: Sendable, Hashable {
             /// - Remark: Generated from `#/components/responses/ErrorBadRequest/headers`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// A description here.
                 ///
                 /// - Remark: Generated from `#/components/responses/ErrorBadRequest/headers/X-Reason`.
@@ -643,9 +642,9 @@ public enum Components {
             /// Received HTTP response headers
             public var headers: Components.Responses.ErrorBadRequest.Headers
             /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Hashable {
                 /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/json`.
-                public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                public struct jsonPayload: Codable, Hashable, Sendable {
                     /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/json/code`.
                     public var code: Swift.Int
                     /// Creates a new `jsonPayload`.
@@ -693,22 +692,22 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/get(listPets)`.
     public enum listPets {
         public static let id: String = "listPets"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/GET/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.listPets.Input.Path
             /// - Remark: Generated from `#/paths/pets/GET/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// How many items to return at one time (max 100)
                 ///
                 /// - Remark: Generated from `#/paths/pets/GET/query/limit`.
                 public var limit: Swift.Int32?
                 /// - Remark: Generated from `#/paths/pets/GET/query/habitat`.
                 @frozen
-                public enum habitatPayload: String, Codable, Equatable, Hashable, Sendable,
+                public enum habitatPayload: String, Codable, Hashable, Sendable,
                     _AutoLosslessStringConvertible, CaseIterable
                 {
                     case water = "water"
@@ -720,7 +719,7 @@ public enum Operations {
                 public var habitat: Operations.listPets.Input.Query.habitatPayload?
                 /// - Remark: Generated from `#/paths/pets/GET/query/feedsPayload`.
                 @frozen
-                public enum feedsPayloadPayload: String, Codable, Equatable, Hashable, Sendable,
+                public enum feedsPayloadPayload: String, Codable, Hashable, Sendable,
                     _AutoLosslessStringConvertible, CaseIterable
                 {
                     case omnivore = "omnivore"
@@ -757,7 +756,7 @@ public enum Operations {
             }
             public var query: Operations.listPets.Input.Query
             /// - Remark: Generated from `#/paths/pets/GET/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Request identifier
                 ///
                 /// - Remark: Generated from `#/paths/pets/GET/header/My-Request-UUID`.
@@ -772,13 +771,13 @@ public enum Operations {
             }
             public var headers: Operations.listPets.Input.Headers
             /// - Remark: Generated from `#/paths/pets/GET/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.listPets.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/GET/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            @frozen public enum Body: Sendable, Hashable {}
             public var body: Operations.listPets.Input.Body?
             /// Creates a new `Input`.
             ///
@@ -802,10 +801,10 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Ok: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/GET/responses/200/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Response identifier
                     ///
                     /// - Remark: Generated from `#/paths/pets/GET/responses/200/headers/My-Response-UUID`.
@@ -830,7 +829,7 @@ public enum Operations {
                 /// Received HTTP response headers
                 public var headers: Operations.listPets.Output.Ok.Headers
                 /// - Remark: Generated from `#/paths/pets/GET/responses/200/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/GET/responses/200/content/application\/json`.
                     case json(Components.Schemas.Pets)
                 }
@@ -855,16 +854,16 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.listPets.Output.Ok)
-            public struct Default: Sendable, Equatable, Hashable {
+            public struct Default: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/GET/responses/default/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.listPets.Output.Default.Headers
                 /// - Remark: Generated from `#/paths/pets/GET/responses/default/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/GET/responses/default/content/application\/json`.
                     case json(Components.Schemas._Error)
                 }
@@ -897,21 +896,21 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/post(createPet)`.
     public enum createPet {
         public static let id: String = "createPet"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/POST/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.createPet.Input.Path
             /// - Remark: Generated from `#/paths/pets/POST/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.createPet.Input.Query
             /// - Remark: Generated from `#/paths/pets/POST/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// A description here.
                 ///
                 /// - Remark: Generated from `#/paths/pets/POST/header/X-Extra-Arguments`.
@@ -926,13 +925,13 @@ public enum Operations {
             }
             public var headers: Operations.createPet.Input.Headers
             /// - Remark: Generated from `#/paths/pets/POST/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.createPet.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/POST/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/POST/requestBody/content/application\/json`.
                 case json(Components.Schemas.CreatePetRequest)
             }
@@ -959,10 +958,10 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Created: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Created: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/POST/responses/201/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// A description here.
                     ///
                     /// - Remark: Generated from `#/paths/pets/POST/responses/201/headers/X-Extra-Arguments`.
@@ -978,7 +977,7 @@ public enum Operations {
                 /// Received HTTP response headers
                 public var headers: Operations.createPet.Output.Created.Headers
                 /// - Remark: Generated from `#/paths/pets/POST/responses/201/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/POST/responses/201/content/application\/json`.
                     case json(Components.Schemas.Pet)
                 }
@@ -1019,33 +1018,33 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
     public enum getStats {
         public static let id: String = "getStats"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/stats/GET/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.getStats.Input.Path
             /// - Remark: Generated from `#/paths/pets/stats/GET/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.getStats.Input.Query
             /// - Remark: Generated from `#/paths/pets/stats/GET/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.getStats.Input.Headers
             /// - Remark: Generated from `#/paths/pets/stats/GET/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.getStats.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/stats/GET/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            @frozen public enum Body: Sendable, Hashable {}
             public var body: Operations.getStats.Input.Body?
             /// Creates a new `Input`.
             ///
@@ -1069,17 +1068,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Ok: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/stats/GET/responses/200/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.getStats.Output.Ok.Headers
                 /// - Remark: Generated from `#/paths/pets/stats/GET/responses/200/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/stats/GET/responses/200/content/application\/json`.
                     case json(Components.Schemas.PetStats)
                     /// - Remark: Generated from `#/paths/pets/stats/GET/responses/200/content/text\/plain`.
@@ -1118,33 +1117,33 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/stats/post(postStats)`.
     public enum postStats {
         public static let id: String = "postStats"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/stats/POST/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.postStats.Input.Path
             /// - Remark: Generated from `#/paths/pets/stats/POST/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.postStats.Input.Query
             /// - Remark: Generated from `#/paths/pets/stats/POST/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.postStats.Input.Headers
             /// - Remark: Generated from `#/paths/pets/stats/POST/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.postStats.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/stats/POST/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/stats/POST/requestBody/content/application\/json`.
                 case json(Components.Schemas.PetStats)
                 /// - Remark: Generated from `#/paths/pets/stats/POST/requestBody/content/text\/plain`.
@@ -1175,17 +1174,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Accepted: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Accepted: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/stats/POST/responses/202/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.postStats.Output.Accepted.Headers
                 /// - Remark: Generated from `#/paths/pets/stats/POST/responses/202/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                @frozen public enum Body: Sendable, Hashable {}
                 /// Received HTTP response body
                 public var body: Operations.postStats.Output.Accepted.Body?
                 /// Creates a new `Accepted`.
@@ -1217,33 +1216,33 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
     public enum probe {
         public static let id: String = "probe"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/probe/POST/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Creates a new `Path`.
                 public init() {}
             }
             public var path: Operations.probe.Input.Path
             /// - Remark: Generated from `#/paths/probe/POST/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.probe.Input.Query
             /// - Remark: Generated from `#/paths/probe/POST/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.probe.Input.Headers
             /// - Remark: Generated from `#/paths/probe/POST/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.probe.Input.Cookies
             /// - Remark: Generated from `#/paths/probe/POST/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            @frozen public enum Body: Sendable, Hashable {}
             public var body: Operations.probe.Input.Body?
             /// Creates a new `Input`.
             ///
@@ -1267,17 +1266,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct NoContent: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct NoContent: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/probe/POST/responses/204/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.probe.Output.NoContent.Headers
                 /// - Remark: Generated from `#/paths/probe/POST/responses/204/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                @frozen public enum Body: Sendable, Hashable {}
                 /// Received HTTP response body
                 public var body: Operations.probe.Output.NoContent.Body?
                 /// Creates a new `NoContent`.
@@ -1311,9 +1310,9 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/{petId}/patch(updatePet)`.
     public enum updatePet {
         public static let id: String = "updatePet"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// Id of the pet
                 ///
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/path/petId`.
@@ -1326,19 +1325,19 @@ public enum Operations {
             }
             public var path: Operations.updatePet.Input.Path
             /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.updatePet.Input.Query
             /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.updatePet.Input.Headers
             /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
@@ -1366,17 +1365,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct NoContent: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct NoContent: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/204/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.updatePet.Output.NoContent.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/204/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                @frozen public enum Body: Sendable, Hashable {}
                 /// Received HTTP response body
                 public var body: Operations.updatePet.Output.NoContent.Body?
                 /// Creates a new `NoContent`.
@@ -1398,18 +1397,18 @@ public enum Operations {
             ///
             /// HTTP response code: `204 noContent`.
             case noContent(Operations.updatePet.Output.NoContent)
-            public struct BadRequest: Sendable, Equatable, Hashable {
+            public struct BadRequest: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/400/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.updatePet.Output.BadRequest.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/400/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/400/content/json`.
-                    public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                    public struct jsonPayload: Codable, Hashable, Sendable {
                         /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/responses/400/content/json/message`.
                         public var message: Swift.String
                         /// Creates a new `jsonPayload`.
@@ -1455,9 +1454,9 @@ public enum Operations {
     /// - Remark: Generated from `#/paths//pets/{petId}/avatar/put(uploadAvatarForPet)`.
     public enum uploadAvatarForPet {
         public static let id: String = "uploadAvatarForPet"
-        public struct Input: Sendable, Equatable, Hashable {
+        public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/path`.
-            public struct Path: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Hashable {
                 /// The id of the pet to retrieve
                 ///
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/path/petId`.
@@ -1470,25 +1469,25 @@ public enum Operations {
             }
             public var path: Operations.uploadAvatarForPet.Input.Path
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/query`.
-            public struct Query: Sendable, Equatable, Hashable {
+            public struct Query: Sendable, Hashable {
                 /// Creates a new `Query`.
                 public init() {}
             }
             public var query: Operations.uploadAvatarForPet.Input.Query
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/header`.
-            public struct Headers: Sendable, Equatable, Hashable {
+            public struct Headers: Sendable, Hashable {
                 /// Creates a new `Headers`.
                 public init() {}
             }
             public var headers: Operations.uploadAvatarForPet.Input.Headers
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/cookie`.
-            public struct Cookies: Sendable, Equatable, Hashable {
+            public struct Cookies: Sendable, Hashable {
                 /// Creates a new `Cookies`.
                 public init() {}
             }
             public var cookies: Operations.uploadAvatarForPet.Input.Cookies
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/requestBody`.
-            @frozen public enum Body: Sendable, Equatable, Hashable {
+            @frozen public enum Body: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/requestBody/content/application\/octet-stream`.
                 case binary(Foundation.Data)
             }
@@ -1515,17 +1514,17 @@ public enum Operations {
                 self.body = body
             }
         }
-        @frozen public enum Output: Sendable, Equatable, Hashable {
-            public struct Ok: Sendable, Equatable, Hashable {
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/200/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.Ok.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/200/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/200/content/application\/octet-stream`.
                     case binary(Foundation.Data)
                 }
@@ -1550,16 +1549,16 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.uploadAvatarForPet.Output.Ok)
-            public struct PreconditionFailed: Sendable, Equatable, Hashable {
+            public struct PreconditionFailed: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/412/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.PreconditionFailed.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/412/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/412/content/application\/json`.
                     case json(Swift.String)
                 }
@@ -1585,16 +1584,16 @@ public enum Operations {
             ///
             /// HTTP response code: `412 preconditionFailed`.
             case preconditionFailed(Operations.uploadAvatarForPet.Output.PreconditionFailed)
-            public struct InternalServerError: Sendable, Equatable, Hashable {
+            public struct InternalServerError: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/500/headers`.
-                public struct Headers: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Hashable {
                     /// Creates a new `Headers`.
                     public init() {}
                 }
                 /// Received HTTP response headers
                 public var headers: Operations.uploadAvatarForPet.Output.InternalServerError.Headers
                 /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/500/content`.
-                @frozen public enum Body: Sendable, Equatable, Hashable {
+                @frozen public enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/responses/500/content/text\/plain`.
                     case plainText(Swift.String)
                 }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -112,7 +112,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Schemas {
-                public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                public struct MyObject: Codable, Hashable, Sendable {
                     public init() {}
                     public init(from decoder: any Decoder) throws {
                         try decoder.ensureNoAdditionalProperties(knownKeys: [])
@@ -134,7 +134,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Schemas {
-                public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                public struct MyObject: Codable, Hashable, Sendable {
                     public var additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer
                     public init(additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer = .init()) {
                         self.additionalProperties = additionalProperties
@@ -163,7 +163,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Schemas {
-                public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                public struct MyObject: Codable, Hashable, Sendable {
                     public var additionalProperties: [String: Swift.Int]
                     public init(additionalProperties: [String: Swift.Int] = .init()) {
                         self.additionalProperties = additionalProperties
@@ -197,7 +197,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
                 public enum Schemas {
-                  public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                  public struct MyObject: Codable, Hashable, Sendable {
                     public var id: Swift.Int64
                     public var alias: Swift.String?
                     public init(id: Swift.Int64, alias: Swift.String? = nil) {
@@ -233,7 +233,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             public enum Schemas {
                 public typealias A = OpenAPIRuntime.OpenAPIValueContainer
                 public typealias B = OpenAPIRuntime.OpenAPIValueContainer
-                public struct MyAllOf: Codable, Equatable, Hashable, Sendable {
+                public struct MyAllOf: Codable, Hashable, Sendable {
                     public var value1: Components.Schemas.A
                     public var value2: Components.Schemas.B
                     public var value3: Swift.String
@@ -286,7 +286,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             public enum Schemas {
                 public typealias A = OpenAPIRuntime.OpenAPIValueContainer
                 public typealias B = OpenAPIRuntime.OpenAPIValueContainer
-                public struct MyAnyOf: Codable, Equatable, Hashable, Sendable {
+                public struct MyAnyOf: Codable, Hashable, Sendable {
                     public var value1: Components.Schemas.A?
                     public var value2: Components.Schemas.B?
                     public var value3: Swift.String?
@@ -339,7 +339,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public enum Schemas {
                 public typealias A = OpenAPIRuntime.OpenAPIValueContainer
-                @frozen public enum MyOneOf: Codable, Equatable, Hashable, Sendable {
+                @frozen public enum MyOneOf: Codable, Hashable, Sendable {
                     case case1(Swift.String)
                     case case2(Swift.Int)
                     case A(Components.Schemas.A)
@@ -406,17 +406,17 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Schemas {
-                public struct A: Codable, Equatable, Hashable, Sendable {
+                public struct A: Codable, Hashable, Sendable {
                     public var which: Swift.String?
                     public init(which: Swift.String? = nil) { self.which = which }
                     public enum CodingKeys: String, CodingKey { case which }
                 }
-                public struct B: Codable, Equatable, Hashable, Sendable {
+                public struct B: Codable, Hashable, Sendable {
                     public var which: Swift.String?
                     public init(which: Swift.String? = nil) { self.which = which }
                     public enum CodingKeys: String, CodingKey { case which }
                 }
-                @frozen public enum MyOneOf: Codable, Equatable, Hashable, Sendable {
+                @frozen public enum MyOneOf: Codable, Hashable, Sendable {
                     case A(Components.Schemas.A)
                     case B(Components.Schemas.B)
                     case undocumented(OpenAPIRuntime.OpenAPIObjectContainer)
@@ -461,7 +461,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public enum Schemas {
                 public typealias A = OpenAPIRuntime.OpenAPIValueContainer
-                @frozen public enum MyOneOf: Codable, Equatable, Hashable, Sendable {
+                @frozen public enum MyOneOf: Codable, Hashable, Sendable {
                     case case1(Swift.String)
                     case case2(Swift.Int)
                     case A(Components.Schemas.A)
@@ -514,14 +514,14 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Schemas {
-                public struct A: Codable, Equatable, Hashable, Sendable {
+                public struct A: Codable, Hashable, Sendable {
                     public init() {}
                     public init(from decoder: any Decoder) throws {
                         try decoder.ensureNoAdditionalProperties(knownKeys: [])
                     }
                 }
-                public struct MyOpenOneOf: Codable, Equatable, Hashable, Sendable {
-                    @frozen public enum Value1Payload: Codable, Equatable, Hashable, Sendable {
+                public struct MyOpenOneOf: Codable, Hashable, Sendable {
+                    @frozen public enum Value1Payload: Codable, Hashable, Sendable {
                         case case1(Swift.String)
                         case case2(Swift.Int)
                         case A(Components.Schemas.A)
@@ -592,7 +592,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public enum Schemas {
                 public typealias A = Swift.String
-                public struct MyAllOf: Codable, Equatable, Hashable, Sendable {
+                public struct MyAllOf: Codable, Hashable, Sendable {
                     public var value1: Components.Schemas.A
                     public init(value1: Components.Schemas.A) {
                         self.value1 = value1
@@ -627,8 +627,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public enum Schemas {
                 public typealias A = Swift.String
-                public struct B: Codable, Equatable, Hashable, Sendable {
-                    public struct cPayload: Codable, Equatable, Hashable, Sendable {
+                public struct B: Codable, Hashable, Sendable {
+                    public struct cPayload: Codable, Hashable, Sendable {
                         public var value1: Components.Schemas.A
                         public init(value1: Components.Schemas.A) { self.value1 = value1 }
                         public init(from decoder: any Decoder) throws { value1 = try .init(from: decoder) }
@@ -660,8 +660,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public enum Schemas {
                 public typealias A = Swift.String
-                public struct B: Codable, Equatable, Hashable, Sendable {
-                    public struct cPayload: Codable, Equatable, Hashable, Sendable {
+                public struct B: Codable, Hashable, Sendable {
+                    public struct cPayload: Codable, Hashable, Sendable {
                         public var value1: Components.Schemas.A
                         public init(value1: Components.Schemas.A) { self.value1 = value1 }
                         public init(from decoder: any Decoder) throws { value1 = try .init(from: decoder) }
@@ -691,7 +691,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public enum Schemas {
                 @frozen
-                public enum MyEnum: RawRepresentable, Codable, Equatable, Hashable, Sendable,
+                public enum MyEnum: RawRepresentable, Codable, Hashable, Sendable,
                     _AutoLosslessStringConvertible, CaseIterable
                 {
                     case one
@@ -740,7 +740,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public enum Schemas {
                 @frozen
-                public enum MyEnum: String, Codable, Equatable, Hashable, Sendable,
+                public enum MyEnum: String, Codable, Hashable, Sendable,
                     _AutoLosslessStringConvertible, CaseIterable
                 {
                     case one = "one"
@@ -768,9 +768,9 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Schemas {
-                public struct MyOpenEnum: Codable, Equatable, Hashable, Sendable {
+                public struct MyOpenEnum: Codable, Hashable, Sendable {
                     @frozen
-                    public enum Value1Payload: String, Codable, Equatable, Hashable, Sendable,
+                    public enum Value1Payload: String, Codable, Hashable, Sendable,
                         _AutoLosslessStringConvertible, CaseIterable
                     {
                         case one = "one"
@@ -817,7 +817,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public enum Schemas {
                 @available(*, deprecated)
-                public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                public struct MyObject: Codable, Hashable, Sendable {
                     public init() {}
                     public init(from decoder: any Decoder) throws {
                         try decoder.ensureNoAdditionalProperties(knownKeys: [])
@@ -841,7 +841,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Schemas {
-                public struct MyObject: Codable, Equatable, Hashable, Sendable {
+                public struct MyObject: Codable, Hashable, Sendable {
                     @available(*, deprecated)
                     public var id: Swift.String?
                     public init(id: Swift.String? = nil) { self.id = id }
@@ -877,10 +877,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Responses {
-                public struct BadRequest: Sendable, Equatable, Hashable {
-                    public struct Headers: Sendable, Equatable, Hashable { public init() {} }
+                public struct BadRequest: Sendable, Hashable {
+                    public struct Headers: Sendable, Hashable { public init() {} }
                     public var headers: Components.Responses.BadRequest.Headers
-                    @frozen public enum Body: Sendable, Equatable, Hashable {}
+                    @frozen public enum Body: Sendable, Hashable {}
                     public var body: Components.Responses.BadRequest.Body?
                     public init(
                         headers: Components.Responses.BadRequest.Headers = .init(),
@@ -908,10 +908,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Responses {
-                public struct BadRequest: Sendable, Equatable, Hashable {
-                    public struct Headers: Sendable, Equatable, Hashable { public init() {} }
+                public struct BadRequest: Sendable, Hashable {
+                    public struct Headers: Sendable, Hashable { public init() {} }
                     public var headers: Components.Responses.BadRequest.Headers
-                    @frozen public enum Body: Sendable, Equatable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
                         case json(Swift.String)
                     }
                     public var body: Components.Responses.BadRequest.Body
@@ -945,10 +945,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Responses {
-                public struct MultipleContentTypes: Sendable, Equatable, Hashable {
-                    public struct Headers: Sendable, Equatable, Hashable { public init() {} }
+                public struct MultipleContentTypes: Sendable, Hashable {
+                    public struct Headers: Sendable, Hashable { public init() {} }
                     public var headers: Components.Responses.MultipleContentTypes.Headers
-                    @frozen public enum Body: Sendable, Equatable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
                         case json(Swift.Int)
                     }
                     public var body: Components.Responses.MultipleContentTypes.Body
@@ -981,10 +981,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Responses {
-                public struct MultipleContentTypes: Sendable, Equatable, Hashable {
-                    public struct Headers: Sendable, Equatable, Hashable { public init() {} }
+                public struct MultipleContentTypes: Sendable, Hashable {
+                    public struct Headers: Sendable, Hashable { public init() {} }
                     public var headers: Components.Responses.MultipleContentTypes.Headers
-                    @frozen public enum Body: Sendable, Equatable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
                         case json(Swift.Int)
                         case plainText(Swift.String)
                         case binary(Foundation.Data)
@@ -1016,14 +1016,14 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Responses {
-                public struct BadRequest: Sendable, Equatable, Hashable {
-                    public struct Headers: Sendable, Equatable, Hashable {
+                public struct BadRequest: Sendable, Hashable {
+                    public struct Headers: Sendable, Hashable {
                         public var X_Reason: Swift.String?
                         public init(X_Reason: Swift.String? = nil) {
                             self.X_Reason = X_Reason }
                     }
                     public var headers: Components.Responses.BadRequest.Headers
-                    @frozen public enum Body: Sendable, Equatable, Hashable {}
+                    @frozen public enum Body: Sendable, Hashable {}
                     public var body: Components.Responses.BadRequest.Body?
                     public init(
                         headers: Components.Responses.BadRequest.Headers = .init(),
@@ -1052,14 +1052,14 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Responses {
-                public struct BadRequest: Sendable, Equatable, Hashable {
-                    public struct Headers: Sendable, Equatable, Hashable {
+                public struct BadRequest: Sendable, Hashable {
+                    public struct Headers: Sendable, Hashable {
                         public var X_Reason: Swift.String
                         public init(X_Reason: Swift.String) {
                             self.X_Reason = X_Reason }
                     }
                     public var headers: Components.Responses.BadRequest.Headers
-                    @frozen public enum Body: Sendable, Equatable, Hashable {}
+                    @frozen public enum Body: Sendable, Hashable {}
                     public var body: Components.Responses.BadRequest.Body?
                     public init(
                         headers: Components.Responses.BadRequest.Headers,
@@ -1086,7 +1086,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum RequestBodies {
-                @frozen public enum MyResponseBody: Sendable, Equatable, Hashable {
+                @frozen public enum MyResponseBody: Sendable, Hashable {
                     case json(Swift.String)
                 }
             }
@@ -1106,7 +1106,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum RequestBodies {
-                @frozen public enum MyResponseBody: Sendable, Equatable, Hashable {
+                @frozen public enum MyResponseBody: Sendable, Hashable {
                     case json(Components.Schemas.MyBody)
                 }
             }
@@ -1130,7 +1130,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum RequestBodies {
-                @frozen public enum MyResponseBody: Sendable, Equatable, Hashable {
+                @frozen public enum MyResponseBody: Sendable, Hashable {
                     case json(Components.Schemas.MyBody)
                 }
             }
@@ -1153,7 +1153,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum RequestBodies {
-                @frozen public enum MyResponseBody: Sendable, Equatable, Hashable {
+                @frozen public enum MyResponseBody: Sendable, Hashable {
                     case json(Components.Schemas.MyBody)
                     case plainText(Swift.String)
                     case binary(Foundation.Data)
@@ -1281,10 +1281,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Responses {
-                public struct MyResponse: Sendable, Equatable, Hashable {
-                    public struct Headers: Sendable, Equatable, Hashable { public init() {} }
+                public struct MyResponse: Sendable, Hashable {
+                    public struct Headers: Sendable, Hashable { public init() {} }
                     public var headers: Components.Responses.MyResponse.Headers
-                    @frozen public enum Body: Sendable, Equatable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
                         case json(Swift.String)
                     }
                     public var body: Components.Responses.MyResponse.Body
@@ -1372,10 +1372,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     description: Response
             """,
             types: """
-                public struct Input: Sendable, Equatable, Hashable {
-                    public struct Path: Sendable, Equatable, Hashable { public init() {} }
+                public struct Input: Sendable, Hashable {
+                    public struct Path: Sendable, Hashable { public init() {} }
                     public var path: Operations.get_foo.Input.Path
-                    public struct Query: Sendable, Equatable, Hashable {
+                    public struct Query: Sendable, Hashable {
                         public var single: Swift.String?
                         public var manyExploded: [Swift.String]?
                         public var manyUnexploded: [Swift.String]?
@@ -1390,11 +1390,11 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         }
                     }
                     public var query: Operations.get_foo.Input.Query
-                    public struct Headers: Sendable, Equatable, Hashable { public init() {} }
+                    public struct Headers: Sendable, Hashable { public init() {} }
                     public var headers: Operations.get_foo.Input.Headers
-                    public struct Cookies: Sendable, Equatable, Hashable { public init() {} }
+                    public struct Cookies: Sendable, Hashable { public init() {} }
                     public var cookies: Operations.get_foo.Input.Cookies
-                    @frozen public enum Body: Sendable, Equatable, Hashable {}
+                    @frozen public enum Body: Sendable, Hashable {}
                     public var body: Operations.get_foo.Input.Body?
                     public init(
                         path: Operations.get_foo.Input.Path = .init(),


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/210.

### Modifications

With this PR. we are removing the explicit `Equatable` conformance when a type already conforms to `Hashable`
 in generated code.

### Result

Generated types now conforms explicitly to `Hashable`  but not to `Equatable`.

```diff
- public struct Generated: Equatable, Hashable {
  }
+ public sutrct Generated: Hashable {
 }
```

### Test Plan

I have updated the reference ressources used by tests to check generated code.
