### PR TITLE
Compile with -warnings-as-errors in CI (incl. StrictSendability)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 import PackageDescription
 
 // General Swift-settings for all targets.
@@ -23,6 +24,15 @@ swiftSettings.append(
     // Require `any` for existential types.
     .enableUpcomingFeature("ExistentialAny")
 )
+
+// Strict concurrency is enabled in CI; use this environment variable to enable it locally.
+if ProcessInfo.processInfo.environment["SWIFT_OPENAPI_STRICT_CONCURRENCY"].flatMap(Bool.init) ?? false {
+    #warning("Compiling with Strict Concurrency")
+    swiftSettings.append(contentsOf: [
+        .enableExperimentalFeature("StrictConcurrency"),
+        .unsafeFlags(["-warnings-as-errors"]),
+    ])
+}
 #endif
 
 let package = Package(

--- a/Sources/_OpenAPIGeneratorCore/GeneratorMode.swift
+++ b/Sources/_OpenAPIGeneratorCore/GeneratorMode.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Describes the file to be generated from the specified OpenAPI document.
-public enum GeneratorMode: String, Codable, CaseIterable {
+public enum GeneratorMode: String, Codable, CaseIterable, Sendable {
 
     /// A file that contains the API protocol, reusable types, and operation
     /// namespaces.

--- a/Sources/_OpenAPIGeneratorCore/Layers/RenderedSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/RenderedSwiftRepresentation.swift
@@ -11,7 +11,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import Foundation
+#if os(Linux)
+@preconcurrency import struct Foundation.URL
+@preconcurrency import struct Foundation.Data
+#else
+import struct Foundation.URL
+import struct Foundation.Data
+#endif
 
 /// An in-memory file that contains the generated Swift code.
 typealias RenderedSwiftRepresentation = InMemoryOutputFile
@@ -19,7 +25,7 @@ typealias RenderedSwiftRepresentation = InMemoryOutputFile
 /// An in-memory input file that contains the raw data of an OpenAPI document.
 ///
 /// Contents are formatted as either YAML or JSON.
-public struct InMemoryInputFile {
+public struct InMemoryInputFile: Sendable {
 
     /// The absolute path to the file.
     public var absolutePath: URL
@@ -38,7 +44,7 @@ public struct InMemoryInputFile {
 }
 
 /// An in-memory output file that contains the generated Swift source code.
-public struct InMemoryOutputFile {
+public struct InMemoryOutputFile: Sendable {
 
     /// The base name of the file.
     public var baseName: String

--- a/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
@@ -29,7 +29,6 @@ final class CompatibilityTest: XCTestCase {
     let compatibilityTestNumBuildJobs = getIntEnv("SWIFT_OPENAPI_COMPATIBILITY_TEST_NUM_BUILD_JOBS")
 
     override func setUp() async throws {
-        setbuf(stdout, nil)
         continueAfterFailure = false
         try XCTSkipUnless(compatibilityTestEnabled)
         if _isDebugAssertConfiguration() {
@@ -333,7 +332,7 @@ fileprivate extension CompatibilityTest {
 }
 
 /// Records diagnostics into an array for testing.
-private final class RecordingDiagnosticCollector: DiagnosticCollector {
+private final class RecordingDiagnosticCollector: DiagnosticCollector, @unchecked Sendable {
     private let lock = NSLock()
     private var _diagnostics: [Diagnostic] = []
     var diagnostics: [Diagnostic] {

--- a/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
@@ -332,7 +332,7 @@ fileprivate extension CompatibilityTest {
 }
 
 /// Records diagnostics into an array for testing.
-private final class RecordingDiagnosticCollector: DiagnosticCollector {
+private final class RecordingDiagnosticCollector: DiagnosticCollector, @unchecked Sendable {
     private let lock = NSLock()
     private var _diagnostics: [Diagnostic] = []
     var diagnostics: [Diagnostic] {

--- a/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
@@ -332,7 +332,7 @@ fileprivate extension CompatibilityTest {
 }
 
 /// Records diagnostics into an array for testing.
-private final class RecordingDiagnosticCollector: DiagnosticCollector, @unchecked Sendable {
+private final class RecordingDiagnosticCollector: DiagnosticCollector {
     private let lock = NSLock()
     private var _diagnostics: [Diagnostic] = []
     var diagnostics: [Diagnostic] {

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -141,7 +141,6 @@ paths:
   /probe/:
     post:
       operationId: probe
-      deprecated: true
       responses:
         '204':
           description: Ack
@@ -229,13 +228,6 @@ components:
       schema:
         type: integer
         format: int64
-    header.deprecatedHeader:
-      name: deprecatedHeader
-      in: header
-      deprecated: true
-      description: A deprecated header parameter
-      schema:
-        type: string
   schemas:
     Pet:
       type: object
@@ -259,7 +251,6 @@ components:
     PetKind:
       type: string
       description: "Kind of pet"
-      deprecated: true
       enum:
         - cat
         - dog
@@ -403,17 +394,6 @@ components:
         - $ref: '#/components/schemas/MessagedExercise'
       discriminator:
         propertyName: kind
-    DeprecatedObject:
-      deprecated: true
-      type: object
-      properties: {}
-      additionalProperties: false
-    ObjectWithDeprecatedProperty:
-      type: object
-      properties:
-        message:
-          type: string
-          deprecated: true
     PetStats:
       type: object
       properties:

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -303,8 +303,7 @@ public struct Client: APIProtocol {
     }
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
-    @available(*, deprecated) public func probe(_ input: Operations.probe.Input) async throws -> Operations.probe.Output
-    {
+    public func probe(_ input: Operations.probe.Input) async throws -> Operations.probe.Output {
         try await client.send(
             input: input,
             forOperation: Operations.probe.id,

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -353,7 +353,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     }
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
-    @available(*, deprecated) func probe(request: Request, metadata: ServerRequestMetadata) async throws -> Response {
+    func probe(request: Request, metadata: ServerRequestMetadata) async throws -> Response {
         try await handle(
             request: request,
             with: metadata,

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -32,7 +32,7 @@ public protocol APIProtocol: Sendable {
     func postStats(_ input: Operations.postStats.Input) async throws -> Operations.postStats.Output
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
-    @available(*, deprecated) func probe(_ input: Operations.probe.Input) async throws -> Operations.probe.Output
+    func probe(_ input: Operations.probe.Input) async throws -> Operations.probe.Output
     /// Update just a specific property of an existing pet. Nothing is updated if no request body is provided.
     ///
     /// - Remark: HTTP `PATCH /pets/{petId}`.
@@ -496,23 +496,6 @@ public enum Components {
                 }
             }
         }
-        /// - Remark: Generated from `#/components/schemas/DeprecatedObject`.
-        @available(*, deprecated) public struct DeprecatedObject: Codable, Hashable, Sendable {
-            /// Creates a new `DeprecatedObject`.
-            public init() {}
-            public init(from decoder: any Decoder) throws { try decoder.ensureNoAdditionalProperties(knownKeys: []) }
-        }
-        /// - Remark: Generated from `#/components/schemas/ObjectWithDeprecatedProperty`.
-        public struct ObjectWithDeprecatedProperty: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/ObjectWithDeprecatedProperty/message`.
-            @available(*, deprecated) public var message: Swift.String?
-            /// Creates a new `ObjectWithDeprecatedProperty`.
-            ///
-            /// - Parameters:
-            ///   - message:
-            public init(message: Swift.String? = nil) { self.message = message }
-            public enum CodingKeys: String, CodingKey { case message }
-        }
         /// - Remark: Generated from `#/components/schemas/PetStats`.
         public struct PetStats: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/PetStats/count`.
@@ -535,10 +518,6 @@ public enum Components {
         ///
         /// - Remark: Generated from `#/components/parameters/path.petId`.
         public typealias path_period_petId = Swift.Int64
-        /// A deprecated header parameter
-        ///
-        /// - Remark: Generated from `#/components/parameters/header.deprecatedHeader`.
-        public typealias header_period_deprecatedHeader = Swift.String
     }
     /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
     public enum RequestBodies {

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -10,14 +10,7 @@ services:
   test:
     image: *image
     environment:
-      # Because OpenAPI supports deprecation, the generated code could include
-      # deprecated symbols, which will produce warnings.
-      #
-      # We'll disable -warnings-as-errors for now and revisit this when we
-      # refactor the compilation of the generated code into a separate
-      # pipeline.
-      #
-      # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 


### PR DESCRIPTION
### Motivation

We were not compiling with `-warnings-as-errors` in CI because some of the reference source code contained deprecation annotations. This meant that we are not getting CI failures for other warnings that we'd like to be clean of; specifically strict concurrency. However, in addition to the file-based reference tests, we now have in-memory snippet-based reference tests, which contain tests for deprecated OpenAPI schemas and operations.

### Modifications

- Remove deprecated tests from file-based reference test.
- Clean up warnings under StrictConcurrency.
- Compile with -warnings-as-errors in CI.
- Opt into StrictConcurrency and `-warnings-as-errors` locally with environment variable.

### Result

- CI will catch sendability warning regressions.
- Developing locally with `SWIFT_OPENAPI_STRICT_CONCURRENCY` will enable the same behaviour.

### Test Plan

- Added a canary commit to the end of this PR with a sendability issue, which will be reverted before merging.
