### PR TITLE
Support OpenAPI 3.1 in addition to 3.0

### DIFF
--- a/IntegrationTest/Sources/openapi.yaml
+++ b/IntegrationTest/Sources/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.3"
+openapi: "3.1.0"
 info:
   title: "GreetingService"
   version: "1.0.0"

--- a/Package.swift
+++ b/Package.swift
@@ -91,7 +91,9 @@ let package = Package(
         .target(
             name: "_OpenAPIGeneratorCore",
             dependencies: [
+                .product(name: "OpenAPIKit", package: "OpenAPIKit"),
                 .product(name: "OpenAPIKit30", package: "OpenAPIKit"),
+                .product(name: "OpenAPIKitCompat", package: "OpenAPIKit"),
                 .product(name: "Algorithms", package: "swift-algorithms"),
                 .product(name: "Yams", package: "Yams"),
                 .product(name: "SwiftSyntax", package: "swift-syntax"),

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         // Read OpenAPI documents
         .package(
             url: "https://github.com/mattpolzin/OpenAPIKit.git",
-            exact: "3.0.0-beta.1"
+            exact: "3.0.0-beta.2"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Choose one of the transports listed below, or create your own by adopting the `C
 
 ## Requirements and supported features
 
-- Swift 5.8
-- OpenAPI 3.0.x
+| Generator versions | Supported OpenAPI versions | Minimum Swift version |
+| -------- | ------- | ----- |
+| `0.1.0` ... `0.1.11` | 3.0 | 5.8 |
+| `0.1.12` ... `main` | 3.0, 3.1 | 5.8 |
 
 ### Supported platforms and minimum versions
 

--- a/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
+++ b/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A message emitted by the generator.
 public struct Diagnostic: Error, Codable {

--- a/Sources/_OpenAPIGeneratorCore/Extensions/OpenAPIKit.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/OpenAPIKit.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension Either {
 
@@ -20,7 +20,7 @@ extension Either {
     /// - Parameter components: The Components section of the OpenAPI document.
     func resolve(
         in components: OpenAPI.Components
-    ) throws -> B where A == JSONReference<B> {
+    ) throws -> B where A == OpenAPI.Reference<B> {
         switch self {
         case let .a(a):
             return try components.lookup(a)
@@ -59,6 +59,8 @@ extension JSONSchema.Schema {
             return "reference"
         case .fragment:
             return "fragment"
+        case .null:
+            return "null"
         }
     }
 
@@ -89,6 +91,8 @@ extension JSONSchema.Schema {
             return nil
         case .fragment(let coreContext):
             return coreContext.formatString
+        case .null:
+            return nil
         }
     }
 

--- a/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
+++ b/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 import Foundation
 import Yams
 

--- a/Sources/_OpenAPIGeneratorCore/Layers/ParsedOpenAPIRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/ParsedOpenAPIRepresentation.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// An OpenAPIKit document that contains the operations and types for which the generator emits Swift types.
 typealias ParsedOpenAPIRepresentation = OpenAPI.Document

--- a/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/ClientTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/ClientTranslator.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A translator for the generated client.
 ///

--- a/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension ClientFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// Describes one of the two options: allOf or anyOf.
 enum AllOrAnyOf {

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateArray.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateArray.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateRawRepresentableEnum.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateRawRepresentableEnum.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 
@@ -38,7 +38,7 @@ extension FileTranslator {
             switch schema {
             case let .a(ref):
                 // reference, wrap that into JSONSchema
-                unwrappedSchema = .reference(ref)
+                unwrappedSchema = .reference(ref.jsonReference)
             case let .b(schema):
                 unwrappedSchema = schema
             }

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateTypealias.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateTypealias.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/CommentExtensions.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/CommentExtensions.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension Comment {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// Constant values used in generated code, some of which refer to type names
 /// in the Runtime library, so they need to be kept in sync.

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/DiscriminatorExtensions.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/DiscriminatorExtensions.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 import Foundation
 
 /// A child schema of a oneOf with a discriminator.

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/SchemaOverrides.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/SchemaOverrides.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A container of properties that can be defined at multiple levels in
 /// the OpenAPI document. If a property is filled in, the value is used instead

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A structure that contains the information about an OpenAPI object that is
 /// required to generate a matching Swift structure.

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// Utilities for asking questions about OpenAPI.Content
 extension FileTranslator {

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A content type of a request, response, and other types.
 ///

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/SchemaContent.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/SchemaContent.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A type representing OpenAPI content that contains both a content type
 /// and the optional JSON schema.
@@ -48,4 +48,4 @@ struct TypedSchemaContent {
 /// An unresolved OpenAPI schema.
 ///
 /// Can be either a reference or an inline schema.
-typealias UnresolvedSchema = Either<JSONReference<JSONSchema>, JSONSchema>
+typealias UnresolvedSchema = Either<OpenAPI.Reference<JSONSchema>, JSONSchema>

--- a/Sources/_OpenAPIGeneratorCore/Translator/FileTranslator+FeatureFlags.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/FileTranslator+FeatureFlags.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension FileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/FileTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/FileTranslator.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// An object that generates a Swift file for a provided OpenAPI document.
 ///

--- a/Sources/_OpenAPIGeneratorCore/Translator/MultiplexTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/MultiplexTranslator.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A translator that inspects the generator configuration and delegates
 /// the code generation logic to the appropriate translator.

--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A wrapper of an OpenAPI operation that includes the information
 /// about the parent containers of the operation, such as its path

--- a/Sources/_OpenAPIGeneratorCore/Translator/Parameters/TypedParameter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Parameters/TypedParameter.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A container for an OpenAPI parameter and its computed Swift type usage.
 struct TypedParameter {
@@ -258,7 +258,7 @@ extension FileTranslator {
 /// An unresolved OpenAPI parameter.
 ///
 /// Can be either a reference or an inline parameter.
-typealias UnresolvedParameter = Either<JSONReference<OpenAPI.Parameter>, OpenAPI.Parameter>
+typealias UnresolvedParameter = Either<OpenAPI.Reference<OpenAPI.Parameter>, OpenAPI.Parameter>
 
 extension OpenAPI.Parameter.Context.Location {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/Parameters/translateParameter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Parameters/translateParameter.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/RequestBody/TypedRequestBody.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/RequestBody/TypedRequestBody.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A container for an OpenAPI request body and its computed Swift type usage.
 struct TypedRequestBody {
@@ -117,4 +117,4 @@ extension FileTranslator {
 /// An unresolved OpenAPI request.
 ///
 /// Can be either a reference or an inline request.
-typealias UnresolvedRequest = Either<JSONReference<OpenAPI.Request>, OpenAPI.Request>
+typealias UnresolvedRequest = Either<OpenAPI.Reference<OpenAPI.Request>, OpenAPI.Request>

--- a/Sources/_OpenAPIGeneratorCore/Translator/RequestBody/translateRequestBody.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/RequestBody/translateRequestBody.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/ResponseKind.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/ResponseKind.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A type of an OpenAPI operation response: a specific HTTP status code,
 /// a range of HTTP status codes, or default.

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/TypedResponse.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/TypedResponse.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A container for an OpenAPI response and its computed Swift type usage.
 struct TypedResponse {
@@ -63,4 +63,4 @@ extension FileTranslator {
 /// An unresolved OpenAPI response.
 ///
 /// Can be either a reference or an inline response.
-typealias UnresolvedResponse = Either<JSONReference<OpenAPI.Response>, OpenAPI.Response>
+typealias UnresolvedResponse = Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/TypedResponseHeader.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/TypedResponseHeader.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A container for an OpenAPI response header and its computed
 /// Swift type usage.
@@ -173,4 +173,4 @@ extension FileTranslator {
 /// An unresolved OpenAPI response header.
 ///
 /// Can be either a reference or an inline response header.
-typealias UnresolvedHeader = Either<JSONReference<OpenAPI.Header>, OpenAPI.Header>
+typealias UnresolvedHeader = Either<OpenAPI.Reference<OpenAPI.Header>, OpenAPI.Header>

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/acceptHeaderContentTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/acceptHeaderContentTypes.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 import Algorithms
 
 extension FileTranslator {

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponse.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponse.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseHeader.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseHeader.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseOutcome.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseOutcome.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A translator for the generated server.
 ///

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension ServerFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TranslatorProtocol.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TranslatorProtocol.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// An object that turns an OpenAPI document into the structured Swift
 /// representation of the request generated file: types, client, or server.

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 import Foundation
 
 /// A set of functions that compute the deterministic, unique, and global
@@ -366,6 +366,25 @@ struct TypeAssigner {
             throw JSONReferenceParsingError.externalPathsUnsupported(reference.absoluteString)
         }
         return try typeName(for: internalReference, in: componentType)
+    }
+
+    /// Returns a type name for an OpenAPI reference.
+    ///
+    /// Behaves similarly to JSONReference.
+    ///
+    /// - NOTE: Only internal references are currently supported; throws an error for external references.
+    /// - Parameters:
+    ///   - reference: The reference to compute a type name for.
+    ///   - componentType: The type of the component to which the reference
+    ///   points.
+    func typeName<Component: ComponentDictionaryLocatable>(
+        for reference: OpenAPI.Reference<Component>,
+        in componentType: Component.Type = Component.self
+    ) throws -> TypeName {
+        try typeName(
+            for: reference.jsonReference,
+            in: componentType
+        )
     }
 
     /// Returns a type name for an internal reference to a component.

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeLocation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeLocation.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// Describes the location of a name type in the OpenAPI document.
 enum TypeLocation {

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A set of functions that match Swift types onto OpenAPI types.
 struct TypeMatcher {
@@ -71,7 +71,7 @@ struct TypeMatcher {
     ) throws -> TypeUsage? {
         try Self._tryMatchRecursive(
             for: schema.value,
-            test: { schema in
+            test: { (schema) -> TypeUsage? in
                 if let builtinType = Self._tryMatchBuiltinNonRecursive(for: schema) {
                     return builtinType
                 }
@@ -238,7 +238,7 @@ struct TypeMatcher {
             // arrays are already recursed-into by _tryMatchTypeRecursive
             // so just return nil here
             return nil
-        case .reference, .not, .all, .any, .one:
+        case .reference, .not, .all, .any, .one, .null:
             // never built-in
             return nil
         }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A result of checking whether a schema is supported.
 enum IsSchemaSupportedResult: Equatable {
@@ -163,7 +163,7 @@ extension FileTranslator {
             // > When using the discriminator, inline schemas will not be considered.
             // > — https://spec.openapis.org/oas/v3.0.3#discriminator-object
             return try areRefsToObjectishSchemaAndSupported(schemas.filter(\.isReference))
-        case .not:
+        case .not, .null:
             return .unsupported(
                 reason: .schemaType,
                 schema: schema

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 /// A translator for the generated common types.
 ///

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentHeaders.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentHeaders.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentParameters.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentParameters.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentRequestBodies.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentRequestBodies.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentResponses.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentResponses.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponents.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponents.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateSchemas.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateSchemas.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateServers.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateServers.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 
 extension TypesFileTranslator {
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
@@ -4,9 +4,9 @@ Learn which OpenAPI features are supported by Swift OpenAPI Generator.
 
 ## Overview
 
-Swift OpenAPI Generator is currently focused on supporting [OpenAPI 3.0.3][0].
+Swift OpenAPI Generator is currently focused on supporting [OpenAPI 3.0.3][0] and [OpenAPI 3.1.0][1]. 
 
-As the project evolves, support may be added [OpenAPI 3.1.0][1].
+> Note: Internally, documents are converted from 3.0.3 to 3.1.0 to allow the generator to only work with a single set of parsed OpenAPI types.
 
 Supported features are always provided on _both_ client and server.
 
@@ -155,7 +155,7 @@ Supported features are always provided on _both_ client and server.
 - [x] description
 - [x] format
 - [ ] default
-- [ ] nullable
+- [ ] nullable (only in 3.0, removed in 3.1)
 - [x] discriminator
 - [ ] readOnly
 - [ ] writeOnly

--- a/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
@@ -41,8 +41,12 @@ Choose one of the transports listed below, or create your own by adopting the `C
 
 ### Requirements and supported features
 
-- Swift 5.8
-- OpenAPI 3.0.x (for details, see <doc:Supported-OpenAPI-features>)
+| Generator versions | Supported OpenAPI versions | Minimum Swift version |
+| -------- | ------- | ----- |
+| `0.1.0` ... `0.1.11` | 3.0 | 5.8 |
+| `0.1.12` ... `main` | 3.0, 3.1 | 5.8 |
+
+See also <doc:Supported-OpenAPI-features>.
 
 ### Supported platforms and minimum versions
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/ExploreOpenAPI.tutorial
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/ExploreOpenAPI.tutorial
@@ -16,7 +16,7 @@
 
         @Steps {
             @Step {
-                Every OpenAPI document needs to declare its format version using the `openapi` key. Use the version `3.0.3` for this document.
+                Every OpenAPI document needs to declare its format version using the `openapi` key. Use the version `3.1.0` for this document.
                 @Code(name: "openapi.yaml", file: exploring-openapi.openapi.0.yaml, reset: true)
             }
             @Step {

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.openapi.2.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.openapi.2.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.openapi.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/client.openapi.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.0.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.0.yaml
@@ -1,1 +1,1 @@
-openapi: '3.0.3'
+openapi: '3.1.0'

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.1.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.1.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.2.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.2.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.3.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.3.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.4.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.4.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.5.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.5.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.6.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.6.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.7.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/exploring-openapi.openapi.7.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.openapi.0.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.openapi.0.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.openapi.1.yaml
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.openapi.1.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.3'
+openapi: '3.1.0'
 info:
   title: GreetingService
   version: 1.0.0

--- a/Sources/swift-openapi-generator/GenerateOptions.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions.swift
@@ -14,7 +14,7 @@
 import ArgumentParser
 import Foundation
 import Yams
-import OpenAPIKit30
+import OpenAPIKit
 import _OpenAPIGeneratorCore
 
 struct _GenerateOptions: ParsableArguments {

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
@@ -21,13 +21,14 @@ final class Test_YamsParser: Test_Core {
         XCTAssertNoThrow(try _test(openAPIVersionString: "3.0.1"))
         XCTAssertNoThrow(try _test(openAPIVersionString: "3.0.2"))
         XCTAssertNoThrow(try _test(openAPIVersionString: "3.0.3"))
+        XCTAssertNoThrow(try _test(openAPIVersionString: "3.1.0"))
 
         let expected1 =
-            "/foo.yaml: error: Unsupported document version: openapi: 3.1.0. Please provide a document with OpenAPI versions in the 3.0.x set."
-        assertThrownError(try _test(openAPIVersionString: "3.1.0"), expectedDiagnostic: expected1)
+            "/foo.yaml: error: Unsupported document version: openapi: 3.2.0. Please provide a document with OpenAPI versions in the 3.0.x or 3.1.x sets."
+        assertThrownError(try _test(openAPIVersionString: "3.2.0"), expectedDiagnostic: expected1)
 
         let expected2 =
-            "/foo.yaml: error: Unsupported document version: openapi: 2.0. Please provide a document with OpenAPI versions in the 3.0.x set."
+            "/foo.yaml: error: Unsupported document version: openapi: 2.0. Please provide a document with OpenAPI versions in the 3.0.x or 3.1.x sets."
         assertThrownError(try _test(openAPIVersionString: "2.0"), expectedDiagnostic: expected2)
     }
 
@@ -53,7 +54,7 @@ final class Test_YamsParser: Test_Core {
             """
 
         let expected =
-            "/foo.yaml: error: No openapi key found, please provide a valid OpenAPI document with OpenAPI versions in the 3.0.x set."
+            "/foo.yaml: error: No openapi key found, please provide a valid OpenAPI document with OpenAPI versions in the 3.0.x or 3.1.x sets."
         assertThrownError(try _test(yaml), expectedDiagnostic: expected)
     }
 

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
@@ -61,7 +61,7 @@ final class Test_YamsParser: Test_Core {
     func testEmitsYamsParsingError() throws {
         // The `title: "Test"` line is indented the wrong amount to make the YAML invalid for the parser
         let yaml = """
-            openapi: "3.0.0"
+            openapi: "3.1.0"
             info:
              title: "Test"
               version: 1.0.0
@@ -76,7 +76,7 @@ final class Test_YamsParser: Test_Core {
     func testEmitsYamsScanningError() throws {
         // The `version:"1.0.0"` line is missing a space after the colon to make it invalid YAML for the scanner
         let yaml = """
-            openapi: "3.0.0"
+            openapi: "3.1.0"
             info:
               title: "Test"
               version:"1.0.0"
@@ -91,7 +91,7 @@ final class Test_YamsParser: Test_Core {
     func testEmitsMissingInfoKeyOpenAPIParsingError() throws {
         // The `smurf` line should be `info` in a real OpenAPI document.
         let yaml = """
-            openapi: "3.0.0"
+            openapi: "3.1.0"
             smurf:
               title: "Test"
               version: "1.0.0"
@@ -106,7 +106,7 @@ final class Test_YamsParser: Test_Core {
     func testEmitsComplexOpenAPIParsingError() throws {
         // The `resonance` line should be `response` in a real OpenAPI document.
         let yaml = """
-            openapi: "3.0.0"
+            openapi: "3.1.0"
             info:
               title: "Test"
               version: "1.0.0"

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_validateDoc.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_validateDoc.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_validateDoc: Test_Core {

--- a/Tests/OpenAPIGeneratorCoreTests/TestUtilities.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/TestUtilities.swift
@@ -14,7 +14,7 @@
 import XCTest
 import Foundation
 import Yams
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 class Test_Core: XCTestCase {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateCodable.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateCodable.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_translateCodable: Test_Core {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStringEnum.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStringEnum.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_translateStringEnum: Test_Core {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStructBlueprint.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStructBlueprint.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_translateStructBlueprint: Test_Core {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTypes/Test_DiscriminatorExtensions.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTypes/Test_DiscriminatorExtensions.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_DiscriminatorExtensions: Test_Core {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_ContentSwiftName: Test_Core {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_ContentType: Test_Core {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Operations/Test_OperationDescription.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Operations/Test_OperationDescription.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 import XCTest
 @testable import _OpenAPIGeneratorCore
 

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeAssigner.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeAssigner.swift
@@ -12,28 +12,28 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 class Test_TypeAssigner: Test_Core {
 
     func testTypeNameForReferences() throws {
         try XCTAssertEqual(
-            typeAssigner.typeName(for: JSONReference<JSONSchema>.component(named: "mumble")),
+            typeAssigner.typeName(for: OpenAPI.Reference<JSONSchema>.component(named: "mumble")),
             newTypeName(
                 swiftFQName: "Components.Schemas.mumble",
                 jsonFQName: "#/components/schemas/mumble"
             )
         )
         try XCTAssertEqual(
-            typeAssigner.typeName(for: JSONReference<OpenAPI.Parameter>.component(named: "mumble")),
+            typeAssigner.typeName(for: OpenAPI.Reference<OpenAPI.Parameter>.component(named: "mumble")),
             newTypeName(
                 swiftFQName: "Components.Parameters.mumble",
                 jsonFQName: "#/components/parameters/mumble"
             )
         )
         try XCTAssertEqual(
-            typeAssigner.typeName(for: JSONReference<OpenAPI.Header>.component(named: "mumble")),
+            typeAssigner.typeName(for: OpenAPI.Reference<OpenAPI.Header>.component(named: "mumble")),
             newTypeName(
                 swiftFQName: "Components.Headers.mumble",
                 jsonFQName: "#/components/headers/mumble"
@@ -41,7 +41,7 @@ class Test_TypeAssigner: Test_Core {
 
         )
         try XCTAssertEqual(
-            typeAssigner.typeName(for: JSONReference<OpenAPI.Request>.component(named: "mumble")),
+            typeAssigner.typeName(for: OpenAPI.Reference<OpenAPI.Request>.component(named: "mumble")),
             newTypeName(
                 swiftFQName: "Components.RequestBodies.mumble",
                 jsonFQName: "#/components/requestBodies/mumble"
@@ -49,7 +49,7 @@ class Test_TypeAssigner: Test_Core {
 
         )
         try XCTAssertEqual(
-            typeAssigner.typeName(for: JSONReference<OpenAPI.Response>.component(named: "mumble")),
+            typeAssigner.typeName(for: OpenAPI.Reference<OpenAPI.Response>.component(named: "mumble")),
             newTypeName(
                 swiftFQName: "Components.Responses.mumble",
                 jsonFQName: "#/components/responses/mumble"

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_TypeMatcher: Test_Core {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 class Test_isSchemaSupported: XCTestCase {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 import Yams
 @testable import _OpenAPIGeneratorCore
 

--- a/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit30
+import OpenAPIKit
 import Yams
 @testable import _OpenAPIGeneratorCore
 

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -297,9 +297,8 @@ components:
         me$sage:
           type: string
         extraInfo:
+          $ref: '#/components/schemas/ExtraInfo'
           description: Extra information about the error.
-          allOf:
-            - $ref: '#/components/schemas/ExtraInfo'
         userData:
           description: Custom user-provided key-value pairs.
           type: object

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.3"
+openapi: "3.1.0"
 info:
   version: 1.0.0
   title: Petstore

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -176,23 +176,7 @@ public enum Components {
             /// Extra information about the error.
             ///
             /// - Remark: Generated from `#/components/schemas/Error/extraInfo`.
-            public struct extraInfoPayload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/Error/extraInfo/value1`.
-                public var value1: Components.Schemas.ExtraInfo
-                /// Creates a new `extraInfoPayload`.
-                ///
-                /// - Parameters:
-                ///   - value1:
-                public init(value1: Components.Schemas.ExtraInfo) { self.value1 = value1 }
-                public init(from decoder: any Decoder) throws { value1 = try .init(from: decoder) }
-                public func encode(to encoder: any Encoder) throws {
-                    try value1.encode(to: encoder)
-                }
-            }
-            /// Extra information about the error.
-            ///
-            /// - Remark: Generated from `#/components/schemas/Error/extraInfo`.
-            public var extraInfo: Components.Schemas._Error.extraInfoPayload?
+            public var extraInfo: Components.Schemas.ExtraInfo?
             /// Custom user-provided key-value pairs.
             ///
             /// - Remark: Generated from `#/components/schemas/Error/userData`.
@@ -207,7 +191,7 @@ public enum Components {
             public init(
                 code: Swift.Int32,
                 me_sage: Swift.String,
-                extraInfo: Components.Schemas._Error.extraInfoPayload? = nil,
+                extraInfo: Components.Schemas.ExtraInfo? = nil,
                 userData: OpenAPIRuntime.OpenAPIObjectContainer? = nil
             ) {
                 self.code = code

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
@@ -149,23 +149,7 @@ public enum Components {
             /// Extra information about the error.
             ///
             /// - Remark: Generated from `#/components/schemas/Error/extraInfo`.
-            public struct extraInfoPayload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/Error/extraInfo/value1`.
-                public var value1: Components.Schemas.ExtraInfo
-                /// Creates a new `extraInfoPayload`.
-                ///
-                /// - Parameters:
-                ///   - value1:
-                public init(value1: Components.Schemas.ExtraInfo) { self.value1 = value1 }
-                public init(from decoder: any Decoder) throws { value1 = try .init(from: decoder) }
-                public func encode(to encoder: any Encoder) throws {
-                    try value1.encode(to: encoder)
-                }
-            }
-            /// Extra information about the error.
-            ///
-            /// - Remark: Generated from `#/components/schemas/Error/extraInfo`.
-            public var extraInfo: Components.Schemas._Error.extraInfoPayload?
+            public var extraInfo: Components.Schemas.ExtraInfo?
             /// Custom user-provided key-value pairs.
             ///
             /// - Remark: Generated from `#/components/schemas/Error/userData`.
@@ -180,7 +164,7 @@ public enum Components {
             public init(
                 code: Swift.Int32,
                 me_dollar_sage: Swift.String,
-                extraInfo: Components.Schemas._Error.extraInfoPayload? = nil,
+                extraInfo: Components.Schemas.ExtraInfo? = nil,
                 userData: OpenAPIRuntime.OpenAPIObjectContainer? = nil
             ) {
                 self.code = code

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit30
+import OpenAPIKit
 import XCTest
 import Yams
 @testable import _OpenAPIGeneratorCore
@@ -1561,7 +1561,7 @@ extension SnippetBasedReferenceTests {
             } ?? OpenAPI.Components.noComponents
         let paths = try YAMLDecoder().decode(OpenAPI.PathItem.Map.self, from: pathsYAML)
         let document = OpenAPI.Document(
-            openAPIVersion: .v3_0_3,
+            openAPIVersion: .v3_1_0,
             info: .init(title: "Test", version: "1.0.0"),
             servers: [],
             paths: paths,


### PR DESCRIPTION
### Motivation

Fixes #39. We need to start accepting 3.1 documents in addition to 3.0.

It also has useful features, like being able to add descriptions to references.

### Modifications

Migrated the codebase to use the `OpenAPIKit` instead of the `OpenAPIKit30` module, and updated the parser to handle both 3.0 and 3.1, and convert 3.0 to 3.1 documents in memory transparently.

### Result

OpenAPI 3.1 documents are now accepted, instead of rejected. Any 3.1 specific features can be addressed separately, this is the MVP support.

### Test Plan

Updated the file-based reference test to use version 3.1.0, and the parser tests that 3.0.x documents are loaded and converted successfully. So no need to duplicate our reference tests or anything.
