### PR TITLE
Move warning about strict concurrency into PlatformChecks.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,10 +27,9 @@ swiftSettings.append(
 
 // Strict concurrency is enabled in CI; use this environment variable to enable it locally.
 if ProcessInfo.processInfo.environment["SWIFT_OPENAPI_STRICT_CONCURRENCY"].flatMap(Bool.init) ?? false {
-    #warning("Compiling with Strict Concurrency")
     swiftSettings.append(contentsOf: [
+        .define("SWIFT_OPENAPI_STRICT_CONCURRENCY"),
         .enableExperimentalFeature("StrictConcurrency"),
-        .unsafeFlags(["-warnings-as-errors"]),
     ])
 }
 #endif

--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -17,3 +17,7 @@
 #if !(os(macOS) || os(Linux))
 #error("_OpenAPIGeneratorCore is only to be used by swift-openapi-generator itself—your target should not link this library or the command line tool directly.")
 #endif
+
+#if SWIFT_OPENAPI_STRICT_CONCURRENCY
+#warning("Compiling with Strict Concurrency")
+#endif


### PR DESCRIPTION
### Motivation

In #191 we enabled strict concurrency in CI. We also attempted to include it conditionally as part of a local development flow. However, the `#warning` (that strict concurrency was enabled) added to Package.swift was firing unconditionally because it was, itself, behind a _runtime_ conditional.

### Modifications

Now if `SWIFT_OPENAPI_STRICT_CONCURRENCY=true` then we will add a `define` to the `swiftSettings` and we will move the `#warning` to the existing `PlatformChecks.swift`.

### Result

Opening Xcode with `SWIFT_OPENAPI_STRICT_CONCURRENCY=true` will enable strict concurrency warnings locally. Opening Xcode without this will no longer produce a misleading warning.

### Test Plan

Tested locally.
