### PR TITLE
[Generator] Fix nested coding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,7 +80,7 @@ let package = Package(
         // Tests-only: Runtime library linked by generated code, and also
         // helps keep the runtime library new enough to work with the generated
         // code.
-        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.2.2")),
 
         // Build and preview docs
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
@@ -41,7 +41,7 @@ extension FileTranslator {
         type: AllOrAnyOf,
         schemas: [JSONSchema]
     ) throws -> Declaration {
-        let properties: [PropertyBlueprint] =
+        let properties: [(property: PropertyBlueprint, isKeyValuePair: Bool)] =
             try schemas
             .enumerated()
             .map { index, schema in
@@ -75,23 +75,30 @@ extension FileTranslator {
                 } else {
                     associatedDeclarations = []
                 }
-                return PropertyBlueprint(
+                let blueprint = PropertyBlueprint(
                     comment: comment,
                     originalName: key,
                     typeUsage: propertyType,
                     associatedDeclarations: associatedDeclarations,
                     asSwiftSafeName: swiftSafeName
                 )
+                let isKeyValuePairSchema = try TypeMatcher.isKeyValuePair(
+                    schema,
+                    components: components
+                )
+                return (blueprint, isKeyValuePairSchema)
             }
         let comment: Comment? =
             typeName
             .docCommentWithUserDescription(openAPIDescription)
+        let isKeyValuePairValues = properties.map(\.isKeyValuePair)
+        let propertyValues = properties.map(\.property)
         let codableStrategy: StructBlueprint.OpenAPICodableStrategy
         switch type {
         case .allOf:
-            codableStrategy = .allOf
+            codableStrategy = .allOf(propertiesIsKeyValuePairSchema: isKeyValuePairValues)
         case .anyOf:
-            codableStrategy = .anyOf
+            codableStrategy = .anyOf(propertiesIsKeyValuePairSchema: isKeyValuePairValues)
         }
         let structDecl = translateStructBlueprint(
             .init(
@@ -101,7 +108,7 @@ extension FileTranslator {
                 conformances: Constants.ObjectStruct.conformances,
                 shouldGenerateCodingKeys: false,
                 codableStrategy: codableStrategy,
-                properties: properties
+                properties: propertyValues
             )
         )
         return structDecl
@@ -124,7 +131,7 @@ extension FileTranslator {
         discriminator: OpenAPI.Discriminator?,
         schemas: [JSONSchema]
     ) throws -> Declaration {
-        let cases: [(String, [String]?, Comment?, TypeUsage, [Declaration])]
+        let cases: [(String, [String]?, Bool, Comment?, TypeUsage, [Declaration])]
         if let discriminator {
             // > When using the discriminator, inline schemas will not be considered.
             // > — https://spec.openapis.org/oas/v3.0.3#discriminator-object
@@ -147,7 +154,7 @@ extension FileTranslator {
                     parent: typeName
                 )
                 let caseName = safeSwiftNameForOneOfMappedType(mappedType)
-                return (caseName, mappedType.rawNames, comment, mappedType.typeName.asUsage, [])
+                return (caseName, mappedType.rawNames, true, comment, mappedType.typeName.asUsage, [])
             }
         } else {
             cases = try schemas.enumerated()
@@ -183,12 +190,16 @@ extension FileTranslator {
                     } else {
                         associatedDeclarations = []
                     }
-                    return (caseName, nil, comment, childType, associatedDeclarations)
+                    let isKeyValuePair = try TypeMatcher.isKeyValuePair(
+                        schema,
+                        components: components
+                    )
+                    return (caseName, nil, isKeyValuePair, comment, childType, associatedDeclarations)
                 }
         }
 
         let caseDecls: [Declaration] = cases.flatMap { caseInfo in
-            let (caseName, _, comment, childType, associatedDeclarations) = caseInfo
+            let (caseName, _, _, comment, childType, associatedDeclarations) = caseInfo
             return associatedDeclarations + [
                 .commentable(
                     comment,
@@ -204,8 +215,6 @@ extension FileTranslator {
                 )
             ]
         }
-
-        let caseNames = cases.map(\.0)
 
         let codingKeysDecls: [Declaration]
         let decoder: Declaration
@@ -232,11 +241,11 @@ extension FileTranslator {
         } else {
             codingKeysDecls = []
             decoder = translateOneOfWithoutDiscriminatorDecoder(
-                caseNames: caseNames
+                cases: cases.map { ($0.0, $0.2) }
             )
         }
 
-        let encoder = translateOneOfEncoder(caseNames: caseNames)
+        let encoder = translateOneOfEncoder(cases: cases.map { ($0.0, $0.2) })
 
         let comment: Comment? =
             typeName

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
@@ -63,11 +63,11 @@ struct StructBlueprint {
 
         /// A Codable implementation for allOf, where all of the child
         /// property types get encoded into the top level keyed container.
-        case allOf
+        case allOf(propertiesIsKeyValuePairSchema: [Bool])
 
         /// A Codable implementation for anyOf, where one or more of the child
         /// property types get encoded into the top level keyed container.
-        case anyOf
+        case anyOf(propertiesIsKeyValuePairSchema: [Bool])
     }
 
     /// The kind of Codable implementation used for the structure.

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
@@ -210,16 +210,32 @@ extension FileTranslator {
     /// - Parameter schema: A schemas to check.
     func isObjectishSchemaAndSupported(_ schema: JSONSchema) throws -> IsSchemaSupportedResult {
         switch schema.value {
-        case .object, .reference:
+        case .object:
             return try isSchemaSupported(schema)
+        case .reference:
+            return try isRefToObjectishSchemaAndSupported(schema)
         case .all(of: let schemas, _), .any(of: let schemas, _), .one(of: let schemas, _):
-            return try areSchemasSupported(schemas)
+            return try areObjectishSchemasAndSupported(schemas)
         default:
             return .unsupported(
                 reason: .notObjectish,
                 schema: schema
             )
         }
+    }
+
+    /// Returns a result indicating whether the provided schemas
+    /// are object-ish schemas and supported.
+    /// - Parameter schemas: Schemas to check.
+    /// - Returns: `.supported` if all schemas match; `.unsupported` otherwise.
+    func areObjectishSchemasAndSupported(_ schemas: [JSONSchema]) throws -> IsSchemaSupportedResult {
+        for schema in schemas {
+            let result = try isObjectishSchemaAndSupported(schema)
+            guard result == .supported else {
+                return result
+            }
+        }
+        return .supported
     }
 
     /// Returns a result indicating whether the provided schemas

--- a/Sources/swift-openapi-generator/Documentation.docc/Development/Documentation-for-maintainers.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Development/Documentation-for-maintainers.md
@@ -11,3 +11,4 @@ Use the resources below if you'd like to learn more about how the generator work
 ## Topics
 
 - <doc:Converting-between-data-and-Swift-types>
+- <doc:Generating-custom-Codable-conformance-methods>

--- a/Sources/swift-openapi-generator/Documentation.docc/Development/Generating-custom-Codable-conformance-methods.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Development/Generating-custom-Codable-conformance-methods.md
@@ -1,0 +1,108 @@
+# Generating custom Codable implementations
+
+Learn about when and how the generator emits a custom Codable implementation.
+
+## Overview
+
+As much as possible, the generator tries to rely on the [compiler-synthesized](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types#2904055) implementation of Codable requirements:
+- [`init(from: Decoder) throws`](https://developer.apple.com/documentation/swift/decodable/init(from:)-8ezpn)
+- [`func encode(to: Encoder) throws`](https://developer.apple.com/documentation/swift/encodable/encode(to:)-7ibwv)
+
+The synthesized implementation is used as-is for:
+- primitive types, such as `String`, `Int`, `Double`, and `Bool`
+- string and integer-backed enums
+- arrays of other Codable types
+- structs generated for `object` schemas with no `additionalProperties` customization
+
+However, a custom Codable implementation is emitted for the following types:
+- structs generated for `object` schemas with `additionalProperties` customized
+- structs generated for `allOf` and `anyOf` schemas
+- enums with associated values generated for `oneOf` schemas
+
+This document goes into detail about each of these types, explains why a custom Codable implementation is needed, and how it works.
+
+> Tip: To check out a concrete example of generated Codable conformances, inspect the file-based reference tests, which contain realistic examples of generated code for various schemas. 
+
+### Object structs with additional properties
+
+An [`object` schema](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.1) can have the [`additionalProperties`](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.3.2.3) key, which documents how any properties _not_ documented in the `properties` key should be handled.
+
+1. When the `additionalProperties` key is unspecified in an object schema, no custom Codable implementation is emitted and the generator lets the Swift compiler synthesize one based on the stored properties.
+    - Custom decoder: no
+    - Custom encoder: no
+2. When `additionalProperties: false`, any additional properties are forbidden.
+    - Custom decoder: yes, it decodes documented properties and then throws an error if any unknown properties are detected.
+    - Custom encoder: no, since there is no storage to put them, so the user could not have accidentally created such an value of the struct, and there is no need to perform additional validation on encoding.
+3. When `additionalProperties: true`, an extra property called `additionalProperties` of type `OpenAPIRuntime.OpenAPIObjectContainer` is generated on the struct, in addition to any documented stored properties.
+    - Custom decoder: yes, it decodes documented properties and then collects all unknown properties into the `additionalProperties` property, which is a key-value dictionary with untyped values.
+    - Custom encoder: yes, it encodes all documented and additional properties.
+4. When `additionalProperties: {type: ...}`, for example `{type: integer}`, all unknown properties must have an integer value. An extra property called `additionalProperties` of type (for example) `[String: Int]` is generated on the struct, in addition to any documented stored properties.
+    - Custom decoder: yes, similar to 3., with the difference that values are validated to be of the specified type (for example, `Int`).
+    - Custom encoder, yes, same as 3.
+
+### Structs for allOf and anyOf
+
+The [`allOf`](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.1) and [`anyOf`](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.2) schemas include one or more subschemas that all (for `allOf`) or at least one (for `anyOf`) need to be decodable from the underlying value.
+
+These schemas are generated as a struct where each property maps to one subschema.
+
+For `allOf`, all properties are required, and for `anyOf`, all properties are optional.
+
+Since the subschemas are all using the same top level container for coding, the synthesized Codable implementation cannot be used and the generator always emits custom methods for coding.
+
+An important concept referenced below is of a "key-value pair schema". A key-value pair schema is defined as one of:
+- `object`
+- `allOf` where all subschemas are also key-value pair schemas
+- `anyOf` or `oneOf` where at least one subschema is also a key-value pair schema
+
+The reason we make the distinction between key-value pair schemas and other schemas is because key-value pair schemas can be safely combined (you can merge two dictionaries), but other schemas cannot be safely combined (there's no way to combine two strings, or an integer and an array, and so on). Common Swift coders, such as JSONEncoder and JSONDecoder require that we use the right methods, as you, for example, cannot encode into a single value container more than once.
+
+The custom Codable implementations work as follows:
+
+- `allOf`:
+    - Custom decoder: yes, for key-value pair schemas uses `init(from:)` of the type directly, for others decodes from a single value container.
+    - Custom encoder: yes, only encodes the first non-key-value pair schema using a single value container (reason: encoding any additional one would overwrite the first value, and the different values should persist to the same exact bytes on the wire, so only encoding the first one is safe). If no non-key-value pair subschemas are present, encodes all the key-value pair subschemas using their `encoder(to:)` method directly. (Note that an `allOf` that has both non-key-value pair and key-value pair subschemas are not valid, as it's not possible, for example, for something to be _both_ a string and a dictionary.)
+- `anyOf`:
+    - Custom decoder: yes, for key-value pair schemas uses `init(from:)` of the type directly, for others decodes from a single value container. The decoding is graceful, in other words any failure is turned into a nil result. But, to ensure a valid `anyOf`, at the end it validates that at least one subschema decoded successfully, otherwise throws an error.
+    - Custom encoder: yes, only encodes the first _non-nil_ non-key-value pair schema using a single value container (similar to the `allOf` encoder above), then it encodes all the key-value pair subschemas using their `encoder(to:)` method directly. Note that only if all of the non-key-value pair schemas were nil will it actually encode the key-value pairs, again because an `anyOf` cannot be simultaneously a single value schema (for example, a string) and a key-value pair schema (for example, a dictionary). 
+
+### Enums for oneOf
+
+A [`oneOf`](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.3) schema represents a payload that matches exactly one subschema (but not more).
+
+In Swift, the generator emits an enum with associated values, which matches the JSON Schema semantics.
+
+There are two groups of oneOf schemas, which require different handling - based on whether a _discriminator_ is present.
+
+A [discriminator](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminator-object) is one value in the payload that encodes the name of the schema that should be used to encode and decode the payload. While normally JSON payloads are _not_ self-describing (in other words, the code needs to know which type-safe object to decode the value into upfront), including a discriminator allows for heterogeneous collections and decoding based on this dynamic value - making the payload self-describing.
+
+Including a discriminator restricts the subschemas to be object-ish (objects and allOf/anyOf/oneOf of object-ish subschemas) schemas, as no other schemas can have properties, and a discriminator is always a property. However, it allows direct decoding, so instead of trying to decode the payload using each subschema, one by one, until one succeeds, the discriminator tells the decoder which type to use for decoding.
+
+| Has discriminator | Allowed subschemas | Decoding |
+| ----------------- | ------------------ | -------- |
+| Yes | Only object-ish | Direct |
+| No | All | Try one-by-one |
+
+The rule of thumb is roughly as follows:
+- If needing to include non-object-ish schemas in a oneOf, don't use a discriminator.
+- If only including object-ish schemas, use a discriminator
+    - while not required, it is recommended for better performance and debugging.
+    - it also allows having multiple schemas that would successfully validate from the payload, but without a discriminator would fail to be a valid oneOf, where exactly one schema must validate (but not more).
+
+#### oneOf without a discriminator
+
+- Custom decoder: yes, tries to decode each subschema one-by-one, and stops when one validates correctly. For decoding the subschemas, it uses the same rules as allOf/anyOf, where key-value pair schemas are decoded directly using `init(from:)`, and other schemas are decoded from a single value container.
+- Custom encoder: yes, a switch statement over the schema and only encodes the value matching the case of the enum, again, using the direct `encode(to:)` method for key-value pair schemas, and a single value container for all other schemas.
+
+#### oneOf with a discriminator
+
+- Custom decoder: yes, performs decoding in two stages. First, decodes the discriminator property value to identify the Swift type to decode the full payload into. Then switches over the discriminator value and decodes the full payload using the chosen type. Since oneOf enums with a discriminator always contain object-ish schemas, which are key-value pair schemas, uses the direct `init(from:)` decoding initializer.
+- Custom encoder: yes, same as oneOf without a discriminator, but always uses `encode(to:)` because only key-value pair schemas are ever used here.
+
+### A note on Foundation.Date
+
+While `Foundation.Date` technically conforms to `Codable`, it's not really codable on its own, as the method for coding is customizable by JSONEncoder/JSONDecoder (and other coders) using `dateEncodingStrategy`.
+
+This means that you cannot use Date's `init(from:)` and `encode(to:)` methods directly, otherwise you always get the default date encoding, which uses a `Double` - not what you usually want (ISO 8601 is more widely used).
+
+Having to go through the container, which goes through the coder's customized Date coding strategy is part of the reason behind some of the complexity above and why we need to make the distinction between "key-value pair schemas" and others.

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -256,6 +256,24 @@ components:
           type: string
         kind:
           $ref: '#/components/schemas/PetKind'
+    MixedAnyOf:
+      anyOf:
+        - type: string
+          format: date-time
+        - $ref: '#/components/schemas/PetKind'
+        - $ref: "#/components/schemas/Pet"
+        - type: string
+    MixedOneOf:
+      oneOf:
+        - type: string
+          format: date-time
+        - $ref: '#/components/schemas/PetKind'
+        - $ref: "#/components/schemas/Pet"
+    MixedAllOfPrimitive:
+      allOf:
+        - type: string
+          format: date-time
+        - type: string
     PetKind:
       type: string
       description: "Kind of pet"

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -96,6 +96,102 @@ public enum Components {
                 case kind
             }
         }
+        /// - Remark: Generated from `#/components/schemas/MixedAnyOf`.
+        public struct MixedAnyOf: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value1`.
+            public var value1: Foundation.Date?
+            /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value2`.
+            public var value2: Components.Schemas.PetKind?
+            /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value3`.
+            public var value3: Components.Schemas.Pet?
+            /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value4`.
+            public var value4: Swift.String?
+            /// Creates a new `MixedAnyOf`.
+            ///
+            /// - Parameters:
+            ///   - value1:
+            ///   - value2:
+            ///   - value3:
+            ///   - value4:
+            public init(
+                value1: Foundation.Date? = nil,
+                value2: Components.Schemas.PetKind? = nil,
+                value3: Components.Schemas.Pet? = nil,
+                value4: Swift.String? = nil
+            ) {
+                self.value1 = value1
+                self.value2 = value2
+                self.value3 = value3
+                self.value4 = value4
+            }
+            public init(from decoder: any Decoder) throws {
+                value1 = try? decoder.decodeFromSingleValueContainer()
+                value2 = try? decoder.decodeFromSingleValueContainer()
+                value3 = try? .init(from: decoder)
+                value4 = try? decoder.decodeFromSingleValueContainer()
+                try DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                    [value1, value2, value3, value4],
+                    type: Self.self,
+                    codingPath: decoder.codingPath
+                )
+            }
+            public func encode(to encoder: any Encoder) throws {
+                try encoder.encodeFirstNonNilValueToSingleValueContainer([value1, value2, value4])
+                try value3?.encode(to: encoder)
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/MixedOneOf`.
+        @frozen public enum MixedOneOf: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/MixedOneOf/case1`.
+            case case1(Foundation.Date)
+            /// - Remark: Generated from `#/components/schemas/MixedOneOf/case2`.
+            case PetKind(Components.Schemas.PetKind)
+            /// - Remark: Generated from `#/components/schemas/MixedOneOf/case3`.
+            case Pet(Components.Schemas.Pet)
+            public init(from decoder: any Decoder) throws {
+                do {
+                    self = .case1(try decoder.decodeFromSingleValueContainer())
+                    return
+                } catch {}
+                do {
+                    self = .PetKind(try decoder.decodeFromSingleValueContainer())
+                    return
+                } catch {}
+                do {
+                    self = .Pet(try .init(from: decoder))
+                    return
+                } catch {}
+                throw DecodingError.failedToDecodeOneOfSchema(type: Self.self, codingPath: decoder.codingPath)
+            }
+            public func encode(to encoder: any Encoder) throws {
+                switch self {
+                case let .case1(value): try encoder.encodeToSingleValueContainer(value)
+                case let .PetKind(value): try encoder.encodeToSingleValueContainer(value)
+                case let .Pet(value): try value.encode(to: encoder)
+                }
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/MixedAllOfPrimitive`.
+        public struct MixedAllOfPrimitive: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/MixedAllOfPrimitive/value1`.
+            public var value1: Foundation.Date
+            /// - Remark: Generated from `#/components/schemas/MixedAllOfPrimitive/value2`.
+            public var value2: Swift.String
+            /// Creates a new `MixedAllOfPrimitive`.
+            ///
+            /// - Parameters:
+            ///   - value1:
+            ///   - value2:
+            public init(value1: Foundation.Date, value2: Swift.String) {
+                self.value1 = value1
+                self.value2 = value2
+            }
+            public init(from decoder: any Decoder) throws {
+                value1 = try decoder.decodeFromSingleValueContainer()
+                value2 = try decoder.decodeFromSingleValueContainer()
+            }
+            public func encode(to encoder: any Encoder) throws { try encoder.encodeToSingleValueContainer(value1) }
+        }
         /// Kind of pet
         ///
         /// - Remark: Generated from `#/components/schemas/PetKind`.
@@ -377,11 +473,11 @@ public enum Components {
             case case4(Components.Schemas.OneOfAny.Case4Payload)
             public init(from decoder: any Decoder) throws {
                 do {
-                    self = .case1(try .init(from: decoder))
+                    self = .case1(try decoder.decodeFromSingleValueContainer())
                     return
                 } catch {}
                 do {
-                    self = .case2(try .init(from: decoder))
+                    self = .case2(try decoder.decodeFromSingleValueContainer())
                     return
                 } catch {}
                 do {
@@ -396,8 +492,8 @@ public enum Components {
             }
             public func encode(to encoder: any Encoder) throws {
                 switch self {
-                case let .case1(value): try value.encode(to: encoder)
-                case let .case2(value): try value.encode(to: encoder)
+                case let .case1(value): try encoder.encodeToSingleValueContainer(value)
+                case let .case2(value): try encoder.encodeToSingleValueContainer(value)
                 case let .CodeError(value): try value.encode(to: encoder)
                 case let .case4(value): try value.encode(to: encoder)
                 }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -348,15 +348,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public init(from decoder: any Decoder) throws {
                         value1 = try .init(from: decoder)
                         value2 = try .init(from: decoder)
-                        value3 = try .init(from: decoder)
-                        value4 = try .init(from: decoder)
+                        value3 = try decoder.decodeFromSingleValueContainer()
+                        value4 = try decoder.decodeFromSingleValueContainer()
                     }
-                    public func encode(to encoder: any Encoder) throws {
-                        try value1.encode(to: encoder)
-                        try value2.encode(to: encoder)
-                        try value3.encode(to: encoder)
-                        try value4.encode(to: encoder)
-                    }
+                    public func encode(to encoder: any Encoder) throws { try encoder.encodeToSingleValueContainer(value3) }
                 }
             }
             """
@@ -401,8 +396,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public init(from decoder: any Decoder) throws {
                         value1 = try? .init(from: decoder)
                         value2 = try? .init(from: decoder)
-                        value3 = try? .init(from: decoder)
-                        value4 = try? .init(from: decoder)
+                        value3 = try? decoder.decodeFromSingleValueContainer()
+                        value4 = try? decoder.decodeFromSingleValueContainer()
                         try DecodingError.verifyAtLeastOneSchemaIsNotNil(
                             [value1, value2, value3, value4],
                             type: Self.self,
@@ -410,10 +405,9 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         )
                     }
                     public func encode(to encoder: any Encoder) throws {
+                        try encoder.encodeFirstNonNilValueToSingleValueContainer([value3, value4])
                         try value1?.encode(to: encoder)
                         try value2?.encode(to: encoder)
-                        try value3?.encode(to: encoder)
-                        try value4?.encode(to: encoder)
                     }
                 }
             }
@@ -591,11 +585,11 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     case A(Components.Schemas.A)
                     public init(from decoder: any Decoder) throws {
                         do {
-                            self = .case1(try .init(from: decoder))
+                            self = .case1(try decoder.decodeFromSingleValueContainer())
                             return
                         } catch {}
                         do {
-                            self = .case2(try .init(from: decoder))
+                            self = .case2(try decoder.decodeFromSingleValueContainer())
                             return
                         } catch {}
                         do {
@@ -609,8 +603,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     }
                     public func encode(to encoder: any Encoder) throws {
                         switch self {
-                        case let .case1(value): try value.encode(to: encoder)
-                        case let .case2(value): try value.encode(to: encoder)
+                        case let .case1(value): try encoder.encodeToSingleValueContainer(value)
+                        case let .case2(value): try encoder.encodeToSingleValueContainer(value)
                         case let .A(value): try value.encode(to: encoder)
                         }
                     }
@@ -650,11 +644,11 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         case A(Components.Schemas.A)
                         public init(from decoder: any Decoder) throws {
                             do {
-                                self = .case1(try .init(from: decoder))
+                                self = .case1(try decoder.decodeFromSingleValueContainer())
                                 return
                             } catch {}
                             do {
-                                self = .case2(try .init(from: decoder))
+                                self = .case2(try decoder.decodeFromSingleValueContainer())
                                 return
                             } catch {}
                             do {
@@ -668,8 +662,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         }
                         public func encode(to encoder: any Encoder) throws {
                             switch self {
-                            case let .case1(value): try value.encode(to: encoder)
-                            case let .case2(value): try value.encode(to: encoder)
+                            case let .case1(value): try encoder.encodeToSingleValueContainer(value)
+                            case let .case2(value): try encoder.encodeToSingleValueContainer(value)
                             case let .A(value): try value.encode(to: encoder)
                             }
                         }
@@ -720,12 +714,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public init(value1: Components.Schemas.A) {
                         self.value1 = value1
                     }
-                    public init(from decoder: any Decoder) throws {
-                        value1 = try .init(from: decoder)
-                    }
-                    public func encode(to encoder: any Encoder) throws {
-                        try value1.encode(to: encoder)
-                    }
+                    public init(from decoder: any Decoder) throws { value1 = try decoder.decodeFromSingleValueContainer() }
+                    public func encode(to encoder: any Encoder) throws { try encoder.encodeToSingleValueContainer(value1) }
                 }
             }
             """
@@ -754,8 +744,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public struct cPayload: Codable, Hashable, Sendable {
                         public var value1: Components.Schemas.A
                         public init(value1: Components.Schemas.A) { self.value1 = value1 }
-                        public init(from decoder: any Decoder) throws { value1 = try .init(from: decoder) }
-                        public func encode(to encoder: any Encoder) throws { try value1.encode(to: encoder) }
+                        public init(from decoder: any Decoder) throws { value1 = try decoder.decodeFromSingleValueContainer() }
+                        public func encode(to encoder: any Encoder) throws { try encoder.encodeToSingleValueContainer(value1) }
                     }
                     public var c: Components.Schemas.B.cPayload
                     public init(c: Components.Schemas.B.cPayload) { self.c = c }
@@ -787,8 +777,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public struct cPayload: Codable, Hashable, Sendable {
                         public var value1: Components.Schemas.A
                         public init(value1: Components.Schemas.A) { self.value1 = value1 }
-                        public init(from decoder: any Decoder) throws { value1 = try .init(from: decoder) }
-                        public func encode(to encoder: any Encoder) throws { try value1.encode(to: encoder) }
+                        public init(from decoder: any Decoder) throws { value1 = try decoder.decodeFromSingleValueContainer() }
+                        public func encode(to encoder: any Encoder) throws { try encoder.encodeToSingleValueContainer(value1) }
                     }
                     public var c: Components.Schemas.B.cPayload?
                     public init(c: Components.Schemas.B.cPayload? = nil) { self.c = c }
@@ -877,8 +867,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         self.value2 = value2
                     }
                     public init(from decoder: any Decoder) throws {
-                        value1 = try? .init(from: decoder)
-                        value2 = try? .init(from: decoder)
+                        value1 = try? decoder.decodeFromSingleValueContainer()
+                        value2 = try? decoder.decodeFromSingleValueContainer()
                         try DecodingError.verifyAtLeastOneSchemaIsNotNil(
                             [value1, value2],
                             type: Self.self,
@@ -886,8 +876,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         )
                     }
                     public func encode(to encoder: any Encoder) throws {
-                        try value1?.encode(to: encoder)
-                        try value2?.encode(to: encoder)
+                        try encoder.encodeFirstNonNilValueToSingleValueContainer([value1, value2])
                     }
                 }
             }

--- a/Tests/PetstoreConsumerTests/Test_Types.swift
+++ b/Tests/PetstoreConsumerTests/Test_Types.swift
@@ -43,11 +43,16 @@ final class Test_Types: XCTestCase {
     }
 
     var testEncoder: JSONEncoder {
-        .init()
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
     }
 
     var testDecoder: JSONDecoder {
-        .init()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
     }
 
     func roundtrip<T: Codable & Equatable>(_ value: T) throws -> T {
@@ -131,13 +136,9 @@ final class Test_Types: XCTestCase {
             file: StaticString = #file,
             line: UInt = #line
         ) throws {
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            let data = try encoder.encode(value)
+            let data = try testEncoder.encode(value)
             XCTAssertEqual(String(decoding: data, as: UTF8.self), expectedJSON, file: file, line: line)
-            let decodedValue = try decoder.decode(T.self, from: data)
+            let decodedValue = try testDecoder.decode(T.self, from: data)
             XCTAssertEqual(decodedValue, value, file: file, line: line)
         }
 

--- a/Tests/PetstoreConsumerTests/Test_Types.swift
+++ b/Tests/PetstoreConsumerTests/Test_Types.swift
@@ -124,6 +124,72 @@ final class Test_Types: XCTestCase {
         )
     }
 
+    func testAllAnyOneOf_withDate_roundtrip() throws {
+        func testJSON<T: Codable & Equatable>(
+            _ value: T,
+            expectedJSON: String,
+            file: StaticString = #file,
+            line: UInt = #line
+        ) throws {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let data = try encoder.encode(value)
+            XCTAssertEqual(String(decoding: data, as: UTF8.self), expectedJSON, file: file, line: line)
+            let decodedValue = try decoder.decode(T.self, from: data)
+            XCTAssertEqual(decodedValue, value, file: file, line: line)
+        }
+
+        try testJSON(
+            Components.Schemas.MixedAnyOf(
+                value1: Date(timeIntervalSince1970: 1_674_036_251),
+                value4: #"2023-01-18T10:04:11Z"#
+            ),
+            expectedJSON: #""2023-01-18T10:04:11Z""#
+        )
+        try testJSON(
+            Components.Schemas.MixedAnyOf(
+                value2: .BIG_ELEPHANT_1,
+                value4: #"BIG_ELEPHANT_1"#
+            ),
+            expectedJSON: #""BIG_ELEPHANT_1""#
+        )
+        try testJSON(
+            Components.Schemas.MixedAnyOf(
+                value3: .init(id: 1, name: "Fluffz")
+            ),
+            expectedJSON: #"{"id":1,"name":"Fluffz"}"#
+        )
+
+        try testJSON(
+            Components.Schemas.MixedOneOf.case1(
+                Date(timeIntervalSince1970: 1_674_036_251)
+            ),
+            expectedJSON: #""2023-01-18T10:04:11Z""#
+        )
+        try testJSON(
+            Components.Schemas.MixedOneOf.PetKind(
+                .BIG_ELEPHANT_1
+            ),
+            expectedJSON: #""BIG_ELEPHANT_1""#
+        )
+        try testJSON(
+            Components.Schemas.MixedOneOf.Pet(
+                .init(id: 1, name: "Fluffz")
+            ),
+            expectedJSON: #"{"id":1,"name":"Fluffz"}"#
+        )
+
+        try testJSON(
+            Components.Schemas.MixedAllOfPrimitive(
+                value1: Date(timeIntervalSince1970: 1_674_036_251),
+                value2: #"2023-01-18T10:04:11Z"#
+            ),
+            expectedJSON: #""2023-01-18T10:04:11Z""#
+        )
+    }
+
     func testAllOf_missingProperty() throws {
         XCTAssertThrowsError(
             try testDecoder.decode(


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/263. Depends on https://github.com/apple/swift-openapi-runtime/pull/50.

### Modifications

This started as a "simple" fix for Date coding, which was broken when nested in oneOf/allOf/anyOf, and resulted in a refactoring of how we generate custom Codable implementations.

I wrote it up in a new article for maintainers, that has all the detail that should explain this PR: https://github.com/apple/swift-openapi-generator/blob/d735ac18354cee03bd3b087e229948593394e9c0/Sources/swift-openapi-generator/Documentation.docc/Development/Generating-custom-Codable-conformance-methods.md

### Result

Now Dates are correctly encoded/decoded even when nested in oneOf/allOf/anyOf.

### Test Plan

Updated reference tests to cover more of these tricky cases (that's why they were added to the file-based reference tests), updated snippet tests as well, and unit tests.

Verified that the motivating use case - the k8s API, now parses responses correctly when Dates are nested in allOf.
