### PR TITLE
Escape negative numbers in integer-backed enums

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
@@ -61,7 +61,7 @@ extension FileTranslator {
                     guard let rawValue = anyValue as? Int else {
                         throw GenericError(message: "Disallowed value for an integer enum '\(typeName)': \(anyValue)")
                     }
-                    let caseName = "_\(rawValue)"
+                    let caseName = rawValue < 0 ? "n\(abs(rawValue))" : "_\(rawValue)"
                     return (caseName, .int(rawValue))
                 }
             }

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
@@ -61,7 +61,7 @@ extension FileTranslator {
                     guard let rawValue = anyValue as? Int else {
                         throw GenericError(message: "Disallowed value for an integer enum '\(typeName)': \(anyValue)")
                     }
-                    let caseName = rawValue < 0 ? "n\(abs(rawValue))" : "_\(rawValue)"
+                    let caseName = rawValue < 0 ? "_n\(abs(rawValue))" : "_\(rawValue)"
                     return (caseName, .int(rawValue))
                 }
             }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStringEnum.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateStringEnum.swift
@@ -38,6 +38,16 @@ final class Test_translateStringEnum: Test_Core {
         XCTAssertEqual(names, ["a", "_empty"])
     }
 
+    func testCaseValuesForIntegerSchema() throws {
+        let names = try _caseValues(
+            .integer(
+                allowedValues: -1,
+                1
+            )
+        )
+        XCTAssertEqual(names, ["_n1", "_1"])
+    }
+
     func _caseValues(_ schema: JSONSchema) throws -> [String] {
         self.continueAfterFailure = false
         let translator = makeTypesTranslator()


### PR DESCRIPTION
### Motivation

Fixes #265

### Modifications

When handling a negative number, it takes its absolute value and add 'n' before it

### Result

Example: "-1" -> "n1"

### Test Plan

Ran and passed all the tests