### PR TITLE
YAML diagnostics collector should have stable output

### DIFF
--- a/Sources/swift-openapi-generator/YamlFileDiagnosticsCollector.swift
+++ b/Sources/swift-openapi-generator/YamlFileDiagnosticsCollector.swift
@@ -48,12 +48,15 @@ final class _YamlFileDiagnosticsCollector: DiagnosticCollector, @unchecked Senda
     func finalize() throws {
         lock.lock()
         defer { lock.unlock() }
-        let uniqueMessages = Set(diagnostics.map(\.message)).sorted()
+        let sortedDiagnostics = diagnostics.sorted(by: { a, b in
+            a.description < b.description
+        })
+        let uniqueMessages = Set(sortedDiagnostics.map(\.message)).sorted()
         let encoder = YAMLEncoder()
         encoder.options.sortKeys = true
         let container = _DiagnosticsYamlFileContent(
             uniqueMessages: uniqueMessages,
-            diagnostics: diagnostics
+            diagnostics: sortedDiagnostics
         )
         try encoder
             .encode(container)


### PR DESCRIPTION
### Motivation

Fixes #294.

Since we're running generation in parallel now, the order of diagnostics depends on the racing of the cores, resulting in unstable output.

### Modifications

Sort the diagnostics before writing them to file, making the output stable again.

### Result

Stable YAML diagnostics file.

### Test Plan

N/A, the order isn't significant, so we're not testing the details of the sorting function, we just care about it being stable.
