### PR TITLE
Update GreetingService for 0.2.0 and update docs

### DIFF
--- a/Examples/GreetingService/Package.swift
+++ b/Examples/GreetingService/Package.swift
@@ -20,10 +20,10 @@ let package = Package(
         .macOS(.v13)
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/apple/swift-openapi-urlsession", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/swift-server/swift-openapi-vapor", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/swift-server/swift-openapi-vapor", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/vapor/vapor", from: "4.76.0"),
     ],
     targets: [

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Manually-invoking-the-generator-CLI.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Manually-invoking-the-generator-CLI.md
@@ -1,6 +1,6 @@
 # Manually invoking the generator CLI
 
-Manually invoke the command-line tool to generate code as an alternative to the Swift package plugin.
+Manually invoke the command-line tool to generate code as an alternative to the Swift package build plugin.
 
 ## Overview
 
@@ -39,3 +39,17 @@ To see the usage documentation for the generator CLI, use the following command:
 ```zsh
 % swift run swift-openapi-generator --help
 ```
+
+### Use the Swift package command
+
+As an alternative to invoking the CLI manually, you can also use the package command, which works similarly to the build plugin.
+
+Set up the `openapi.yaml` and `openapi-generator-config.yaml` files the same way as you would for the build plugin, and then run:
+
+```
+swift package plugin generate-code-from-openapi --target GreetingServiceClient
+```
+
+This will generate files into the `GreetingServiceClient` target's Sources directory, in a directory called GeneratedSources, which you can then check into your repository.
+
+You can also invoke the command from the Xcode UI by control-clicking on a target in the Project Navigator, and selecting the command.


### PR DESCRIPTION
### Motivation

The example project needs updating, but it was only possible to do after we've tagged 0.2.0, so here we go.

### Modifications

Updated the example service and updated docs for using the command plugin, which I noticed wasn't documented.

### Result

The example project now uses the latest version. Our tutorials point to it, so it's good for it to track the latest and greatest.

### Test Plan

Built locally.
