### PR TITLE
Bump OpenAPIKit to RC.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -73,7 +73,7 @@ let package = Package(
         // Read OpenAPI documents
         .package(
             url: "https://github.com/mattpolzin/OpenAPIKit.git",
-            exact: "3.0.0-beta.5"
+            exact: "3.0.0-rc.2"
         ),
         .package(
             url: "https://github.com/jpsim/Yams.git",

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTypes/Test_DiscriminatorExtensions.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTypes/Test_DiscriminatorExtensions.swift
@@ -29,7 +29,7 @@ final class Test_DiscriminatorExtensions: Test_Core {
     func testMappedTypes() throws {
         let typeAssigner = makeTranslator().typeAssigner
         func _test(
-            mapping: [String: String]?,
+            mapping: OrderedDictionary<String, String>?,
             schemaNames: [String],
             expectedOutputs: [Output],
             file: StaticString = #file,


### PR DESCRIPTION
### Motivation

OpenAPIKit is getting close to releasing a stable v3, so let's keep on top of the latest version to make sure it'll work well for us.

### Modifications

Bumped to release candidate 2.

Only had to adjusted one place in tests.

### Result

We're on the latest OpenAPIKit v3 version.

### Test Plan

Updated one place in tests, all other tests are passing.
