### PR TITLE
Add support for nullable schemas

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
+++ b/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
@@ -27,9 +27,11 @@
 /// 1.0 is released.)
 public enum FeatureFlag: String, Hashable, Codable, CaseIterable {
 
-    /// Has to be here until we add more feature flags, otherwise the enum
-    /// doesn't compile.
-    case empty
+    /// Support for `nullable` schemas.
+    ///
+    /// A dedicated field in OpenAPI 3.0, a `null` value present in
+    /// the `types` array in OpenAPI 3.1.
+    case nullableSchemas
 }
 
 /// A set of enabled feature flags.

--- a/Sources/_OpenAPIGeneratorCore/Translator/FileTranslator+FeatureFlags.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/FileTranslator+FeatureFlags.swift
@@ -15,4 +15,10 @@ import OpenAPIKit
 
 extension FileTranslator {
     // Add helpers for reading feature flags below.
+
+    /// A Boolean value indicating whether the `nullable` field on schemas
+    /// should be taken into account.
+    var supportNullableSchemas: Bool {
+        config.featureFlags.contains(.nullableSchemas)
+    }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
@@ -45,6 +45,10 @@ struct TypeAssigner {
     /// safe to be used as a Swift identifier.
     var asSwiftSafeName: (String) -> String
 
+    /// A Boolean value indicating whether the `nullable` field on schemas
+    /// should be taken into account.
+    var supportNullableSchemas: Bool
+
     /// Returns a type name for an OpenAPI-named component type.
     ///
     /// A component type is any type in `#/components` in the OpenAPI document.
@@ -256,7 +260,10 @@ struct TypeAssigner {
         // Check if this type can be simply referenced without
         // creating a new inline type.
         if let referenceableType =
-            try TypeMatcher(asSwiftSafeName: asSwiftSafeName)
+            try TypeMatcher(
+                asSwiftSafeName: asSwiftSafeName,
+                supportNullableSchemas: supportNullableSchemas
+            )
             .tryMatchReferenceableType(for: schema)
         {
             return referenceableType
@@ -452,12 +459,18 @@ extension FileTranslator {
 
     /// A configured type assigner.
     var typeAssigner: TypeAssigner {
-        TypeAssigner(asSwiftSafeName: swiftSafeName)
+        TypeAssigner(
+            asSwiftSafeName: swiftSafeName,
+            supportNullableSchemas: supportNullableSchemas
+        )
     }
 
     /// A configured type matcher.
     var typeMatcher: TypeMatcher {
-        TypeMatcher(asSwiftSafeName: swiftSafeName)
+        TypeMatcher(
+            asSwiftSafeName: swiftSafeName,
+            supportNullableSchemas: supportNullableSchemas
+        )
     }
 }
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
@@ -20,6 +20,10 @@ struct TypeMatcher {
     /// safe to be used as a Swift identifier.
     var asSwiftSafeName: (String) -> String
 
+    /// A Boolean value indicating whether the `nullable` field on schemas
+    /// should be taken into account.
+    var supportNullableSchemas: Bool
+
     /// Returns the type name of a built-in type that matches the specified
     /// schema.
     ///
@@ -78,8 +82,11 @@ struct TypeMatcher {
                 guard case let .reference(ref, _) = schema else {
                     return nil
                 }
-                return try TypeAssigner(asSwiftSafeName: asSwiftSafeName)
-                    .typeName(for: ref).asUsage
+                return try TypeAssigner(
+                    asSwiftSafeName: asSwiftSafeName,
+                    supportNullableSchemas: supportNullableSchemas
+                )
+                .typeName(for: ref).asUsage
             },
             matchedArrayHandler: { elementType in
                 elementType.asArray
@@ -88,7 +95,7 @@ struct TypeMatcher {
                 TypeName.arrayContainer.asUsage
             }
         )?
-        .withOptional(!schema.required)
+        .withOptional(!schema.required || (supportNullableSchemas && schema.nullable))
     }
 
     /// Returns a Boolean value that indicates whether the schema

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
@@ -155,7 +155,7 @@ Supported features are always provided on _both_ client and server.
 - [x] description
 - [x] format
 - [ ] default
-- [ ] nullable (only in 3.0, removed in 3.1)
+- [x] nullable (only in 3.0, removed in 3.1, add `null` in `types` instead)
 - [x] discriminator
 - [ ] readOnly
 - [ ] writeOnly

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -101,6 +101,102 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testComponentsSchemasNullableStringProperty() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              MyObj:
+                type: object
+                properties:
+                  fooOptional:
+                    type: string
+                  fooRequired:
+                    type: string
+                  fooOptionalNullable:
+                    type: [string, null]
+                  fooRequiredNullable:
+                    type: [string, null]
+                required:
+                  - fooRequired
+                  - fooRequiredNullable
+            """,
+            """
+            public enum Schemas {
+                public struct MyObj: Codable, Hashable, Sendable {
+                    public var fooOptional: Swift.String?
+                    public var fooRequired: Swift.String
+                    public var fooOptionalNullable: Swift.String?
+                    public var fooRequiredNullable: Swift.String
+                    public init(
+                        fooOptional: Swift.String? = nil,
+                        fooRequired: Swift.String,
+                        fooOptionalNullable: Swift.String? = nil,
+                        fooRequiredNullable: Swift.String
+                    ) {
+                        self.fooOptional = fooOptional
+                        self.fooRequired = fooRequired
+                        self.fooOptionalNullable = fooOptionalNullable
+                        self.fooRequiredNullable = fooRequiredNullable
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case fooOptional
+                        case fooRequired
+                        case fooOptionalNullable
+                        case fooRequiredNullable
+                    }
+                }
+            }
+            """
+        )
+        try self.assertSchemasTranslation(
+            featureFlags: [.nullableSchemas],
+            """
+            schemas:
+              MyObj:
+                type: object
+                properties:
+                  fooOptional:
+                    type: string
+                  fooRequired:
+                    type: string
+                  fooOptionalNullable:
+                    type: [string, null]
+                  fooRequiredNullable:
+                    type: [string, null]
+                required:
+                  - fooRequired
+                  - fooRequiredNullable
+            """,
+            """
+            public enum Schemas {
+                public struct MyObj: Codable, Hashable, Sendable {
+                    public var fooOptional: Swift.String?
+                    public var fooRequired: Swift.String
+                    public var fooOptionalNullable: Swift.String?
+                    public var fooRequiredNullable: Swift.String?
+                    public init(
+                        fooOptional: Swift.String? = nil,
+                        fooRequired: Swift.String,
+                        fooOptionalNullable: Swift.String? = nil,
+                        fooRequiredNullable: Swift.String? = nil
+                    ) {
+                        self.fooOptional = fooOptional
+                        self.fooRequired = fooRequired
+                        self.fooOptionalNullable = fooOptionalNullable
+                        self.fooRequiredNullable = fooRequiredNullable
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case fooOptional
+                        case fooRequired
+                        case fooOptionalNullable
+                        case fooRequiredNullable
+                    }
+                }
+            }
+            """
+        )
+    }
+
     func testComponentsObjectNoAdditionalProperties() throws {
         try self.assertSchemasTranslation(
             """


### PR DESCRIPTION
### Motivation

Fixes #82.

More background:

In JSON Schema, there are two fields that affect what we represent as optionality in Swift.
1. In object schemas, not including a property in the `required` array.
2. In all schemas, marking the schema as nullable. In OpenAPI 3.0, that used to be done using a dedicated `nullable` field, in OpenAPI 3.1, that field is removed and instead the same result is achieved by adding the `null` type in the `type` array. So for a non-nullable string, you'd use `type: string`, and for a nullable string, you'd use `type: [string, null]`.

Up until now, we've only supported (1) in how we decide which types are generated as optional, and that seems to be how most adopters control nullability. However, (2) is also supported in JSON Schema, so we should also support it, and as evidenced by the comments in #82, a few folks have hit the lack of nullability support in Swift OpenAPI Generator.

### Modifications

This PR takes nullability on the schema into account when deciding whether to generate a type as optional or not.

Since this is a source-breaking change, it's introduced behind the feature flag `nullableSchemas`, and it'll become default behavior in 0.3.0.

Most of this change is just propagating the feature flag to the right place.

### Result

Marking a schema as nullable will result in an optional type being generated.

### Test Plan

Added a snippet test, both with and without the feature flag, which shows the change.
