### PR TITLE
Use per-type imports everywhere

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -73,37 +73,30 @@ struct TextBasedRenderer: RendererProtocol {
 
     /// Renders a single import statement.
     func renderImport(_ description: ImportDescription) -> String {
-        func render(moduleName: String, moduleTypes: [String]? = nil, spi: String?, preconcurrency: Bool) -> String {
-            let spiPrefix = spi.map { "@_spi(\($0)) " } ?? ""
+        func render(preconcurrency: Bool) -> String {
+            let spiPrefix = description.spi.map { "@_spi(\($0)) " } ?? ""
             let preconcurrencyPrefix = preconcurrency ? "@preconcurrency " : ""
             var types = [String]()
-            if let moduleTypes, preconcurrency {
+            if let moduleTypes = description.moduleTypes {
                 types = moduleTypes.map {
                     "\(preconcurrencyPrefix)\(spiPrefix)import \($0)"
                 }
                 return types.joinedLines()
             }
-            return "\(preconcurrencyPrefix)\(spiPrefix)import \(moduleName)"
+            return "\(preconcurrencyPrefix)\(spiPrefix)import \(description.moduleName)"
         }
 
         switch description.preconcurrency {
         case .always:
-            return render(moduleName: description.moduleName, spi: description.spi, preconcurrency: true)
+            return render(preconcurrency: true)
         case .never:
-            return render(moduleName: description.moduleName, spi: description.spi, preconcurrency: false)
+            return render(preconcurrency: false)
         case .onOS(let operatingSystems):
             var lines = [String]()
             lines.append("#if \(operatingSystems.map { "os(\($0))" }.joined(separator: " || "))")
-            lines.append(
-                render(
-                    moduleName: description.moduleName,
-                    moduleTypes: description.moduleTypes,
-                    spi: description.spi,
-                    preconcurrency: true
-                )
-            )
+            lines.append(render(preconcurrency: true))
             lines.append("#else")
-            lines.append(render(moduleName: description.moduleName, spi: description.spi, preconcurrency: false))
+            lines.append(render(preconcurrency: false))
             lines.append("#endif")
             return lines.joinedLines()
         }

--- a/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/ClientTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/ClientTranslator.swift
@@ -38,7 +38,6 @@ struct ClientFileTranslator: FileTranslator {
 
         let imports =
             Constants.File.imports
-            + Constants.Client.scopedImports
             + config.additionalImports
             .map { ImportDescription(moduleName: $0) }
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -25,7 +25,12 @@ enum Constants {
 
         /// The descriptions of modules imported by every generated file.
         static let imports: [ImportDescription] = [
-            ImportDescription(moduleName: "OpenAPIRuntime", spi: "Generated")
+            ImportDescription(moduleName: "OpenAPIRuntime", spi: "Generated"),
+            ImportDescription(
+                moduleName: "Foundation",
+                moduleTypes: ["struct Foundation.URL", "struct Foundation.Data", "struct Foundation.Date"],
+                preconcurrency: .onOS(["Linux"])
+            ),
         ]
     }
 
@@ -61,15 +66,6 @@ enum Constants {
     /// Constants related to the generated client type.
     enum Client {
 
-        /// An array of scoped imports specific to the `Client` namespace.
-        static let scopedImports: [ImportDescription] = [
-            ImportDescription(
-                moduleName: "Foundation",
-                moduleTypes: ["struct Foundation.URL", "struct Foundation.Data"],
-                preconcurrency: .onOS(["Linux"])
-            )
-        ]
-
         /// The name of the client type.
         static let typeName: String = "Client"
 
@@ -99,29 +95,8 @@ enum Constants {
         }
     }
 
-    enum Types {
-
-        /// An array of scoped imports specific to the `Types` namespace.
-        static let scopedImports: [ImportDescription] = [
-            ImportDescription(
-                moduleName: "Foundation",
-                moduleTypes: ["struct Foundation.URL", "struct Foundation.Data", "struct Foundation.Date"],
-                preconcurrency: .onOS(["Linux"])
-            )
-        ]
-    }
-
     /// Constants related to the generated server types.
     enum Server {
-
-        /// An array of scoped imports specific to the `Server` namespace.
-        static let scopedImports: [ImportDescription] = [
-            ImportDescription(
-                moduleName: "Foundation",
-                moduleTypes: ["struct Foundation.URL", "struct Foundation.Data"],
-                preconcurrency: .onOS(["Linux"])
-            )
-        ]
 
         /// Constants related to the universal server.
         enum Universal {

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
@@ -36,7 +36,6 @@ struct ServerFileTranslator: FileTranslator {
 
         let imports =
             Constants.File.imports
-            + Constants.Server.scopedImports
             + config.additionalImports
             .map { ImportDescription(moduleName: $0) }
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
@@ -38,7 +38,6 @@ struct TypesFileTranslator: FileTranslator {
 
         let imports =
             Constants.File.imports
-            + Constants.Types.scopedImports
             + config.additionalImports
             .map { ImportDescription(moduleName: $0) }
 

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -3,8 +3,11 @@
 #if os(Linux)
 @preconcurrency import struct Foundation.URL
 @preconcurrency import struct Foundation.Data
+@preconcurrency import struct Foundation.Date
 #else
-import Foundation
+import struct Foundation.URL
+import struct Foundation.Data
+import struct Foundation.Date
 #endif
 /// Service for managing pet metadata.
 ///

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -3,8 +3,11 @@
 #if os(Linux)
 @preconcurrency import struct Foundation.URL
 @preconcurrency import struct Foundation.Data
+@preconcurrency import struct Foundation.Date
 #else
-import Foundation
+import struct Foundation.URL
+import struct Foundation.Data
+import struct Foundation.Date
 #endif
 extension APIProtocol {
     /// Registers each operation handler with the provided transport.

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -5,7 +5,9 @@
 @preconcurrency import struct Foundation.Data
 @preconcurrency import struct Foundation.Date
 #else
-import Foundation
+import struct Foundation.URL
+import struct Foundation.Data
+import struct Foundation.Date
 #endif
 /// A type that performs HTTP operations defined by the OpenAPI document.
 public protocol APIProtocol: Sendable {


### PR DESCRIPTION
### Motivation

The PR #184 broke the build when Foundation.Date was used in specific locations on client/server.

### Modifications

Fixed the bug, but also made things even more consistent by using per-type imports on all platforms.

### Result

All the necessary Foundation imports are now present, plus code got simplified a bit.

### Test Plan

Now that all platforms emit the same imports (except for the `@preconcurrency` attribute), it's easier to catch similar issues even during local dev. Verified on a sample proj this now works correctly.

Updated reference tests.
