### PR TITLE
Bump OpenAPIKit to beta.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         // Read OpenAPI documents
         .package(
             url: "https://github.com/mattpolzin/OpenAPIKit.git",
-            exact: "3.0.0-beta.3"
+            exact: "3.0.0-beta.5"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",

--- a/Sources/_OpenAPIGeneratorCore/Parser/validateDoc.swift
+++ b/Sources/_OpenAPIGeneratorCore/Parser/validateDoc.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import OpenAPIKit
+
 /// Runs validation steps on the incoming OpenAPI document.
 /// - Parameters:
 ///   - doc: The OpenAPI document to validate.
@@ -27,7 +29,10 @@ func validateDoc(_ doc: ParsedOpenAPIRepresentation, config: Config) throws -> [
     // block the generator from running.
     // Validation errors continue to be fatal, such as
     // structural issues, like non-unique operationIds, etc.
-    let warnings = try doc.validate(strict: false)
+    let warnings = try doc.validate(
+        using: Validator().validating(.operationsContainResponses),
+        strict: false
+    )
     let diagnostics: [Diagnostic] = warnings.map { warning in
         .warning(
             message: "Validation warning: \(warning.description)",

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
@@ -123,7 +123,7 @@ final class Test_YamsParser: Test_Core {
             /foo.yaml: error: Found neither a $ref nor a PathItem in Document.paths['/system']. 
 
             PathItem could not be decoded because:
-            Expected to find `responses` key for the **GET** endpoint under `/system` but it is missing..
+            Inconsistency encountered when parsing `Vendor Extension` for the **GET** endpoint under `/system`: Found at least one vendor extension property that does not begin with the required 'x-' prefix. Invalid properties: [ resonance ]..
             """
         assertThrownError(try _test(yaml), expectedDiagnostic: expected)
     }
@@ -148,7 +148,8 @@ final class Test_YamsParser: Test_Core {
     ) {
         XCTAssertThrowsError(try closure(), file: file, line: line) { error in
             if let exitError = error as? Diagnostic {
-                XCTAssertEqual(exitError.localizedDescription, expectedDiagnostic, file: file, line: line)
+                let actualDiagnostic = exitError.localizedDescription
+                XCTAssertEqual(actualDiagnostic, expectedDiagnostic, file: file, line: line)
             } else {
                 XCTFail("Thrown error is \(type(of: error)) but should be Diagnostic", file: file, line: line)
             }


### PR DESCRIPTION
### Motivation

OpenAPIKit is getting ready to tag a 3.0.0 release candidate, so we need to keep on the latest version and ensure it works for us.

### Modifications

Bumped from beta.3 to beta.5, contains some new features like `const` support.

Adapted to the slight changes in behavior.

### Result

Now using the latest version.

### Test Plan

All tests pass again.
