### PR TITLE
Include parameters in the content type name

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/CommentExtensions.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/CommentExtensions.swift
@@ -167,7 +167,7 @@ extension ContentType {
     func docComment(typeName: TypeName) -> Comment? {
         typeName.docCommentWithUserDescription(
             nil,
-            subPath: lowercasedTypeAndSubtypeWithEscape
+            subPath: lowercasedTypeSubtypeAndParametersWithEscape
         )
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
@@ -155,7 +155,7 @@ extension FileTranslator {
         }
         let chosenContent: (SchemaContent, OpenAPI.Content)?
         if let (contentKey, contentValue) = map.first(where: { $0.key.isJSON }) {
-            let contentType = ContentType(contentKey.typeAndSubtype)
+            let contentType = contentKey.asGeneratorContentType
             chosenContent = (
                 .init(
                     contentType: contentType,
@@ -164,7 +164,7 @@ extension FileTranslator {
                 contentValue
             )
         } else if let (contentKey, contentValue) = map.first(where: { $0.key.isText }) {
-            let contentType = ContentType(contentKey.typeAndSubtype)
+            let contentType = contentKey.asGeneratorContentType
             chosenContent = (
                 .init(
                     contentType: contentType,
@@ -173,7 +173,7 @@ extension FileTranslator {
                 contentValue
             )
         } else if !excludeBinary, let (contentKey, contentValue) = map.first(where: { $0.key.isBinary }) {
-            let contentType = ContentType(contentKey.typeAndSubtype)
+            let contentType = contentKey.asGeneratorContentType
             chosenContent = (
                 .init(
                     contentType: contentType,
@@ -225,7 +225,7 @@ extension FileTranslator {
         foundIn: String
     ) -> SchemaContent? {
         if contentKey.isJSON {
-            let contentType = ContentType(contentKey.typeAndSubtype)
+            let contentType = contentKey.asGeneratorContentType
             if contentType.lowercasedType == "multipart"
                 || contentType.lowercasedTypeAndSubtype.contains("application/x-www-form-urlencoded")
             {
@@ -241,14 +241,14 @@ extension FileTranslator {
             )
         }
         if contentKey.isText {
-            let contentType = ContentType(contentKey.typeAndSubtype)
+            let contentType = contentKey.asGeneratorContentType
             return .init(
                 contentType: contentType,
                 schema: .b(.string)
             )
         }
         if !excludeBinary, contentKey.isBinary {
-            let contentType = ContentType(contentKey.typeAndSubtype)
+            let contentType = contentKey.asGeneratorContentType
             return .init(
                 contentType: contentType,
                 schema: .b(.string(format: .binary))

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
@@ -20,7 +20,8 @@ extension FileTranslator {
     ///
     /// - Parameter contentType: The content type for which to compute the name.
     func contentSwiftName(_ contentType: ContentType) -> String {
-        switch contentType.lowercasedTypeAndSubtype {
+        let rawContentType = contentType.lowercasedTypeSubtypeAndParameters
+        switch rawContentType {
         case "application/json":
             return "json"
         case "application/x-www-form-urlencoded":
@@ -50,7 +51,21 @@ extension FileTranslator {
         default:
             let safedType = swiftSafeName(for: contentType.originallyCasedType)
             let safedSubtype = swiftSafeName(for: contentType.originallyCasedSubtype)
-            return "\(safedType)_\(safedSubtype)"
+            let prefix = "\(safedType)_\(safedSubtype)"
+            let params = contentType
+                .lowercasedParameterPairs
+            guard !params.isEmpty else {
+                return prefix
+            }
+            let safedParams = params
+                .map { pair in
+                    pair
+                        .split(separator: "=")
+                        .map { swiftSafeName(for: String($0)) }
+                        .joined(separator: "_")
+                }
+                .joined(separator: "_")
+            return prefix + "_" + safedParams
         }
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentSwiftName.swift
@@ -57,7 +57,8 @@ extension FileTranslator {
             guard !params.isEmpty else {
                 return prefix
             }
-            let safedParams = params
+            let safedParams =
+                params
                 .map { pair in
                     pair
                         .split(separator: "=")

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
@@ -108,15 +108,15 @@ struct ContentType: Hashable {
         originallyCasedSubtype.lowercased()
     }
 
-    /// The parameter section, if any.
+    /// The parameter key-value pairs.
     ///
     /// Preserves the casing from the input, do not use this
-    /// for equality comparisons, use `lowercasedParameters` instead.
+    /// for equality comparisons, use `lowercasedParameterPairs` instead.
     let originallyCasedParameterPairs: [String]
 
-    /// The component after ';' of the MIME type, as a lowercase string.
+    /// The parameter key-value pairs, lowercased.
     ///
-    /// The raw value in its original casing is only provided by `originallyCasedParameters`.
+    /// The raw value in its original casing is only provided by `originallyCasedParameterPairs`.
     var lowercasedParameterPairs: [String] {
         originallyCasedParameterPairs.map { $0.lowercased() }
     }
@@ -136,7 +136,7 @@ struct ContentType: Hashable {
         originallyCasedTypeAndSubtype + originallyCasedParametersString
     }
 
-    /// The type, subtype, and parameters components normalized and combined.
+    /// The type, subtype, and parameters components combined and lowercased.
     var lowercasedTypeSubtypeAndParameters: String {
         originallyCasedTypeSubtypeAndParameters.lowercased()
     }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
@@ -151,7 +151,10 @@ struct ContentType: Hashable {
             .split(separator: ";")
         let typeAndSubtypeComponent = semiComponents.removeFirst()
         self.originallyCasedParameterPairs = semiComponents.map { component in
-            component.trimmingCharacters(in: .whitespacesAndNewlines)
+            component
+                .split(separator: "=")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .joined(separator: "=")
         }
         let rawTypeAndSubtype =
             typeAndSubtypeComponent

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
@@ -182,7 +182,7 @@ struct ContentType: Hashable {
         "\(lowercasedType)/\(lowercasedSubtype)"
     }
 
-    /// Returns the type and subtype as a "<type>\/<subtype>[;<param>...]" string.
+    /// Returns the type, subtype and parameters (if present) as a "<type>\/<subtype>[;<param>...]" string.
     ///
     /// Lowercased to ease case-insensitive comparisons, and escaped to show
     /// that the slash between type and subtype is not a path separator.

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
@@ -100,7 +100,7 @@ struct ContentType: Hashable {
     /// Preserves the casing from the input, do not use this
     /// for equality comparisons, use `lowercasedSubtype` instead.
     let originallyCasedSubtype: String
-    
+
     /// The second component of the MIME type, as a lowercase string.
     ///
     /// The raw value in its original casing is only provided by `originallyCasedTypeAndSubtype`.
@@ -113,19 +113,19 @@ struct ContentType: Hashable {
     /// Preserves the casing from the input, do not use this
     /// for equality comparisons, use `lowercasedParameters` instead.
     let originallyCasedParameterPairs: [String]
-    
+
     /// The component after ';' of the MIME type, as a lowercase string.
     ///
     /// The raw value in its original casing is only provided by `originallyCasedParameters`.
     var lowercasedParameterPairs: [String] {
         originallyCasedParameterPairs.map { $0.lowercased() }
     }
-    
+
     /// The parameters string.
     var originallyCasedParametersString: String {
         originallyCasedParameterPairs.map { "; \($0)" }.joined()
     }
-    
+
     /// The parameters string, lowercased.
     var lowercasedParametersString: String {
         originallyCasedParametersString.lowercased()
@@ -140,13 +140,14 @@ struct ContentType: Hashable {
     var lowercasedTypeSubtypeAndParameters: String {
         originallyCasedTypeSubtypeAndParameters.lowercased()
     }
-    
+
     /// Creates a new content type by parsing the specified MIME type.
     /// - Parameter rawValue: A MIME type, for example "application/json". Must
     ///   not be empty.
     init(_ rawValue: String) {
         precondition(!rawValue.isEmpty, "rawValue of a ContentType cannot be empty.")
-        var semiComponents = rawValue
+        var semiComponents =
+            rawValue
             .split(separator: ";")
         let typeAndSubtypeComponent = semiComponents.removeFirst()
         self.originallyCasedParameterPairs = semiComponents.map { component in

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
@@ -43,6 +43,7 @@ final class Test_ContentSwiftName: Test_Core {
             // Names with a parameter.
             ("application/foo", "application_foo"),
             ("application/foo; bar=baz; boo=foo", "application_foo_bar_baz_boo_foo"),
+            ("application/foo; bar = baz", "application_foo_bar_baz"),
         ]
         for item in cases {
             let contentType = try XCTUnwrap(ContentType(item.0))

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
@@ -39,6 +39,10 @@ final class Test_ContentSwiftName: Test_Core {
             // Generic names.
             ("application/myformat+json", "application_myformat_plus_json"),
             ("foo/bar", "foo_bar"),
+            
+            // Names with a parameter.
+            ("application/foo", "application_foo"),
+            ("application/foo; bar=baz; boo=foo", "application_foo_bar_baz_boo_foo"),
         ]
         for item in cases {
             let contentType = try XCTUnwrap(ContentType(item.0))

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
@@ -39,7 +39,7 @@ final class Test_ContentSwiftName: Test_Core {
             // Generic names.
             ("application/myformat+json", "application_myformat_plus_json"),
             ("foo/bar", "foo_bar"),
-            
+
             // Names with a parameter.
             ("application/foo", "application_foo"),
             ("application/foo; bar=baz; boo=foo", "application_foo_bar_baz_boo_foo"),

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
@@ -24,14 +24,18 @@ final class Test_ContentType: Test_Core {
                 category: ContentType.Category,
                 type: String,
                 subtype: String,
+                parameters: String,
                 lowercasedOutput: String,
-                originallyCasedOutput: String
+                originallyCasedOutput: String,
+                originallyCasedOutputWithParameters: String
             )] = [
                 (
                     "application/json",
                     .json,
                     "application",
                     "json",
+                    "",
+                    "application/json",
                     "application/json",
                     "application/json"
                 ),
@@ -40,7 +44,9 @@ final class Test_ContentType: Test_Core {
                     .json,
                     "application",
                     "json",
+                    "",
                     "application/json",
+                    "APPLICATION/JSON",
                     "APPLICATION/JSON"
                 ),
                 (
@@ -48,14 +54,18 @@ final class Test_ContentType: Test_Core {
                     .json,
                     "application",
                     "json",
+                    "; charset=utf-8",
                     "application/json",
-                    "application/json"
+                    "application/json",
+                    "application/json; charset=utf-8"
                 ),
                 (
                     "application/x-www-form-urlencoded",
                     .binary,
                     "application",
                     "x-www-form-urlencoded",
+                    "",
+                    "application/x-www-form-urlencoded",
                     "application/x-www-form-urlencoded",
                     "application/x-www-form-urlencoded"
                 ),
@@ -64,6 +74,8 @@ final class Test_ContentType: Test_Core {
                     .binary,
                     "multipart",
                     "form-data",
+                    "",
+                    "multipart/form-data",
                     "multipart/form-data",
                     "multipart/form-data"
                 ),
@@ -72,6 +84,8 @@ final class Test_ContentType: Test_Core {
                     .text,
                     "text",
                     "plain",
+                    "",
+                    "text/plain",
                     "text/plain",
                     "text/plain"
                 ),
@@ -80,6 +94,8 @@ final class Test_ContentType: Test_Core {
                     .binary,
                     "*",
                     "*",
+                    "",
+                    "*/*",
                     "*/*",
                     "*/*"
                 ),
@@ -88,6 +104,8 @@ final class Test_ContentType: Test_Core {
                     .binary,
                     "application",
                     "xml",
+                    "",
+                    "application/xml",
                     "application/xml",
                     "application/xml"
                 ),
@@ -96,6 +114,8 @@ final class Test_ContentType: Test_Core {
                     .binary,
                     "application",
                     "octet-stream",
+                    "",
+                    "application/octet-stream",
                     "application/octet-stream",
                     "application/octet-stream"
                 ),
@@ -104,6 +124,8 @@ final class Test_ContentType: Test_Core {
                     .json,
                     "application",
                     "myformat+json",
+                    "",
+                    "application/myformat+json",
                     "application/myformat+json",
                     "application/myformat+json"
                 ),
@@ -112,6 +134,8 @@ final class Test_ContentType: Test_Core {
                     .binary,
                     "foo",
                     "bar",
+                    "",
+                    "foo/bar",
                     "foo/bar",
                     "foo/bar"
                 ),
@@ -120,8 +144,20 @@ final class Test_ContentType: Test_Core {
                     .json,
                     "foo",
                     "bar+json",
+                    "",
+                    "foo/bar+json",
                     "foo/bar+json",
                     "foo/bar+json"
+                ),
+                (
+                    "foo/bar+json; param1=a; param2=b",
+                    .json,
+                    "foo",
+                    "bar+json",
+                    "; param1=a; param2=b",
+                    "foo/bar+json",
+                    "foo/bar+json",
+                    "foo/bar+json; param1=a; param2=b"
                 ),
             ]
         for (
@@ -129,15 +165,19 @@ final class Test_ContentType: Test_Core {
             category,
             type,
             subtype,
+            parameters,
             lowercasedTypeAndSubtype,
-            originallyCasedTypeAndSubtype
+            originallyCasedTypeAndSubtype,
+            originallyCasedOutputWithParameters
         ) in cases {
             let contentType = ContentType(rawValue)
             XCTAssertEqual(contentType.category, category)
             XCTAssertEqual(contentType.lowercasedType, type)
             XCTAssertEqual(contentType.lowercasedSubtype, subtype)
+            XCTAssertEqual(contentType.lowercasedParametersString, parameters)
             XCTAssertEqual(contentType.lowercasedTypeAndSubtype, lowercasedTypeAndSubtype)
             XCTAssertEqual(contentType.originallyCasedTypeAndSubtype, originallyCasedTypeAndSubtype)
+            XCTAssertEqual(contentType.originallyCasedTypeSubtypeAndParameters, originallyCasedOutputWithParameters)
         }
     }
 }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -910,6 +910,9 @@ final class SnippetBasedReferenceTests: XCTestCase {
                   application/json:
                     schema:
                       type: integer
+                  application/json; foo=bar:
+                    schema:
+                      type: integer
                   text/plain: {}
                   application/octet-stream: {}
             """,
@@ -920,6 +923,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public var headers: Components.Responses.MultipleContentTypes.Headers
                     @frozen public enum Body: Sendable, Hashable {
                         case json(Swift.Int)
+                        case application_json_foo_bar(Swift.Int)
                         case plainText(Swift.String)
                         case binary(Foundation.Data)
                     }


### PR DESCRIPTION
### Motivation

Fixes #232, which was blocking the Kubernetes OpenAPI doc from successfully generating and building.

### Modifications

Include parameters, such as `application/json; foo=bar` in the content type name, e.g. `application_json_foo_bar`.

### Result

#232 is fixed, verified already locally.

### Test Plan

Updated unit and snippet tests.
