### PR TITLE
Run integration test in $TMPDIR or /tmp

### DIFF
--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -24,7 +24,7 @@ JQ_BIN=${JQ_BIN:-$(command -v jq)} || fatal "JQ_BIN unset and no jq on PATH"
 
 CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
-TMP_DIR=$(mktemp -d "${PWD}/tmp.$(basename "$0").XXXXXXXXXX.noindex")
+TMP_DIR=$(/usr/bin/mktemp -d -p "${TMPDIR-/tmp}" "$(basename "$0").XXXXXXXXXX")
 
 PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
 


### PR DESCRIPTION
### Motivation

Our CI workspace is filling up with integration test runs. This is because they are created in a temporary directory _within_ the current working directory. 

### Modifications

In the integration test script, do everything under `$TMPDIR` or `/tmp`, if `$TMPDIR` is unset.

Note that this script needs to run on macOS and Linux so we have used a set of arguments to `mktemp` which results in similar behaviour on both platforms:

```
# macOS
❯ mktemp -u -d -p ${TMPDIR-/tmp} d.XXXXXX
/var/folders/06/__qdhxzn7ld3_bsvfcfz0kch0000gn/T//d.HLKbxa

❯ export TMPDIR=/tmp

❯ mktemp -u -d -p ${TMPDIR-/tmp} d.XXXXXX
/tmp/d.VcrPx7
```

```
# Linux
root@c548c02e41b1:/code# mktemp -u -d -p ${TMPDIR-/tmp} d.XXXXXX
/tmp/d.cfDcwc
root@c548c02e41b1:/code# export TMPDIR=/var/tmp
root@c548c02e41b1:/code# mktemp -u -d -p ${TMPDIR-/tmp} d.XXXXXX
/var/tmp/d.aah3FR
```

Note also that, on macOS, the `XXXXXX` needs to be at the end, so we've had to stop adding `.noindex` to the end of the directory name.

### Result

No longer clogging up CI workspace with integration test builds.

### Test Plan

Tested locally and in `docker-compose`:

```
# docker-compose logs
** Checking required executables...
** Cloning file:///code to /tmp/run-integration-test.sh.KBytC5cXAS/code
Cloning into '/tmp/run-integration-test.sh.KBytC5cXAS/code'...
```

```
# macOS logs
** Checking required executables...
** Cloning https://github.com/apple/swift-openapi-generator to /var/folders/06/__qdhxzn7ld3_bsvfcfz0kch0000gn/T//run-integration-test.sh.eO0Lt7O0TM/swift-openapi-generator
Cloning into '/var/folders/06/__qdhxzn7ld3_bsvfcfz0kch0000gn/T//run-integration-test.sh.eO0Lt7O0TM/swift-openapi-generator'...
```