### PR TITLE
Bump OpenAPIKit - fixes a server variable parsing issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         // Read OpenAPI documents
         .package(
             url: "https://github.com/mattpolzin/OpenAPIKit.git",
-            exact: "3.0.0-beta.2"
+            exact: "3.0.0-beta.3"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",


### PR DESCRIPTION
### Motivation

Fixes #228.

### Modifications

Bumps OpenAPIKit to a version with the fix.

### Result

OpenAPI docs that use server variables don't fail generation.

### Test Plan

Verified manually on an OpenAPI doc locally.
