### PR TITLE
Allow non-unique values in oneOf.discriminator.mapping

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -636,6 +636,11 @@ enum SwitchCaseKind: Equatable, Codable {
     /// For example: `case let foo(bar):`.
     case `case`(Expression, [String])
 
+    /// A case with multiple comma-separated expressions.
+    ///
+    /// For example: `case "foo", "bar":`.
+    case multiCase([Expression])
+
     /// A default. Spelled as `default:`.
     case `default`
 }

--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -152,6 +152,9 @@ struct TextBasedRenderer: RendererProtocol {
                 maybeLet = ""
             }
             return "case \(maybeLet)\(renderedExpression(expression))\(associatedValues)"
+        case .multiCase(let expressions):
+            let expressions = expressions.map(renderedExpression).joined(separator: ", ")
+            return "case \(expressions)"
         case .`default`:
             return "default"
         }

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
@@ -133,6 +133,26 @@ extension FileTranslator {
             includedSchemas = schemas
         }
 
+        // The list of cases isn't dependent only on the list of subschemas, but
+        // also on the optional discriminator.mapping property, which can
+        // actually map from multiple keys to the same value.
+        // At the same time, the mapping doesn't have to mention all the
+        // subschemas, in which case the default behavior (use the JSON
+        // path of the schema) is used.
+        // This means that we have two sources of cases:
+        // - list of subschemas
+        // - discriminator.mapping
+        // And the final list of cases is a union of these two sources.
+        // Regarding order, somewhat arbitrarily, let's put the cases from
+        // the mapping first, and all the other ones second.
+
+        let casesFromDiscriminatorMapping: [OneOfMappedType]
+        if let mapping = discriminator?.mapping {
+
+        } else {
+            casesFromDiscriminatorMapping = []
+        }
+
         let cases: [(String, Comment?, TypeUsage, [Declaration])] =
             try includedSchemas
             .enumerated()

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
@@ -436,7 +436,7 @@ extension FileTranslator {
                         .expression(
                             .assignment(
                                 left: .identifier("self"),
-                                right: .dot(caseInfo.caseName)
+                                right: .dot(safeSwiftNameForOneOfMappedType(caseInfo))
                                     .call([
                                         .init(
                                             label: nil,

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
@@ -420,23 +420,20 @@ extension FileTranslator {
     }
 
     /// Returns a declaration of a oneOf with a discriminator decoder implementation.
-    /// - Parameters:
-    ///   - caseNames: The cases to decode, first element is the raw string to check for, the second
-    ///     element is the case name (without the leading dot).
     func translateOneOfWithDiscriminatorDecoder(
         discriminatorName: String,
-        cases: [OneOfMappedType]
+        cases: [(caseName: String, rawNames: [String])]
     ) -> Declaration {
         let cases: [SwitchCaseDescription] =
             cases
-            .map { caseInfo in
+            .map { caseName, rawNames in
                 .init(
-                    kind: .case(.literal(caseInfo.rawName)),
+                    kind: .multiCase(rawNames.map { .literal($0) }),
                     body: [
                         .expression(
                             .assignment(
                                 left: .identifier("self"),
-                                right: .dot(safeSwiftNameForOneOfMappedType(caseInfo))
+                                right: .dot(caseName)
                                     .call([
                                         .init(
                                             label: nil,

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/DiscriminatorExtensions.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/DiscriminatorExtensions.swift
@@ -19,26 +19,50 @@ import Foundation
 /// Details: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#fixed-fields-21
 struct OneOfMappedType: Hashable {
 
-    /// The raw name expected in the discriminator for this type.
+    /// The raw names expected in the discriminator for this type.
     ///
     /// Usually matches the raw name from the OpenAPI document, either the last
     /// path component of the `#/components/schemas/Foo` name, or the raw key
-    /// value in a discriminator's mapping.
+    /// value in a discriminator's mapping. That's why it's an array.
     ///
     /// Not automatically safe to be used as a Swift identifier.
-    var rawName: String
+    ///
+    /// Never empty.
+    let rawNames: [String]
 
     /// The type name for this child schema.
-    var typeName: TypeName
+    let typeName: TypeName
+
+    /// The JSON reference.
+    let reference: JSONReference<JSONSchema>
+
+    /// Creates a new type.
+    /// - Parameters:
+    ///   - rawNames: The raw names to match for during decoding.
+    ///   - typeName: The type name.
+    ///   - reference: JSONReference<JSONSchema>.InternalReference.
+    init(rawNames: [String], typeName: TypeName, reference: JSONReference<JSONSchema>) {
+        precondition(!rawNames.isEmpty, "Must specify at least one raw name")
+        self.rawNames = rawNames
+        self.typeName = typeName
+        self.reference = reference
+    }
 
     /// An error thrown during oneOf type mapping.
     enum MappingError: Swift.Error, LocalizedError, CustomStringConvertible {
-        case nonUniqueMapping
+
+        /// The value in the mapping is not a valid JSON reference.
+        case invalidMappingValue(String)
+
+        /// The reference isn't a valid `#/components/schemas/` reference.
+        case invalidReference(String)
 
         var description: String {
             switch self {
-            case .nonUniqueMapping:
-                return "In discriminator.mapping, found multiple keys for the same value."
+            case .invalidMappingValue(let value):
+                return "Invalid discriminator.mapping value: '\(value)', must be an internal JSON reference."
+            case .invalidReference(let reference):
+                return "Invalid reference: '\(reference)'."
             }
         }
 
@@ -57,55 +81,109 @@ extension FileTranslator {
     /// Derived from the mapping key, or the type name, as the last path
     /// component.
     func safeSwiftNameForOneOfMappedType(_ type: OneOfMappedType) -> String {
-        swiftSafeName(for: type.rawName)
+        swiftSafeName(for: type.rawNames[0])
     }
 }
 
 extension OpenAPI.Discriminator {
 
-    /// Returns the mapped types for the provided child schema, taking
-    /// the optional mapping into consideration.
-    /// - Throws: When an inconsistency is detected.
-    func mappedTypes(_ types: [TypeName]) throws -> [OneOfMappedType] {
-        guard let mapping else {
-            // Without a mapping, the raw name and case name are the same, which
-            // is the short name of the type itself.
-            return types.map { type in
-                .init(
-                    rawName: type.shortJSONName ?? type.shortSwiftName,
-                    typeName: type
-                )
+    /// Returns all the types discovered both in the provided list of schemas
+    /// and in the optional mapping.
+    ///
+    /// ## Background
+    /// The list of cases isn't dependent only on the list of subschemas, but
+    /// also on the optional discriminator.mapping property, which can
+    /// actually map from multiple keys to the same value.
+    /// At the same time, the mapping doesn't have to mention all the
+    /// subschemas, in which case the default behavior (use the JSON
+    /// path of the schema) is used.
+    ///
+    /// This means that we have two sources of cases:
+    ///   - list of subschemas
+    ///   - discriminator.mapping
+    ///
+    /// And the final list of cases is a union of these two sources.
+    /// Regarding order, somewhat arbitrarily, let's put the cases from
+    /// the mapping first, and all the other ones second.
+    /// - Parameters:
+    ///   - schemas: The subschemas of the oneOf with this discriminator.
+    ///   - typeAssigner: The current type assigner.
+    /// - Returns: The list of discovered types.
+    func allTypes(
+        schemas: [JSONReference<JSONSchema>],
+        typeAssigner: TypeAssigner
+    ) throws -> [OneOfMappedType] {
+        let mapped = try pairsFromMapping(typeAssigner: typeAssigner)
+        let mappedTypes = Set(mapped.map(\.typeName))
+        var merged = mapped
+        let subschemas = try pairsFromReferences(schemas, typeAssigner: typeAssigner)
+        // Now, we only include a type here if it's not already mentioned
+        // by the mapping.
+        for subschema in subschemas {
+            if mappedTypes.contains(subschema.typeName) {
+                continue
             }
+            merged.append(subschema)
         }
-        // Create a back-mapping, as we need to match the values with our
-        // types, and find the manually defined raw key for it.
-        // First ensure uniqueness of values, otherwise throw an error.
-        if Set(mapping.values).count < mapping.values.count {
-            throw OneOfMappedType.MappingError.nonUniqueMapping
+        return merged
+    }
+
+    /// Returns the mapped types provided by the discriminator's mapping.
+    /// - Parameter typeAssigner: The current type assigner, used to assign
+    ///   a Swift type to the found JSON reference.
+    /// - Returns: An array of found mapped types, but might also be empty.
+    private func pairsFromMapping(typeAssigner: TypeAssigner) throws -> [OneOfMappedType] {
+        guard let mapping else {
+            return []
         }
-        let backMapping = Dictionary(
-            uniqueKeysWithValues: mapping.map { ($1, $0) }
-        )
-        // If a type is found in the mapping, use the key as the raw value.
-        // Otherwise, fall back to as if the mapping was not present for that
-        // child schema.
-        return types.map { type in
-            let shortName = type.shortJSONName ?? type.shortSwiftName
+        // Mapping is a Swift dictionary, so order isn't defined. To produce
+        // stable output, sort by keys here before going through the pairs.
+        let pairs = mapping.sorted(by: { a, b in
+            a.key.localizedCaseInsensitiveCompare(b.key) == .orderedAscending
+        })
+        return try pairs.map { key, value in
+            // If a discriminator was specified, we know all the subschemas
+            // are references to objectish schemas. The reference is all we
+            // need to derive the Swift name.
+            // The value in the mapping is the raw JSON reference.
+            guard
+                let ref = JSONReference<JSONSchema>
+                    .InternalReference(
+                        rawValue: value
+                    )
+            else {
+                throw OneOfMappedType.MappingError.invalidMappingValue(value)
+            }
+            let typeName = try typeAssigner.typeName(for: ref)
+            return .init(
+                rawNames: [key],
+                typeName: typeName,
+                reference: .internal(ref)
+            )
+        }
+    }
+
+    /// Returns the mapped types for the provided subschema.
+    /// - Throws: When an inconsistency is detected.
+    private func pairsFromReferences(
+        _ refs: [JSONReference<JSONSchema>],
+        typeAssigner: TypeAssigner
+    ) throws -> [OneOfMappedType] {
+        try refs.map { ref in
+            guard case let .internal(internalRef) = ref else {
+                throw JSONReferenceParsingError.externalPathsUnsupported(ref.absoluteString)
+            }
             // Check both for "Foo" and "#/components/schemas/Foo", as both
             // are supported.
-            let rawKey: String?
-            if let rawName = backMapping[shortName] {
-                rawKey = rawName
-            } else if let jsonPath = type.fullyQualifiedJSONPath,
-                let rawName = backMapping[jsonPath]
-            {
-                rawKey = rawName
-            } else {
-                rawKey = nil
+            let jsonPath = internalRef.rawValue
+            guard let name = internalRef.name else {
+                throw OneOfMappedType.MappingError.invalidReference(jsonPath)
             }
-            return .init(
-                rawName: rawKey ?? shortName,
-                typeName: type
+            let typeName = try typeAssigner.typeName(for: internalRef)
+            return OneOfMappedType(
+                rawNames: [name, jsonPath],
+                typeName: typeName,
+                reference: ref
             )
         }
     }

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/DiscriminatorExtensions.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/DiscriminatorExtensions.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A child schema of a oneOf with a discriminator.
 ///
 /// Details: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#fixed-fields-21
-struct OneOfMappedType: Equatable {
+struct OneOfMappedType: Hashable {
 
     /// The raw name expected in the discriminator for this type.
     ///
@@ -30,15 +30,6 @@ struct OneOfMappedType: Equatable {
 
     /// The type name for this child schema.
     var typeName: TypeName
-
-    /// The case name, safe for Swift code.
-    ///
-    /// Does not include the leading dot.
-    ///
-    /// Derived from the type name, as the last path component.
-    var caseName: String {
-        typeName.shortSwiftName
-    }
 
     /// An error thrown during oneOf type mapping.
     enum MappingError: Swift.Error, LocalizedError, CustomStringConvertible {
@@ -57,10 +48,23 @@ struct OneOfMappedType: Equatable {
     }
 }
 
+extension FileTranslator {
+
+    /// The case name, safe for Swift code.
+    ///
+    /// Does not include the leading dot.
+    ///
+    /// Derived from the mapping key, or the type name, as the last path
+    /// component.
+    func safeSwiftNameForOneOfMappedType(_ type: OneOfMappedType) -> String {
+        swiftSafeName(for: type.rawName)
+    }
+}
+
 extension OpenAPI.Discriminator {
 
-    /// Returns the mapped type for the provided child schema, taking the optional
-    /// mapping into consideration.
+    /// Returns the mapped types for the provided child schema, taking
+    /// the optional mapping into consideration.
     /// - Throws: When an inconsistency is detected.
     func mappedTypes(_ types: [TypeName]) throws -> [OneOfMappedType] {
         guard let mapping else {

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeName.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeName.swift
@@ -18,7 +18,7 @@ import Foundation
 ///
 /// Use the type name to define a type, see also `TypeUsage` when referring
 /// to a type.
-struct TypeName: Equatable {
+struct TypeName: Hashable {
 
     /// Describes a single component of both the Swift and JSON  paths.
     ///
@@ -27,7 +27,7 @@ struct TypeName: Equatable {
     /// This type preserves the information about which Swift path component
     /// maps to which JSON path component, and vice versa, and allows
     /// reliably adding and removing extra path components.
-    struct Component: Equatable {
+    struct Component: Hashable {
 
         /// The name of the Swift path component.
         var swift: String?

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTypes/Test_DiscriminatorExtensions.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTypes/Test_DiscriminatorExtensions.swift
@@ -18,6 +18,7 @@ import OpenAPIKit30
 final class Test_DiscriminatorExtensions: Test_Core {
 
     func testMappedTypes() throws {
+        let translator = makeTranslator()
         let types = _testTypes()
 
         do {
@@ -40,7 +41,7 @@ final class Test_DiscriminatorExtensions: Test_Core {
                     "Bar",
                     "B_z",
                 ],
-                mapped.map(\.caseName)
+                mapped.map(translator.safeSwiftNameForOneOfMappedType)
             )
         }
 
@@ -48,6 +49,7 @@ final class Test_DiscriminatorExtensions: Test_Core {
             let mapped = try _testMappedTypes(
                 mapping: [
                     "bar": "Bar",
+                    "bar2": "Bar",
                     "baz": "#/components/schemas/B$z",
                 ],
                 types: types
@@ -67,7 +69,7 @@ final class Test_DiscriminatorExtensions: Test_Core {
                     "Bar",
                     "B_z",
                 ],
-                mapped.map(\.caseName)
+                mapped.map(translator.safeSwiftNameForOneOfMappedType)
             )
         }
     }

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -560,9 +560,9 @@ public enum Components {
         }
         /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator`.
         @frozen public enum OneOfObjectsWithDiscriminator: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/case1`.
+            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/Walk`.
             case Walk(Components.Schemas.Walk)
-            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/case2`.
+            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/MessagedExercise`.
             case MessagedExercise(Components.Schemas.MessagedExercise)
             /// Parsed a case that was not defined in the OpenAPI document.
             case undocumented(OpenAPIRuntime.OpenAPIObjectContainer)
@@ -571,8 +571,9 @@ public enum Components {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 let discriminator = try container.decode(String.self, forKey: .kind)
                 switch discriminator {
-                case "Walk": self = .Walk(try .init(from: decoder))
-                case "MessagedExercise": self = .MessagedExercise(try .init(from: decoder))
+                case "Walk", "#/components/schemas/Walk": self = .Walk(try .init(from: decoder))
+                case "MessagedExercise", "#/components/schemas/MessagedExercise":
+                    self = .MessagedExercise(try .init(from: decoder))
                 default:
                     let container = try decoder.singleValueContainer()
                     let value = try container.decode(OpenAPIRuntime.OpenAPIObjectContainer.self)

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore_FF_MultipleContentTypes/Types.swift
@@ -512,17 +512,18 @@ public enum Components {
         }
         /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator`.
         @frozen public enum OneOfObjectsWithDiscriminator: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/case1`.
+            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/Walk`.
             case Walk(Components.Schemas.Walk)
-            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/case2`.
+            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/MessagedExercise`.
             case MessagedExercise(Components.Schemas.MessagedExercise)
             public enum CodingKeys: String, CodingKey { case kind }
             public init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 let discriminator = try container.decode(String.self, forKey: .kind)
                 switch discriminator {
-                case "Walk": self = .Walk(try .init(from: decoder))
-                case "MessagedExercise": self = .MessagedExercise(try .init(from: decoder))
+                case "Walk", "#/components/schemas/Walk": self = .Walk(try .init(from: decoder))
+                case "MessagedExercise", "#/components/schemas/MessagedExercise":
+                    self = .MessagedExercise(try .init(from: decoder))
                 default:
                     throw DecodingError.failedToDecodeOneOfSchema(
                         type: Self.self,

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -505,7 +505,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         case "a": self = .a(try .init(from: decoder))
                         case "a2": self = .a2(try .init(from: decoder))
                         case "b": self = .b(try .init(from: decoder))
-                        case "C", "#/components/schemas/C": self = .c(try .init(from: decoder))
+                        case "C", "#/components/schemas/C": self = .C(try .init(from: decoder))
                         default:
                             throw DecodingError.failedToDecodeOneOfSchema(
                                 type: Self.self,

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -400,9 +400,6 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         type: integer
                 discriminator:
                   propertyName: which
-                  mapping:
-                    a: '#/components/schemas/A'
-                    b: '#/components/schemas/B'
             """,
             """
             public enum Schemas {
@@ -425,8 +422,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         let container = try decoder.container(keyedBy: CodingKeys.self)
                         let discriminator = try container.decode(String.self, forKey: .which)
                         switch discriminator {
-                        case "a": self = .A(try .init(from: decoder))
-                        case "b": self = .B(try .init(from: decoder))
+                        case "A", "#/components/schemas/A": self = .A(try .init(from: decoder))
+                        case "B", "#/components/schemas/B": self = .B(try .init(from: decoder))
                         default:
                             let container = try decoder.singleValueContainer()
                             let value = try container.decode(OpenAPIRuntime.OpenAPIObjectContainer.self)
@@ -438,6 +435,90 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         case let .A(value): try value.encode(to: encoder)
                         case let .B(value): try value.encode(to: encoder)
                         case let .undocumented(value): try value.encode(to: encoder)
+                        }
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsSchemasOneOfWithDiscriminatorWithMapping() throws {
+        try self.assertSchemasTranslation(
+            featureFlags: [.closedEnumsAndOneOfs],
+            """
+            schemas:
+              A:
+                type: object
+                properties:
+                  which:
+                    type: string
+              B:
+                type: object
+                properties:
+                  which:
+                    type: string
+              C:
+                type: object
+                properties:
+                  which:
+                    type: string
+              MyOneOf:
+                oneOf:
+                  - $ref: '#/components/schemas/A'
+                  - $ref: '#/components/schemas/B'
+                  - $ref: '#/components/schemas/C'
+                discriminator:
+                  propertyName: which
+                  mapping:
+                    a: '#/components/schemas/A'
+                    a2: '#/components/schemas/A'
+                    b: '#/components/schemas/B'
+            """,
+            """
+            public enum Schemas {
+                public struct A: Codable, Hashable, Sendable {
+                    public var which: Swift.String?
+                    public init(which: Swift.String? = nil) { self.which = which }
+                    public enum CodingKeys: String, CodingKey { case which }
+                }
+                public struct B: Codable, Hashable, Sendable {
+                    public var which: Swift.String?
+                    public init(which: Swift.String? = nil) { self.which = which }
+                    public enum CodingKeys: String, CodingKey { case which }
+                }
+                public struct C: Codable, Hashable, Sendable {
+                    public var which: Swift.String?
+                    public init(which: Swift.String? = nil) { self.which = which }
+                    public enum CodingKeys: String, CodingKey { case which }
+                }
+                @frozen public enum MyOneOf: Codable, Hashable, Sendable {
+                    case a(Components.Schemas.A)
+                    case a2(Components.Schemas.A)
+                    case b(Components.Schemas.B)
+                    case C(Components.Schemas.C)
+                    public enum CodingKeys: String, CodingKey { case which }
+                    public init(from decoder: any Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        let discriminator = try container.decode(String.self, forKey: .which)
+                        switch discriminator {
+                        case "a": self = .a(try .init(from: decoder))
+                        case "a2": self = .a2(try .init(from: decoder))
+                        case "b": self = .b(try .init(from: decoder))
+                        case "C", "#/components/schemas/C": self = .c(try .init(from: decoder))
+                        default:
+                            throw DecodingError.failedToDecodeOneOfSchema(
+                                type: Self.self,
+                                codingPath: decoder.codingPath
+                            )
+                        }
+                    }
+                    public func encode(to encoder: any Encoder) throws {
+                        switch self {
+                        case let .a(value): try value.encode(to: encoder)
+                        case let .a2(value): try value.encode(to: encoder)
+                        case let .b(value): try value.encode(to: encoder)
+                        case let .C(value): try value.encode(to: encoder)
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation

Fixes #223, see the issue for details.

### Modifications

Changed the logic for deriving the enum cases to take both the mapping and the list of subschemas into account. Documented it more in code.

### Result

Now adopter can actually have different keys pointing to the same types in their mapping - originally reported by an adopter, so it's a real issue.

### Test Plan

Adapted tests.