### PR TITLE
Skip type: string + format: binary in object properties

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
@@ -34,7 +34,29 @@ extension FileTranslator {
             try objectContext
             .properties
             .filter { key, value in
-                try validateSchemaIsSupported(
+
+                let foundIn = "\(typeName.description)/\(key)"
+
+                // We need to catch a special case here:
+                // type: string + format: binary.
+                // It means binary data (unlike format: byte, which means base64
+                // and cannot be used in a structured object, such as in JSON.
+                // It's only valid as the root schema of a request or response.
+                // However, it _is_ a supported schema, so the following
+                // filtering would not exclude it.
+                // Since this is the only place we filter which schemas are
+                // allowed in object properties, explicitly filter these out
+                // here.
+                if value.isString && value.formatString == "binary" {
+                    diagnostics.emitUnsupportedSchema(
+                        reason: "Binary properties in object schemas.",
+                        schema: value,
+                        foundIn: foundIn
+                    )
+                    return false
+                }
+
+                return try validateSchemaIsSupported(
                     value,
                     foundIn: "\(typeName.description)/\(key)"
                 )

--- a/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
@@ -25,7 +25,7 @@ import Yams
 final class CompatibilityTest: XCTestCase {
     let compatibilityTestEnabled = getBoolEnv("SWIFT_OPENAPI_COMPATIBILITY_TEST_ENABLE") ?? false
     let compatibilityTestSkipBuild = getBoolEnv("SWIFT_OPENAPI_COMPATIBILITY_TEST_SKIP_BUILD") ?? false
-    let compatibilityTestParralelCodegen = getBoolEnv("SWIFT_OPENAPI_COMPATIBILITY_TEST_PARALLEL_CODEGEN") ?? false
+    let compatibilityTestParallelCodegen = getBoolEnv("SWIFT_OPENAPI_COMPATIBILITY_TEST_PARALLEL_CODEGEN") ?? false
     let compatibilityTestNumBuildJobs = getIntEnv("SWIFT_OPENAPI_COMPATIBILITY_TEST_NUM_BUILD_JOBS")
 
     override func setUp() async throws {
@@ -132,7 +132,9 @@ final class CompatibilityTest: XCTestCase {
         try await _test(
             "https://raw.githubusercontent.com/openai/openai-openapi/ec0b3953bfa08a92782bdccf34c1931b13402f56/openapi.yaml",
             license: .mit,
-            expectedDiagnostics: [],
+            expectedDiagnostics: [
+                "Schema \"string (binary)\" is not supported, reason: \"Binary properties in object schemas.\", skipping"
+            ],
             skipBuild: compatibilityTestSkipBuild
         )
     }
@@ -221,7 +223,7 @@ fileprivate extension CompatibilityTest {
         log("Generating Swift code (document size: \(documentSize))")
         let input = InMemoryInputFile(absolutePath: URL(string: "openapi.yaml")!, contents: documentData)
         let outputs: [GeneratorPipeline.RenderedOutput]
-        if compatibilityTestParralelCodegen {
+        if compatibilityTestParallelCodegen {
             outputs = try await withThrowingTaskGroup(of: GeneratorPipeline.RenderedOutput.self) { group in
                 for mode in GeneratorMode.allCases {
                     group.addTask {

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -292,6 +292,37 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testComponentsSchemasObjectWithPropertiesBinaryIsSkipped() throws {
+        try self.assertSchemasTranslation(
+            ignoredDiagnosticMessages: [
+                "Schema \"string (binary)\" is not supported, reason: \"Binary properties in object schemas.\", skipping"
+            ],
+            """
+            schemas:
+              MyObject:
+                type: object
+                properties:
+                  actualString:
+                    type: string
+                  binaryProperty:
+                    type: string
+                    format: binary
+                required:
+                  - actualString
+                  - binaryProperty
+            """,
+            """
+                public enum Schemas {
+                  public struct MyObject: Codable, Hashable, Sendable {
+                    public var actualString: Swift.String
+                    public init(actualString: Swift.String) { self.actualString = actualString }
+                    public enum CodingKeys: String, CodingKey { case actualString }
+                  }
+                }
+            """
+        )
+    }
+
     func testComponentsSchemasAllOf() throws {
         try self.assertSchemasTranslation(
             """
@@ -1556,6 +1587,7 @@ extension SnippetBasedReferenceTests {
 
     func assertSchemasTranslation(
         featureFlags: FeatureFlags = [],
+        ignoredDiagnosticMessages: Set<String> = [],
         _ componentsYAML: String,
         _ expectedSwift: String,
         file: StaticString = #filePath,
@@ -1563,6 +1595,7 @@ extension SnippetBasedReferenceTests {
     ) throws {
         let translator = try makeTypesTranslator(
             featureFlags: featureFlags,
+            ignoredDiagnosticMessages: ignoredDiagnosticMessages,
             componentsYAML: componentsYAML
         )
         let translation = try translator.translateSchemas(translator.components.schemas)


### PR DESCRIPTION
### Motivation

Fixes #312.

### Modifications

Explicitly skip binary properties in codable structs.

### Result

Remove build failures for projects using multipart.

### Test Plan

Created a unit test.
