### PR TITLE
Allow refs to oneOf/anyOf inside a oneOf with a discriminator

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
@@ -212,7 +212,7 @@ extension FileTranslator {
         switch schema.value {
         case .object, .reference:
             return try isSchemaSupported(schema)
-        case .all(of: let schemas, _):
+        case .all(of: let schemas, _), .any(of: let schemas, _), .one(of: let schemas, _):
             return try areSchemasSupported(schemas)
         default:
             return .unsupported(

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
@@ -25,6 +25,15 @@ class Test_isSchemaSupported: XCTestCase {
                 "Foo": .string,
                 "MyObj": .object,
                 "MyObj2": .object,
+                "MyNestedObjectishOneOf": .one(of: [
+                    .object(properties: ["foo": .string])
+                ]),
+                "MyNestedAllOf": .all(of: [
+                    .object(properties: ["foo": .string])
+                ]),
+                "MyNestedAnyOf": .any(of: [
+                    .object(properties: ["foo": .string])
+                ]),
             ])
         )
     }
@@ -71,10 +80,14 @@ class Test_isSchemaSupported: XCTestCase {
             .array(items: .string),
         ]),
 
-        // oneOf with a discriminator with two objectish schemas and two (ignored) inline schemas
+        // oneOf with a discriminator with a few objectish schemas and two (ignored) inline schemas
         .one(
             of: .reference(.component(named: "MyObj")),
             .reference(.component(named: "MyObj2")),
+            .reference(.component(named: "MyNestedAllOf")),
+            .reference(.component(named: "MyNestedAnyOf")),
+            .reference(.component(named: "MyNestedObjectishOneOf")),
+
             .object,
             .boolean,
             discriminator: .init(propertyName: "foo")


### PR DESCRIPTION
### Motivation

Fixes #222.

We had a bug, where we considered oneOf/anyOf nested within a oneOf with a discriminator as not supported.

We already allowed allOf in there, but it was an oversight to disallow oneOf/anyOf there.

### Modifications

Update the isSupported logic to allow oneOf and anyOf within such oneOfs with a discriminator. Note that the nested schemas _within_ the oneOf/anyOf still must be objectish, as oneOf + discriminator always represent a JSON object.

### Result

OpenAPI docs with this nesting won't skip such schemas anymore.

### Test Plan

Updated the unit test.
