### PR TITLE
Bump OpenAPIKit to 3.0.0-beta.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         // Read OpenAPI documents
         .package(
             url: "https://github.com/mattpolzin/OpenAPIKit.git",
-            exact: "3.0.0-alpha.9"
+            exact: "3.0.0-beta.1"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1317,10 +1317,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Responses {
-                public struct MyResponse: Sendable, Equatable, Hashable {
-                    public struct Headers: Sendable, Equatable, Hashable { public init() {} }
+                public struct MyResponse: Sendable, Hashable {
+                    public struct Headers: Sendable, Hashable { public init() {} }
                     public var headers: Components.Responses.MyResponse.Headers
-                    @frozen public enum Body: Sendable, Equatable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
                         case json(Swift.String)
                     }
                     public var body: Components.Responses.MyResponse.Body

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1302,45 +1302,39 @@ final class SnippetBasedReferenceTests: XCTestCase {
     }
 
     func testResponseWithExampleWithOnlyValue() throws {
-        // This test currently throws because the parsing of ExampleObject is too strict:
-        // https://github.com/mattpolzin/OpenAPIKit/issues/286.
-        XCTAssertThrowsError(
-            try self.assertResponsesTranslation(
-                """
-                responses:
-                  MyResponse:
-                    description: Some response
-                    content:
+        try self.assertResponsesTranslation(
+            """
+            responses:
+              MyResponse:
+                description: Some response
+                content:
+                  application/json:
+                    schema:
+                      type: string
+                    examples:
                       application/json:
-                        schema:
-                          type: string
-                        examples:
-                          application/json:
-                            summary: "a hello response"
-                """,
-                """
-                public enum Responses {
-                    public struct MyResponse: Sendable, Equatable, Hashable {
-                        public struct Headers: Sendable, Equatable, Hashable { public init() {} }
-                        public var headers: Components.Responses.MyResponse.Headers
-                        @frozen public enum Body: Sendable, Equatable, Hashable {
-                            case json(Swift.String)
-                        }
-                        public var body: Components.Responses.MyResponse.Body
-                        public init(
-                            headers: Components.Responses.MyResponse.Headers = .init(),
-                            body: Components.Responses.MyResponse.Body
-                        ) {
-                            self.headers = headers
-                            self.body = body
-                        }
+                        summary: "a hello response"
+            """,
+            """
+            public enum Responses {
+                public struct MyResponse: Sendable, Equatable, Hashable {
+                    public struct Headers: Sendable, Equatable, Hashable { public init() {} }
+                    public var headers: Components.Responses.MyResponse.Headers
+                    @frozen public enum Body: Sendable, Equatable, Hashable {
+                        case json(Swift.String)
+                    }
+                    public var body: Components.Responses.MyResponse.Body
+                    public init(
+                        headers: Components.Responses.MyResponse.Headers = .init(),
+                        body: Components.Responses.MyResponse.Body
+                    ) {
+                        self.headers = headers
+                        self.body = body
                     }
                 }
-                """
-            )
-        ) { error in
-            XCTAssert(error is DecodingError)
-        }
+            }
+            """
+        )
     }
 
     func testRequestWithQueryItems() throws {


### PR DESCRIPTION
### Motivation

Bump OpenAPIKit to beta.1, which addresses an issue with specification complicance of Example Object, for more see https://github.com/apple/swift-openapi-generator/issues/186.

### Modifications

Bumped the dependency and updated our test.

### Result

Examples without value can get parsed, like the one GitHub has in their OpenAPI doc.

### Test Plan

Updated the x-fail unit test, which now passes.
