### PR TITLE
Support integer-backed enums

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -544,7 +544,7 @@ enum EnumCaseKind: Equatable, Codable {
     /// A case with a name and a raw value.
     ///
     /// For example: `case foo = "Foo"`.
-    case nameWithRawValue(String)
+    case nameWithRawValue(LiteralDescription)
 
     /// A case with a name and associated values.
     ///

--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -520,7 +520,7 @@ struct TextBasedRenderer: RendererProtocol {
         case .nameOnly:
             return ""
         case .nameWithRawValue(let rawValue):
-            return " = \"\(rawValue)\""
+            return " = \(renderedLiteral(rawValue))"
         case .nameWithAssociatedValues(let values):
             if values.isEmpty {
                 return ""

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
@@ -220,7 +220,7 @@ extension FileTranslator {
                     members: [
                         .enumCase(
                             name: swiftName,
-                            kind: swiftName == originalName ? .nameOnly : .nameWithRawValue(originalName)
+                            kind: swiftName == originalName ? .nameOnly : .nameWithRawValue(.string(originalName))
                         )
                     ]
                 )

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateRawRepresentableEnum.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateRawRepresentableEnum.swift
@@ -31,7 +31,7 @@ extension FileTranslator {
         typeName: TypeName,
         conformances: [String],
         userDescription: String?,
-        cases: [(caseName: String, rawValue: String)],
+        cases: [(caseName: String, rawExpr: LiteralDescription)],
         unknownCaseName: String?,
         unknownCaseDescription: String?,
         customSwitchedExpression: (Expression) -> Expression = { $0 }
@@ -40,10 +40,10 @@ extension FileTranslator {
         let generateUnknownCases = unknownCaseName != nil
         let knownCases: [Declaration] =
             cases
-            .map { caseName, rawValue in
+            .map { caseName, rawExpr in
                 .enumCase(
                     name: caseName,
-                    kind: generateUnknownCases ? .nameOnly : .nameWithRawValue(rawValue)
+                    kind: generateUnknownCases ? .nameOnly : .nameWithRawValue(rawExpr)
                 )
             }
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
@@ -112,7 +112,20 @@ extension FileTranslator {
             guard let allowedValues = coreContext.allowedValues else {
                 throw GenericError(message: "Unexpected non-global string for \(typeName)")
             }
-            let enumDecl = try translateStringEnum(
+            let enumDecl = try translateRawEnum(
+                backingType: .string,
+                typeName: typeName,
+                userDescription: overrides.userDescription ?? coreContext.description,
+                isNullable: coreContext.nullable,
+                allowedValues: allowedValues
+            )
+            return [enumDecl]
+        case let .integer(coreContext, _):
+            guard let allowedValues = coreContext.allowedValues else {
+                throw GenericError(message: "Unexpected non-global integer for \(typeName)")
+            }
+            let enumDecl = try translateRawEnum(
+                backingType: .integer,
                 typeName: typeName,
                 userDescription: overrides.userDescription ?? coreContext.description,
                 isNullable: coreContext.nullable,

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
@@ -157,7 +157,7 @@ extension FileTranslator {
                 let rawName = property.originalName
                 return .enumCase(
                     name: swiftName,
-                    kind: swiftName == rawName ? .nameOnly : .nameWithRawValue(property.originalName)
+                    kind: swiftName == rawName ? .nameOnly : .nameWithRawValue(.string(property.originalName))
                 )
             }
         return .enum(

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -138,11 +138,14 @@ enum Constants {
         static let variableName: String = "additionalProperties"
     }
 
-    /// Constants related to all generated string-based enums.
-    enum StringEnum {
+    /// Constants related to all generated raw enums.
+    enum RawEnum {
 
-        /// The name of the base conformance.
-        static let baseConformance: String = "String"
+        /// The name of the base conformance for string-based enums.
+        static let baseConformanceString: String = "String"
+
+        /// The name of the base conformance for int-based enums.
+        static let baseConformanceInteger: String = "Int"
 
         /// The types that every enum conforms to.
         static let conformances: [String] = [

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
@@ -202,6 +202,10 @@ struct TypeMatcher {
                 typeName = .swift("Double")
             }
         case .integer(let core, _):
+            if core.allowedValues != nil {
+                // custom enum isn't a builtin
+                return nil
+            }
             switch core.format {
             case .int32:
                 typeName = .swift("Int32")

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
@@ -210,10 +210,10 @@ extension TypesFileTranslator {
         guard !contentTypes.isEmpty else {
             return nil
         }
-        let cases: [(caseName: String, rawValue: String)] =
+        let cases: [(caseName: String, rawExpr: LiteralDescription)] =
             contentTypes
             .map { contentType in
-                (contentSwiftName(contentType), contentType.lowercasedTypeAndSubtype)
+                (contentSwiftName(contentType), .string(contentType.lowercasedTypeAndSubtype))
             }
         return try translateRawRepresentableEnum(
             typeName: acceptableContentTypeName,

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
@@ -75,6 +75,10 @@ final class Test_TypeMatcher: Test_Core {
         .string(allowedValues: [
             AnyCodable("Foo")
         ]),
+        // an int enum
+        .integer(allowedValues: [
+            AnyCodable(1)
+        ]),
 
         // an object with at least one property
         .object(properties: [

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
@@ -44,6 +44,11 @@ class Test_isSchemaSupported: XCTestCase {
             AnyCodable("Foo")
         ]),
 
+        // an int enum
+        .integer(allowedValues: [
+            AnyCodable(1)
+        ]),
+
         // an object with at least one property
         .object(properties: [
             "Foo": .string

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -703,7 +703,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
-    func testComponentsSchemasEnum() throws {
+    func testComponentsSchemasStringEnum() throws {
         try self.assertSchemasTranslation(
             """
             schemas:
@@ -722,6 +722,29 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     case _empty = ""
                     case _dollar_tart = "$tart"
                     case _public = "public"
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsSchemasIntEnum() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              MyEnum:
+                type: integer
+                enum:
+                  - 0
+                  - 10
+                  - 20
+            """,
+            """
+            public enum Schemas {
+                @frozen public enum MyEnum: Int, Codable, Hashable, Sendable {
+                    case _0 = 0
+                    case _10 = 10
+                    case _20 = 20
                 }
             }
             """


### PR DESCRIPTION
### Motivation

Fixes #241.

### Modifications

Made the existing string-backed enum generation logic a tiny bit more generic, and integer support just fell out of it.

### Result

Now integer-backed enums are also supported.

### Test Plan

Updated tests.
