### PR TITLE
Update integration test to 0.3.0 APIs and temporarily use main

### DIFF
--- a/IntegrationTest/Package.swift
+++ b/IntegrationTest/Package.swift
@@ -32,7 +32,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.3.0")),
+        // TODO: When swift-openapi-generator is tagged with 0.3.0, stop depending on main.
+        .package(url: "https://github.com/apple/swift-openapi-generator", /* .upToNextMinor(from: "0.3.0") */ branch: "main"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.3.0")),
     ],
     targets: [

--- a/IntegrationTest/Package.swift
+++ b/IntegrationTest/Package.swift
@@ -33,7 +33,8 @@ let package = Package(
     ],
     dependencies: [
         // TODO: When swift-openapi-generator is tagged with 0.3.0, stop depending on main.
-        .package(url: "https://github.com/apple/swift-openapi-generator", /* .upToNextMinor(from: "0.3.0") */ branch: "main"),
+        // .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.3.0"),
+        .package(url: "https://github.com/apple/swift-openapi-generator", branch: "main"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.3.0")),
     ],
     targets: [

--- a/IntegrationTest/Sources/MockTransportClient/Client.swift
+++ b/IntegrationTest/Sources/MockTransportClient/Client.swift
@@ -15,14 +15,15 @@ import Types
 import Client
 import OpenAPIRuntime
 import Foundation
+import HTTPTypes
 
 struct MockClientTransport: ClientTransport {
     func send(
-        _ request: Request,
-        baseURL: URL,
-        operationID: String
-    ) async throws -> Response {
-        .init(statusCode: 200)
+        _ request: HTTPTypes.HTTPRequest,
+        body: OpenAPIRuntime.HTTPBody?,
+        baseURL: URL, operationID: String
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
+        (HTTPTypes.HTTPResponse(status: 200), nil)
     }
 }
 

--- a/IntegrationTest/Sources/MockTransportClient/Client.swift
+++ b/IntegrationTest/Sources/MockTransportClient/Client.swift
@@ -21,7 +21,8 @@ struct MockClientTransport: ClientTransport {
     func send(
         _ request: HTTPTypes.HTTPRequest,
         body: OpenAPIRuntime.HTTPBody?,
-        baseURL: URL, operationID: String
+        baseURL: URL,
+        operationID: String
     ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         (HTTPTypes.HTTPResponse(status: 200), nil)
     }

--- a/IntegrationTest/Sources/MockTransportServer/Server.swift
+++ b/IntegrationTest/Sources/MockTransportServer/Server.swift
@@ -14,6 +14,7 @@
 import Types
 import Server
 import OpenAPIRuntime
+import HTTPTypes
 
 actor SimpleAPIImpl: APIProtocol {
     func getGreeting(
@@ -25,14 +26,12 @@ actor SimpleAPIImpl: APIProtocol {
 }
 
 class MockServerTransport: ServerTransport {
-
-    typealias Handler = @Sendable (Request, ServerRequestMetadata) async throws -> Response
+    typealias Handler = @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
 
     func register(
         _ handler: @escaping Handler,
-        method: HTTPMethod,
-        path: [RouterPathComponent],
-        queryItemNames: Set<String>
+        method: HTTPTypes.HTTPRequest.Method,
+        path: String
     ) throws {
         // noop.
     }

--- a/IntegrationTest/Sources/MockTransportServer/Server.swift
+++ b/IntegrationTest/Sources/MockTransportServer/Server.swift
@@ -26,7 +26,9 @@ actor SimpleAPIImpl: APIProtocol {
 }
 
 class MockServerTransport: ServerTransport {
-    typealias Handler = @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
+    typealias Handler = @Sendable (
+        HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
 
     func register(
         _ handler: @escaping Handler,


### PR DESCRIPTION
### Motivation

The integration test has been unable to run because its Package.swift was updated to depend on 0.3.0 of this project, which has yet to be tagged. This means we've been having to merge over broken CI. However, there's nothing stopping us updating it to use the new APIs and getting it running in the meantime.

### Modifications

- Update the integration test to use the new APIs (new Swift HTTP types).
- Temporarily depend on main for swift-openapi-generator (until we tag).

### Result

Integration test pipeline is working again.

### Test Plan

Should pass in CI.