### PR TITLE
Add support for filtering OpenAPI document

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Config.swift
+++ b/Sources/_OpenAPIGeneratorCore/Config.swift
@@ -26,6 +26,9 @@ public struct Config: Sendable {
     /// Additional imports to add to each generated file.
     public var additionalImports: [String]
 
+    /// Filter to apply to the OpenAPI document before generation.
+    public var filter: DocumentFilter?
+
     /// Additional pre-release features to enable.
     public var featureFlags: FeatureFlags
 
@@ -33,14 +36,17 @@ public struct Config: Sendable {
     /// - Parameters:
     ///   - mode: The mode to use for generation.
     ///   - additionalImports: Additional imports to add to each generated file.
+    ///   - filter: Filter to apply to the OpenAPI document before generation.
     ///   - featureFlags: Additional pre-release features to enable.
     public init(
         mode: GeneratorMode,
         additionalImports: [String] = [],
+        filter: DocumentFilter? = nil,
         featureFlags: FeatureFlags = []
     ) {
         self.mode = mode
         self.additionalImports = additionalImports
+        self.filter = filter
         self.featureFlags = featureFlags
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
+++ b/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
@@ -124,13 +124,19 @@ func makeGeneratorPipeline(
                 )
             },
             postTransitionHooks: [
+                { document in
+                    guard let documentFilter = config.filter else {
+                        return document
+                    }
+                    return try documentFilter.filter(document)
+                },
                 { doc in
                     let validationDiagnostics = try validator(doc, config)
                     for diagnostic in validationDiagnostics {
                         diagnostics.emit(diagnostic)
                     }
                     return doc
-                }
+                },
             ]
         ),
         translateOpenAPIToStructuredSwiftStage: .init(

--- a/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
@@ -15,8 +15,6 @@
 @preconcurrency import OpenAPIKit
 
 /// Rules used to filter an OpenAPI document.
-///
-/// - Todo: Add endpoint support
 public struct DocumentFilter: Codable, Sendable {
 
     /// Operations with these operation IDs will be included in the filter.

--- a/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
@@ -19,6 +19,9 @@
 /// - Todo: Add endpoint support
 public struct DocumentFilter: Codable, Sendable {
 
+    /// Operations with these operation IDs will be included in the filter.
+    public var operations: [String]?
+
     /// Operations tagged with these tags will be included in the filter.
     public var tags: [String]?
 
@@ -34,15 +37,17 @@ public struct DocumentFilter: Codable, Sendable {
     /// Create a new DocumentFilter.
     ///
     /// - Parameters:
-    ///   - operations: Paths that contain operations with IDs will be included in the filter.
+    ///   - operations: Operations with these IDs will be included in the filter.
     ///   - tags: Operations tagged with these tags will be included in the filter.
     ///   - paths: These paths will be included in the filter.
     ///   - schemas: These (additional) schemas will be included in the filter.
     public init(
+        operations: [String] = [],
         tags: [String] = [],
         paths: [OpenAPI.Path] = [],
         schemas: [String] = []
     ) {
+        self.operations = operations
         self.tags = tags
         self.paths = paths
         self.schemas = schemas
@@ -56,6 +61,9 @@ public struct DocumentFilter: Codable, Sendable {
         var builder = FilteredDocumentBuilder(document: document)
         for tag in tags ?? [] {
             try builder.requireOperations(tagged: tag)
+        }
+        for operationID in operations ?? [] {
+            try builder.requireOperation(operationID: operationID)
         }
         for path in paths ?? [] {
             try builder.requirePath(path)

--- a/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
@@ -19,7 +19,7 @@
 /// - Todo: Add endpoint support
 public struct DocumentFilter: Codable, Sendable {
 
-    /// Paths that contain operations with these tags will be included in the filter.
+    /// Operations tagged with these tags will be included in the filter.
     public var tags: [String]?
 
     /// These paths will be included in the filter.
@@ -35,7 +35,7 @@ public struct DocumentFilter: Codable, Sendable {
     ///
     /// - Parameters:
     ///   - operations: Paths that contain operations with IDs will be included in the filter.
-    ///   - tags: Paths that contain operations with these tags will be included in the filter.
+    ///   - tags: Operations tagged with these tags will be included in the filter.
     ///   - paths: These paths will be included in the filter.
     ///   - schemas: These (additional) schemas will be included in the filter.
     public init(
@@ -55,7 +55,7 @@ public struct DocumentFilter: Codable, Sendable {
     public func filter(_ document: OpenAPI.Document) throws -> OpenAPI.Document {
         var builder = FilteredDocumentBuilder(document: document)
         for tag in tags ?? [] {
-            try builder.requirePaths(taggedWith: tag)
+            try builder.requireOperations(tagged: tag)
         }
         for path in paths ?? [] {
             try builder.requirePath(path)

--- a/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
@@ -55,6 +55,8 @@ public struct DocumentFilter: Codable, Sendable {
     ///
     /// - Parameter document: The OpenAPI document to filter.
     /// - Returns: The filtered document.
+    /// - Throws: If any requested document components do not exist in the original document.
+    /// - Throws: If any dependencies of the requested document components cannot be resolved.
     public func filter(_ document: OpenAPI.Document) throws -> OpenAPI.Document {
         var builder = FilteredDocumentBuilder(document: document)
         for tag in tags ?? [] {

--- a/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@preconcurrency import OpenAPIKit
+
+/// Rules used to filter an OpenAPI document.
+///
+/// - Todo: Add endpoint support
+public struct DocumentFilter: Codable, Sendable {
+
+    /// Paths that contain operations with these tags will be included in the filter.
+    public var tags: [String]?
+
+    /// These paths will be included in the filter.
+    public var paths: [OpenAPI.Path]?
+
+    /// These (additional) schemas will be included in the filter.
+    ///
+    /// These schemas are included in  addition to the transitive closure of schema dependencies of
+    /// the paths included in the filter.
+    public var schemas: [String]?
+
+    /// Create a new DocumentFilter.
+    ///
+    /// - Parameters:
+    ///   - operations: Paths that contain operations with IDs will be included in the filter.
+    ///   - tags: Paths that contain operations with these tags will be included in the filter.
+    ///   - paths: These paths will be included in the filter.
+    ///   - schemas: These (additional) schemas will be included in the filter.
+    public init(
+        tags: [String] = [],
+        paths: [OpenAPI.Path] = [],
+        schemas: [String] = []
+    ) {
+        self.tags = tags
+        self.paths = paths
+        self.schemas = schemas
+    }
+
+    /// Filter an OpenAPI document.
+    ///
+    /// - Parameter document: The OpenAPI document to filter.
+    /// - Returns: The filtered document.
+    public func filter(_ document: OpenAPI.Document) throws -> OpenAPI.Document {
+        var builder = FilteredDocumentBuilder(document: document)
+        for tag in tags ?? [] {
+            try builder.requirePaths(taggedWith: tag)
+        }
+        for path in paths ?? [] {
+            try builder.requirePath(path)
+        }
+        for schema in schemas ?? [] {
+            try builder.requireSchema(schema)
+        }
+        return try builder.filter()
+    }
+}

--- a/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/DocumentFilter.swift
@@ -60,16 +60,16 @@ public struct DocumentFilter: Codable, Sendable {
     public func filter(_ document: OpenAPI.Document) throws -> OpenAPI.Document {
         var builder = FilteredDocumentBuilder(document: document)
         for tag in tags ?? [] {
-            try builder.requireOperations(tagged: tag)
+            try builder.includeOperations(tagged: tag)
         }
         for operationID in operations ?? [] {
-            try builder.requireOperation(operationID: operationID)
+            try builder.includeOperation(operationID: operationID)
         }
         for path in paths ?? [] {
-            try builder.requirePath(path)
+            try builder.includePath(path)
         }
         for schema in schemas ?? [] {
-            try builder.requireSchema(schema)
+            try builder.includeSchema(schema)
         }
         return try builder.filter()
     }

--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -116,12 +116,12 @@ struct FilteredDocumentBuilder {
     /// referenced within the corresponding path item.
     ///
     /// - Parameter path: The path to be included in the filter.
-    mutating func requirePath(_ path: OpenAPI.Path) throws {
+    mutating func includePath(_ path: OpenAPI.Path) throws {
         guard let pathItem = document.paths[path] else {
             throw FilteredDocumentBuilderError.pathDoesNotExist(path)
         }
         guard requiredPaths.insert(path).inserted else { return }
-        try requirePathItem(pathItem)
+        try includePathItem(pathItem)
     }
 
     /// Include operations that have a given tag (and all their component dependencies).
@@ -130,11 +130,11 @@ struct FilteredDocumentBuilder {
     /// document with a subset of the operations defined in the original document.
     ///
     /// - Parameter tag: The tag to use to include operations (and their paths).
-    mutating func requireOperations(tagged tag: String) throws {
+    mutating func includeOperations(tagged tag: String) throws {
         guard document.allTags.contains(tag) else {
             throw FilteredDocumentBuilderError.tagDoesNotExist(tag)
         }
-        try requireOperations { endpoint in endpoint.operation.tags?.contains(tag) ?? false }
+        try includeOperations { endpoint in endpoint.operation.tags?.contains(tag) ?? false }
     }
 
     /// Include operations that have a given tag (and all their component dependencies).
@@ -143,8 +143,8 @@ struct FilteredDocumentBuilder {
     /// document with a subset of the operations defined in the original document.
     ///
     /// - Parameter tag: The tag by which to include operations (and their paths).
-    mutating func requireOperations(tagged tag: OpenAPI.Tag) throws {
-        try requireOperations(tagged: tag.name)
+    mutating func includeOperations(tagged tag: OpenAPI.Tag) throws {
+        try includeOperations(tagged: tag.name)
     }
 
     /// Include the operation with a given ID (and all its component dependencies).
@@ -153,11 +153,11 @@ struct FilteredDocumentBuilder {
     /// in the original document.
     ///
     /// - Parameter operationID: The operation to include (and its path).
-    mutating func requireOperation(operationID: String) throws {
+    mutating func includeOperation(operationID: String) throws {
         guard document.allOperationIds.contains(operationID) else {
             throw FilteredDocumentBuilderError.operationDoesNotExist(operationID: operationID)
         }
-        try requireOperations { endpoint in endpoint.operation.operationId == operationID }
+        try includeOperations { endpoint in endpoint.operation.operationId == operationID }
     }
 
     /// Include schema (and all its schema dependencies).
@@ -166,8 +166,8 @@ struct FilteredDocumentBuilder {
     /// it references.
     ///
     /// - Parameter name: The key in the `#/components/schemas` map in the OpenAPI document.
-    mutating func requireSchema(_ name: String) throws {
-        try requireSchema(.a(OpenAPI.Reference<JSONSchema>.component(named: name)))
+    mutating func includeSchema(_ name: String) throws {
+        try includeSchema(.a(OpenAPI.Reference<JSONSchema>.component(named: name)))
     }
 }
 
@@ -192,107 +192,107 @@ enum FilteredDocumentBuilderError: Error, LocalizedError {
 }
 
 private extension FilteredDocumentBuilder {
-    mutating func requirePathItem(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.PathItem>, OpenAPI.PathItem>)
+    mutating func includePathItem(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.PathItem>, OpenAPI.PathItem>)
         throws
     {
         switch maybeReference {
         case .a(let reference):
             guard requiredPathItemReferences.insert(reference).inserted else { return }
-            try addComponentsReferencedBy(try document.components.lookup(reference))
+            try includeComponentsReferencedBy(try document.components.lookup(reference))
         case .b(let value):
-            try addComponentsReferencedBy(value)
+            try includeComponentsReferencedBy(value)
         }
     }
 
-    mutating func requireSchema(_ maybeReference: Either<OpenAPI.Reference<JSONSchema>, JSONSchema>) throws {
+    mutating func includeSchema(_ maybeReference: Either<OpenAPI.Reference<JSONSchema>, JSONSchema>) throws {
         switch maybeReference {
         case .a(let reference):
             guard requiredSchemaReferences.insert(reference).inserted else { return }
-            try addComponentsReferencedBy(try document.components.lookup(reference))
+            try includeComponentsReferencedBy(try document.components.lookup(reference))
         case .b(let value):
-            try addComponentsReferencedBy(value)
+            try includeComponentsReferencedBy(value)
         }
     }
 
-    mutating func requireParameter(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Parameter>, OpenAPI.Parameter>)
+    mutating func includeParameter(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Parameter>, OpenAPI.Parameter>)
         throws
     {
         switch maybeReference {
         case .a(let reference):
             guard requiredParameterReferences.insert(reference).inserted else { return }
-            try addComponentsReferencedBy(try document.components.lookup(reference))
+            try includeComponentsReferencedBy(try document.components.lookup(reference))
         case .b(let value):
-            try addComponentsReferencedBy(value)
+            try includeComponentsReferencedBy(value)
         }
     }
 
-    mutating func requireResponse(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>)
+    mutating func includeResponse(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>)
         throws
     {
         switch maybeReference {
         case .a(let reference):
             guard requiredResponseReferences.insert(reference).inserted else { return }
-            try addComponentsReferencedBy(try document.components.lookup(reference))
+            try includeComponentsReferencedBy(try document.components.lookup(reference))
         case .b(let value):
-            try addComponentsReferencedBy(value)
+            try includeComponentsReferencedBy(value)
         }
     }
 
-    mutating func requireHeader(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Header>, OpenAPI.Header>) throws {
+    mutating func includeHeader(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Header>, OpenAPI.Header>) throws {
         switch maybeReference {
         case .a(let reference):
             guard requiredHeaderReferences.insert(reference).inserted else { return }
-            try addComponentsReferencedBy(try document.components.lookup(reference))
+            try includeComponentsReferencedBy(try document.components.lookup(reference))
         case .b(let value):
-            try addComponentsReferencedBy(value)
+            try includeComponentsReferencedBy(value)
         }
     }
 
-    mutating func requireLink(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Link>, OpenAPI.Link>) throws {
+    mutating func includeLink(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Link>, OpenAPI.Link>) throws {
         switch maybeReference {
         case .a(let reference):
             guard requiredLinkReferences.insert(reference).inserted else { return }
-            try addComponentsReferencedBy(try document.components.lookup(reference))
+            try includeComponentsReferencedBy(try document.components.lookup(reference))
         case .b(let value):
-            try addComponentsReferencedBy(value)
+            try includeComponentsReferencedBy(value)
         }
     }
 
-    mutating func requireCallbacks(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Callbacks>, OpenAPI.Callbacks>)
+    mutating func includeCallbacks(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Callbacks>, OpenAPI.Callbacks>)
         throws
     {
         switch maybeReference {
         case .a(let reference):
             guard requiredCallbacksReferences.insert(reference).inserted else { return }
-            try addComponentsReferencedBy(try document.components.lookup(reference))
+            try includeComponentsReferencedBy(try document.components.lookup(reference))
         case .b(let value):
-            try addComponentsReferencedBy(value)
+            try includeComponentsReferencedBy(value)
         }
     }
 
-    mutating func requireRequestBody(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Request>, OpenAPI.Request>)
+    mutating func includeRequestBody(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Request>, OpenAPI.Request>)
         throws
     {
         switch maybeReference {
         case .a(let reference):
             guard requiredRequestReferences.insert(reference).inserted else { return }
-            try addComponentsReferencedBy(try document.components.lookup(reference))
+            try includeComponentsReferencedBy(try document.components.lookup(reference))
         case .b(let value):
-            try addComponentsReferencedBy(value)
+            try includeComponentsReferencedBy(value)
         }
     }
 
-    mutating func requireExample(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Example>, OpenAPI.Example>) throws {
+    mutating func includeExample(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Example>, OpenAPI.Example>) throws {
         switch maybeReference {
         case .a(let reference):
             guard requiredExampleReferences.insert(reference).inserted else { return }
-            try addComponentsReferencedBy(try document.components.lookup(reference))
+            try includeComponentsReferencedBy(try document.components.lookup(reference))
         case .b(let value):
-            try addComponentsReferencedBy(value)
+            try includeComponentsReferencedBy(value)
         }
     }
 
-    mutating func requireOperations(where predicate: (OpenAPI.PathItem.Endpoint) -> Bool) throws {
+    mutating func includeOperations(where predicate: (OpenAPI.PathItem.Endpoint) -> Bool) throws {
         for (path, maybePathItemReference) in document.paths {
             let originalPathItem: OpenAPI.PathItem
             switch maybePathItemReference {
@@ -310,7 +310,7 @@ private extension FilteredDocumentBuilder {
                     requiredEndpoints[path] = Set()
                 }
                 if requiredEndpoints[path]!.insert(endpoint.method).inserted {
-                    try addComponentsReferencedBy(endpoint.operation)
+                    try includeComponentsReferencedBy(endpoint.operation)
                 }
             }
         }
@@ -319,83 +319,83 @@ private extension FilteredDocumentBuilder {
 
 private extension FilteredDocumentBuilder {
 
-    mutating func addComponentsReferencedBy(_ pathItem: OpenAPI.PathItem) throws {
+    mutating func includeComponentsReferencedBy(_ pathItem: OpenAPI.PathItem) throws {
         for endpoint in pathItem.endpoints {
-            try addComponentsReferencedBy(endpoint.operation)
+            try includeComponentsReferencedBy(endpoint.operation)
         }
         for parameter in pathItem.parameters {
-            try requireParameter(parameter)
+            try includeParameter(parameter)
         }
     }
 
-    mutating func addComponentsReferencedBy(_ operation: OpenAPI.Operation) throws {
+    mutating func includeComponentsReferencedBy(_ operation: OpenAPI.Operation) throws {
         for parameter in operation.parameters {
-            try requireParameter(parameter)
+            try includeParameter(parameter)
         }
         for response in operation.responses.values {
-            try requireResponse(response)
+            try includeResponse(response)
         }
         if let requestBody = operation.requestBody {
-            try requireRequestBody(requestBody)
+            try includeRequestBody(requestBody)
         }
         for callbacks in operation.callbacks.values {
-            try requireCallbacks(callbacks)
+            try includeCallbacks(callbacks)
         }
     }
 
-    mutating func addComponentsReferencedBy(_ request: OpenAPI.Request) throws {
+    mutating func includeComponentsReferencedBy(_ request: OpenAPI.Request) throws {
         for content in request.content.values {
-            try addComponentsReferencedBy(content)
+            try includeComponentsReferencedBy(content)
         }
     }
-    mutating func addComponentsReferencedBy(_ callbacks: OpenAPI.Callbacks) throws {
+    mutating func includeComponentsReferencedBy(_ callbacks: OpenAPI.Callbacks) throws {
         for pathItem in callbacks.values {
-            try requirePathItem(pathItem)
+            try includePathItem(pathItem)
         }
     }
 
-    mutating func addComponentsReferencedBy(_ schema: JSONSchema) throws {
+    mutating func includeComponentsReferencedBy(_ schema: JSONSchema) throws {
         switch schema.value {
 
         case .reference(let reference, _):
             guard requiredSchemaReferences.insert(OpenAPI.Reference(reference)).inserted else { return }
-            try addComponentsReferencedBy(document.components.lookup(reference))
+            try includeComponentsReferencedBy(document.components.lookup(reference))
 
         case .object(_, let object):
             for schema in object.properties.values {
-                try addComponentsReferencedBy(schema)
+                try includeComponentsReferencedBy(schema)
             }
             if case .b(let schema) = object.additionalProperties {
-                try addComponentsReferencedBy(schema)
+                try includeComponentsReferencedBy(schema)
             }
 
         case .array(_, let array):
             if let schema = array.items {
-                try addComponentsReferencedBy(schema)
+                try includeComponentsReferencedBy(schema)
             }
 
         case .not(let schema, _):
-            try addComponentsReferencedBy(schema)
+            try includeComponentsReferencedBy(schema)
 
         case .all(of: let schemas, _): fallthrough
         case .one(of: let schemas, _): fallthrough
         case .any(of: let schemas, _):
             for schema in schemas {
-                try addComponentsReferencedBy(schema)
+                try includeComponentsReferencedBy(schema)
             }
         case .null, .boolean, .number, .integer, .string, .fragment: return
         }
     }
 
-    mutating func addComponentsReferencedBy(_ parameter: OpenAPI.Parameter) throws {
-        try addComponentsReferencedBy(parameter.schemaOrContent)
+    mutating func includeComponentsReferencedBy(_ parameter: OpenAPI.Parameter) throws {
+        try includeComponentsReferencedBy(parameter.schemaOrContent)
     }
 
-    mutating func addComponentsReferencedBy(_ header: OpenAPI.Header) throws {
-        try addComponentsReferencedBy(header.schemaOrContent)
+    mutating func includeComponentsReferencedBy(_ header: OpenAPI.Header) throws {
+        try includeComponentsReferencedBy(header.schemaOrContent)
     }
 
-    mutating func addComponentsReferencedBy(
+    mutating func includeComponentsReferencedBy(
         _ schemaOrContent: Either<OpenAPI.Parameter.SchemaContext, OpenAPI.Content.Map>
     ) throws {
         switch schemaOrContent {
@@ -403,18 +403,18 @@ private extension FilteredDocumentBuilder {
             switch schemaContext.schema {
             case .a(let reference):
                 guard requiredSchemaReferences.insert(reference).inserted else { return }
-                try addComponentsReferencedBy(try document.components.lookup(reference))
+                try includeComponentsReferencedBy(try document.components.lookup(reference))
             case .b(let schema):
-                try addComponentsReferencedBy(schema)
+                try includeComponentsReferencedBy(schema)
             }
         case .b(let contentMap):
             for value in contentMap.values {
                 switch value.schema {
                 case .a(let reference):
                     guard requiredSchemaReferences.insert(reference).inserted else { return }
-                    try addComponentsReferencedBy(try document.components.lookup(reference))
+                    try includeComponentsReferencedBy(try document.components.lookup(reference))
                 case .b(let schema):
-                    try addComponentsReferencedBy(schema)
+                    try includeComponentsReferencedBy(schema)
                 case .none:
                     continue
                 }
@@ -422,43 +422,43 @@ private extension FilteredDocumentBuilder {
         }
     }
 
-    mutating func addComponentsReferencedBy(_ response: OpenAPI.Response) throws {
+    mutating func includeComponentsReferencedBy(_ response: OpenAPI.Response) throws {
         if let headers = response.headers {
             for header in headers.values {
-                try requireHeader(header)
+                try includeHeader(header)
             }
         }
         for content in response.content.values {
-            try addComponentsReferencedBy(content)
+            try includeComponentsReferencedBy(content)
         }
         for link in response.links.values {
-            try requireLink(link)
+            try includeLink(link)
         }
     }
 
-    mutating func addComponentsReferencedBy(_ content: OpenAPI.Content) throws {
+    mutating func includeComponentsReferencedBy(_ content: OpenAPI.Content) throws {
         if let schema = content.schema {
-            try requireSchema(schema)
+            try includeSchema(schema)
         }
         if let encoding = content.encoding {
             for encoding in encoding.values {
                 if let headers = encoding.headers {
                     for header in headers.values {
-                        try requireHeader(header)
+                        try includeHeader(header)
                     }
                 }
             }
         }
         if let examples = content.examples {
             for example in examples.values {
-                try requireExample(example)
+                try includeExample(example)
             }
         }
     }
 
-    mutating func addComponentsReferencedBy(_ content: OpenAPI.Link) throws {}
+    mutating func includeComponentsReferencedBy(_ content: OpenAPI.Link) throws {}
 
-    mutating func addComponentsReferencedBy(_ content: OpenAPI.Example) throws {}
+    mutating func includeComponentsReferencedBy(_ content: OpenAPI.Example) throws {}
 }
 
 fileprivate extension OpenAPI.Reference {

--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -146,26 +146,17 @@ public struct FilteredDocumentBuilder {
         try requireOperations(tagged: tag.name)
     }
 
-    /// Include paths with operations that have a given ID (and all their component dependencies).
+    /// Include the operation with a given ID (and all its component dependencies).
     ///
-    /// The paths are added to the filter, along with the transitive closure of all components
-    /// referenced within the corresponding path items.
+    /// This may result in paths within filtered document with a subset of the operations defined
+    /// in the original document.
     ///
     /// - Parameter operationID: The operation to include (and its path).
-    public mutating func requirePath(operationID: String) throws {
+    public mutating func requireOperation(operationID: String) throws {
         guard document.allOperationIds.contains(operationID) else {
             throw FilteredDocumentBuilderError.operationDoesNotExist(operationID: operationID)
         }
-
-        let path = document.paths.first { _, pathItem in
-            document.components[pathItem]?.endpoints
-                .contains {
-                    $0.operation.operationId == operationID
-                } ?? false
-        }!
-        .key
-
-        try requirePath(path)
+        try requireOperations { endpoint in endpoint.operation.operationId == operationID }
     }
 
     /// Include schema (and all its schema dependencies).

--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -467,7 +467,7 @@ fileprivate extension OpenAPI.Reference {
             guard case .internal(.component(name: let name)) = jsonReference else {
                 throw FilteredDocumentBuilderError.cannotResolveInternalReference(absoluteString)
             }
-            return OpenAPI.ComponentKey(rawValue: name)!
+            return OpenAPI.ComponentKey(stringLiteral: name)
         }
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -100,7 +100,8 @@ public struct FilteredDocumentBuilder {
             }
             switch maybeReference {
             case .a(let reference):
-                components.pathItems[try reference.internalComponentKey] = try document.components.lookup(reference).filteringEndpoints { methods.contains($0.method) }
+                components.pathItems[try reference.internalComponentKey] = try document.components.lookup(reference)
+                    .filteringEndpoints { methods.contains($0.method) }
             case .b(let pathItem):
                 filteredDocument.paths[path] = .b(pathItem.filteringEndpoints { methods.contains($0.method) })
             }

--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -383,9 +383,7 @@ private extension FilteredDocumentBuilder {
         case .not(let schema, _):
             try includeComponentsReferencedBy(schema)
 
-        case .all(of: let schemas, _): fallthrough
-        case .one(of: let schemas, _): fallthrough
-        case .any(of: let schemas, _):
+        case .all(of: let schemas, _), .one(of: let schemas, _), .any(of: let schemas, _):
             for schema in schemas {
                 try includeComponentsReferencedBy(schema)
             }

--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -1,0 +1,430 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIKit
+
+/// Filter the paths and components of an OpenAPI document.
+///
+/// The builder starts with an empty filter, which will return the underlying document, but empty
+/// paths and components maps.
+///
+/// Desired paths and/or named schemas are included by calling the `requireXXX` methods.
+///
+/// When adding a path to the filter, the transitive closure of all referenced components are also
+/// included in the filtered document.
+public struct FilteredDocumentBuilder {
+
+    /// The underlying OpenAPI document to filter.
+    private(set) var document: OpenAPI.Document
+
+    private(set) var requiredPaths: Set<OpenAPI.Path>
+    private(set) var requiredPathItemReferences: Set<OpenAPI.Reference<OpenAPI.PathItem>>
+    private(set) var requiredSchemaReferences: Set<OpenAPI.Reference<JSONSchema>>
+    private(set) var requiredParameterReferences: Set<OpenAPI.Reference<OpenAPI.Parameter>>
+    private(set) var requiredHeaderReferences: Set<OpenAPI.Reference<OpenAPI.Header>>
+    private(set) var requiredResponseReferences: Set<OpenAPI.Reference<OpenAPI.Response>>
+    private(set) var requiredCallbacksReferences: Set<OpenAPI.Reference<OpenAPI.Callbacks>>
+    private(set) var requiredExampleReferences: Set<OpenAPI.Reference<OpenAPI.Example>>
+    private(set) var requiredLinkReferences: Set<OpenAPI.Reference<OpenAPI.Link>>
+    private(set) var requiredRequestReferences: Set<OpenAPI.Reference<OpenAPI.Request>>
+
+    /// Create a new FilteredDocumentBuilder.
+    ///
+    /// - Parameter document: The underlying OpenAPI document to filter.
+    public init(document: OpenAPI.Document) {
+        self.document = document
+        self.requiredPaths = []
+        self.requiredPathItemReferences = []
+        self.requiredSchemaReferences = []
+        self.requiredParameterReferences = []
+        self.requiredHeaderReferences = []
+        self.requiredResponseReferences = []
+        self.requiredCallbacksReferences = []
+        self.requiredExampleReferences = []
+        self.requiredLinkReferences = []
+        self.requiredRequestReferences = []
+    }
+
+    /// Filter the underlying document based on the rules provided.
+    ///
+    /// - Returns: The filtered OpenAPI document.
+    public func filter() throws -> OpenAPI.Document {
+        var components = OpenAPI.Components.noComponents
+        for reference in requiredSchemaReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.schemas[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        for reference in requiredPathItemReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.pathItems[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        for reference in requiredParameterReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.parameters[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        for reference in requiredPathItemReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.pathItems[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        for reference in requiredHeaderReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.headers[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        for reference in requiredResponseReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.responses[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        for reference in requiredCallbacksReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.callbacks[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        for reference in requiredExampleReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.examples[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        for reference in requiredLinkReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.links[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        for reference in requiredRequestReferences {
+            guard case .internal(.component(name: let name)) = reference.jsonReference else { fatalError() }
+            components.requestBodies[OpenAPI.ComponentKey(rawValue: name)!] = try document.components.lookup(reference)
+        }
+        var document = document.filteringPaths(with: requiredPaths.contains(_:))
+        document.components = components
+        return document
+    }
+
+    /// Include a path (and all its component dependencies).
+    ///
+    /// The path is added to the filter, along with the transitive closure of all components
+    /// referenced within the corresponding path item.
+    ///
+    /// - Parameter path: The path to be included in the filter.
+    public mutating func requirePath(_ path: OpenAPI.Path) throws {
+        guard let pathItem = document.paths[path] else {
+            preconditionFailure("path does not exist")
+        }
+        guard requiredPaths.insert(path).inserted else { return }
+        try requirePathItem(pathItem)
+    }
+
+    /// Include paths with operations that have a given tag (and all their component dependencies).
+    ///
+    /// The paths are added to the filter, along with the transitive closure of all components
+    /// referenced within the corresponding path items.
+    ///
+    /// - Parameter tag: The tag to use to include operations (and their paths).
+    public mutating func requirePaths(taggedWith tag: String) throws {
+        guard document.allTags.contains(tag) else {
+            preconditionFailure("Tag does not exist")
+        }
+        let pathsWithTaggedOperations = document.paths.filter { _, pathItem in
+            document.components[pathItem]?.endpoints
+                .contains {
+                    $0.operation.tags?.contains(tag) ?? false
+                } ?? false
+        }
+        for path in pathsWithTaggedOperations {
+            try requirePath(path.key)
+        }
+    }
+
+    /// Include paths with operations that have a given tag (and all their component dependencies).
+    ///
+    /// The paths are added to the filter, along with the transitive closure of all components
+    /// referenced within the corresponding path items.
+    ///
+    /// - Parameter tag: The tag by which to include operations (and their paths).
+    public mutating func requirePaths(taggedWith tag: OpenAPI.Tag) throws {
+        try requirePaths(taggedWith: tag.name)
+    }
+
+    /// Include paths with operations that have a given ID (and all their component dependencies).
+    ///
+    /// The paths are added to the filter, along with the transitive closure of all components
+    /// referenced within the corresponding path items.
+    ///
+    /// - Parameter operationID: The operation to include (and its path).
+    public mutating func requirePath(operationID: String) throws {
+        guard document.allOperationIds.contains(operationID) else {
+            preconditionFailure("Operation does not exist")
+        }
+
+        let path = document.paths.first { _, pathItem in
+            document.components[pathItem]?.endpoints
+                .contains {
+                    $0.operation.operationId == operationID
+                } ?? false
+        }!
+        .key
+
+        try requirePath(path)
+    }
+
+    /// Include schema (and all its schema dependencies).
+    ///
+    /// The schema is added to the filter, along with the transitive closure of all other schemas
+    /// it references.
+    ///
+    /// - Parameter name: The key in the `#/components/schemas` map in the OpenAPI document.
+    public mutating func requireSchema(_ name: String) throws {
+        try requireSchema(.a(OpenAPI.Reference<JSONSchema>.component(named: name)))
+    }
+}
+
+private extension FilteredDocumentBuilder {
+    mutating func requirePathItem(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.PathItem>, OpenAPI.PathItem>)
+        throws
+    {
+        switch maybeReference {
+        case .a(let reference):
+            guard requiredPathItemReferences.insert(reference).inserted else { return }
+            try addComponentsReferencedBy(try document.components.lookup(reference))
+        case .b(let value):
+            try addComponentsReferencedBy(value)
+        }
+    }
+
+    mutating func requireSchema(_ maybeReference: Either<OpenAPI.Reference<JSONSchema>, JSONSchema>) throws {
+        switch maybeReference {
+        case .a(let reference):
+            guard requiredSchemaReferences.insert(reference).inserted else { return }
+            try addComponentsReferencedBy(try document.components.lookup(reference))
+        case .b(let value):
+            try addComponentsReferencedBy(value)
+        }
+    }
+
+    mutating func requireParameter(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Parameter>, OpenAPI.Parameter>)
+        throws
+    {
+        switch maybeReference {
+        case .a(let reference):
+            guard requiredParameterReferences.insert(reference).inserted else { return }
+            try addComponentsReferencedBy(try document.components.lookup(reference))
+        case .b(let value):
+            try addComponentsReferencedBy(value)
+        }
+    }
+
+    mutating func requireResponse(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>)
+        throws
+    {
+        switch maybeReference {
+        case .a(let reference):
+            guard requiredResponseReferences.insert(reference).inserted else { return }
+            try addComponentsReferencedBy(try document.components.lookup(reference))
+        case .b(let value):
+            try addComponentsReferencedBy(value)
+        }
+    }
+
+    mutating func requireHeader(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Header>, OpenAPI.Header>) throws {
+        switch maybeReference {
+        case .a(let reference):
+            guard requiredHeaderReferences.insert(reference).inserted else { return }
+            try addComponentsReferencedBy(try document.components.lookup(reference))
+        case .b(let value):
+            try addComponentsReferencedBy(value)
+        }
+    }
+
+    mutating func requireLink(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Link>, OpenAPI.Link>) throws {
+        switch maybeReference {
+        case .a(let reference):
+            guard requiredLinkReferences.insert(reference).inserted else { return }
+            try addComponentsReferencedBy(try document.components.lookup(reference))
+        case .b(let value):
+            try addComponentsReferencedBy(value)
+        }
+    }
+
+    mutating func requireCallbacks(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Callbacks>, OpenAPI.Callbacks>)
+        throws
+    {
+        switch maybeReference {
+        case .a(let reference):
+            guard requiredCallbacksReferences.insert(reference).inserted else { return }
+            try addComponentsReferencedBy(try document.components.lookup(reference))
+        case .b(let value):
+            try addComponentsReferencedBy(value)
+        }
+    }
+
+    mutating func requireRequestBody(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Request>, OpenAPI.Request>)
+        throws
+    {
+        switch maybeReference {
+        case .a(let reference):
+            guard requiredRequestReferences.insert(reference).inserted else { return }
+            try addComponentsReferencedBy(try document.components.lookup(reference))
+        case .b(let value):
+            try addComponentsReferencedBy(value)
+        }
+    }
+
+    mutating func requireExample(_ maybeReference: Either<OpenAPI.Reference<OpenAPI.Example>, OpenAPI.Example>) throws {
+        switch maybeReference {
+        case .a(let reference):
+            guard requiredExampleReferences.insert(reference).inserted else { return }
+            try addComponentsReferencedBy(try document.components.lookup(reference))
+        case .b(let value):
+            try addComponentsReferencedBy(value)
+        }
+    }
+}
+
+private extension FilteredDocumentBuilder {
+
+    mutating func addComponentsReferencedBy(_ pathItem: OpenAPI.PathItem) throws {
+        for endpoint in pathItem.endpoints {
+            try addComponentsReferencedBy(endpoint.operation)
+        }
+        for parameter in pathItem.parameters {
+            try requireParameter(parameter)
+        }
+    }
+
+    mutating func addComponentsReferencedBy(_ operation: OpenAPI.Operation) throws {
+        for parameter in operation.parameters {
+            try requireParameter(parameter)
+        }
+        for response in operation.responses.values {
+            try requireResponse(response)
+        }
+        if let requestBody = operation.requestBody {
+            try requireRequestBody(requestBody)
+        }
+        for callbacks in operation.callbacks.values {
+            try requireCallbacks(callbacks)
+        }
+    }
+
+    mutating func addComponentsReferencedBy(_ request: OpenAPI.Request) throws {
+        for content in request.content.values {
+            try addComponentsReferencedBy(content)
+        }
+    }
+    mutating func addComponentsReferencedBy(_ callbacks: OpenAPI.Callbacks) throws {
+        for pathItem in callbacks.values {
+            try requirePathItem(pathItem)
+        }
+    }
+
+    mutating func addComponentsReferencedBy(_ schema: JSONSchema) throws {
+        switch schema.value {
+
+        case .reference(let reference, _):
+            guard requiredSchemaReferences.insert(OpenAPI.Reference(reference)).inserted else { return }
+            try addComponentsReferencedBy(document.components.lookup(reference))
+
+        case .object(_, let object):
+            for schema in object.properties.values {
+                try addComponentsReferencedBy(schema)
+            }
+            if case .b(let schema) = object.additionalProperties {
+                try addComponentsReferencedBy(schema)
+            }
+
+        case .array(_, let array):
+            if let schema = array.items {
+                try addComponentsReferencedBy(schema)
+            }
+
+        case .not(let schema, _):
+            try addComponentsReferencedBy(schema)
+
+        case .all(of: let schemas, _): fallthrough
+        case .one(of: let schemas, _): fallthrough
+        case .any(of: let schemas, _):
+            for schema in schemas {
+                try addComponentsReferencedBy(schema)
+            }
+        case .null, .boolean, .number, .integer, .string, .fragment: return
+        }
+    }
+
+    mutating func addComponentsReferencedBy(_ parameter: OpenAPI.Parameter) throws {
+        try addComponentsReferencedBy(parameter.schemaOrContent)
+    }
+
+    mutating func addComponentsReferencedBy(_ header: OpenAPI.Header) throws {
+        try addComponentsReferencedBy(header.schemaOrContent)
+    }
+
+    mutating func addComponentsReferencedBy(
+        _ schemaOrContent: Either<OpenAPI.Parameter.SchemaContext, OpenAPI.Content.Map>
+    ) throws {
+        switch schemaOrContent {
+        case .a(let schemaContext):
+            switch schemaContext.schema {
+            case .a(let reference):
+                guard requiredSchemaReferences.insert(reference).inserted else { return }
+                try addComponentsReferencedBy(try document.components.lookup(reference))
+            case .b(let schema):
+                try addComponentsReferencedBy(schema)
+            }
+        case .b(let contentMap):
+            for value in contentMap.values {
+                switch value.schema {
+                case .a(let reference):
+                    guard requiredSchemaReferences.insert(reference).inserted else { return }
+                    try addComponentsReferencedBy(try document.components.lookup(reference))
+                case .b(let schema):
+                    try addComponentsReferencedBy(schema)
+                case .none:
+                    continue
+                }
+            }
+        }
+    }
+
+    mutating func addComponentsReferencedBy(_ response: OpenAPI.Response) throws {
+        if let headers = response.headers {
+            for header in headers.values {
+                try requireHeader(header)
+            }
+        }
+        for content in response.content.values {
+            try addComponentsReferencedBy(content)
+        }
+        for link in response.links.values {
+            try requireLink(link)
+        }
+    }
+
+    mutating func addComponentsReferencedBy(_ content: OpenAPI.Content) throws {
+        if let schema = content.schema {
+            try requireSchema(schema)
+        }
+        if let encoding = content.encoding {
+            for encoding in encoding.values {
+                if let headers = encoding.headers {
+                    for header in headers.values {
+                        try requireHeader(header)
+                    }
+                }
+            }
+        }
+        if let examples = content.examples {
+            for example in examples.values {
+                try requireExample(example)
+            }
+        }
+    }
+
+    mutating func addComponentsReferencedBy(_ content: OpenAPI.Link) throws {}
+
+    mutating func addComponentsReferencedBy(_ content: OpenAPI.Example) throws {}
+}

--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -23,7 +23,7 @@ import Foundation
 ///
 /// When adding a path to the filter, the transitive closure of all referenced components are also
 /// included in the filtered document.
-public struct FilteredDocumentBuilder {
+struct FilteredDocumentBuilder {
 
     /// The underlying OpenAPI document to filter.
     private(set) var document: OpenAPI.Document
@@ -43,7 +43,7 @@ public struct FilteredDocumentBuilder {
     /// Create a new FilteredDocumentBuilder.
     ///
     /// - Parameter document: The underlying OpenAPI document to filter.
-    public init(document: OpenAPI.Document) {
+    init(document: OpenAPI.Document) {
         self.document = document
         self.requiredPaths = []
         self.requiredPathItemReferences = []
@@ -61,7 +61,7 @@ public struct FilteredDocumentBuilder {
     /// Filter the underlying document based on the rules provided.
     ///
     /// - Returns: The filtered OpenAPI document.
-    public func filter() throws -> OpenAPI.Document {
+    func filter() throws -> OpenAPI.Document {
         var components = OpenAPI.Components.noComponents
         for reference in requiredSchemaReferences {
             components.schemas[try reference.internalComponentKey] = try document.components.lookup(reference)
@@ -116,7 +116,7 @@ public struct FilteredDocumentBuilder {
     /// referenced within the corresponding path item.
     ///
     /// - Parameter path: The path to be included in the filter.
-    public mutating func requirePath(_ path: OpenAPI.Path) throws {
+    mutating func requirePath(_ path: OpenAPI.Path) throws {
         guard let pathItem = document.paths[path] else {
             throw FilteredDocumentBuilderError.pathDoesNotExist(path)
         }
@@ -130,7 +130,7 @@ public struct FilteredDocumentBuilder {
     /// document with a subset of the operations defined in the original document.
     ///
     /// - Parameter tag: The tag to use to include operations (and their paths).
-    public mutating func requireOperations(tagged tag: String) throws {
+    mutating func requireOperations(tagged tag: String) throws {
         guard document.allTags.contains(tag) else {
             throw FilteredDocumentBuilderError.tagDoesNotExist(tag)
         }
@@ -143,7 +143,7 @@ public struct FilteredDocumentBuilder {
     /// document with a subset of the operations defined in the original document.
     ///
     /// - Parameter tag: The tag by which to include operations (and their paths).
-    public mutating func requireOperations(tagged tag: OpenAPI.Tag) throws {
+    mutating func requireOperations(tagged tag: OpenAPI.Tag) throws {
         try requireOperations(tagged: tag.name)
     }
 
@@ -153,7 +153,7 @@ public struct FilteredDocumentBuilder {
     /// in the original document.
     ///
     /// - Parameter operationID: The operation to include (and its path).
-    public mutating func requireOperation(operationID: String) throws {
+    mutating func requireOperation(operationID: String) throws {
         guard document.allOperationIds.contains(operationID) else {
             throw FilteredDocumentBuilderError.operationDoesNotExist(operationID: operationID)
         }
@@ -166,7 +166,7 @@ public struct FilteredDocumentBuilder {
     /// it references.
     ///
     /// - Parameter name: The key in the `#/components/schemas` map in the OpenAPI document.
-    public mutating func requireSchema(_ name: String) throws {
+    mutating func requireSchema(_ name: String) throws {
         try requireSchema(.a(OpenAPI.Reference<JSONSchema>.component(named: name)))
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -61,6 +61,7 @@ struct FilteredDocumentBuilder {
     /// Filter the underlying document based on the rules provided.
     ///
     /// - Returns: The filtered OpenAPI document.
+    /// - Throws: If any dependencies of the requested document components cannot be resolved.
     func filter() throws -> OpenAPI.Document {
         var components = OpenAPI.Components.noComponents
         for reference in requiredSchemaReferences {
@@ -116,6 +117,7 @@ struct FilteredDocumentBuilder {
     /// referenced within the corresponding path item.
     ///
     /// - Parameter path: The path to be included in the filter.
+    /// - Throws: If the path does not exist in original OpenAPI document.
     mutating func includePath(_ path: OpenAPI.Path) throws {
         guard let pathItem = document.paths[path] else {
             throw FilteredDocumentBuilderError.pathDoesNotExist(path)
@@ -130,6 +132,7 @@ struct FilteredDocumentBuilder {
     /// document with a subset of the operations defined in the original document.
     ///
     /// - Parameter tag: The tag to use to include operations (and their paths).
+    /// - Throws: If the tag does not exist in original OpenAPI document.
     mutating func includeOperations(tagged tag: String) throws {
         guard document.allTags.contains(tag) else {
             throw FilteredDocumentBuilderError.tagDoesNotExist(tag)
@@ -143,6 +146,7 @@ struct FilteredDocumentBuilder {
     /// document with a subset of the operations defined in the original document.
     ///
     /// - Parameter tag: The tag by which to include operations (and their paths).
+    /// - Throws: If the tag does not exist in original OpenAPI document.
     mutating func includeOperations(tagged tag: OpenAPI.Tag) throws {
         try includeOperations(tagged: tag.name)
     }
@@ -153,6 +157,7 @@ struct FilteredDocumentBuilder {
     /// in the original document.
     ///
     /// - Parameter operationID: The operation to include (and its path).
+    /// - Throws: If the operation does not exist in original OpenAPI document.
     mutating func includeOperation(operationID: String) throws {
         guard document.allOperationIds.contains(operationID) else {
             throw FilteredDocumentBuilderError.operationDoesNotExist(operationID: operationID)
@@ -166,6 +171,7 @@ struct FilteredDocumentBuilder {
     /// it references.
     ///
     /// - Parameter name: The key in the `#/components/schemas` map in the OpenAPI document.
+    /// - Throws: If the named schema does not exist in original OpenAPI document.
     mutating func includeSchema(_ name: String) throws {
         try includeSchema(.a(OpenAPI.Reference<JSONSchema>.component(named: name)))
     }

--- a/Sources/_OpenAPIGeneratorCore/Parser/YamsParser.swift
+++ b/Sources/_OpenAPIGeneratorCore/Parser/YamsParser.swift
@@ -40,11 +40,10 @@ public struct YamsParser: ParserProtocol {
         return yamlKeys
     }
 
-    func parseOpenAPI(
+    public static func parseOpenAPIDocument(
         _ input: InMemoryInputFile,
-        config: Config,
         diagnostics: any DiagnosticCollector
-    ) throws -> ParsedOpenAPIRepresentation {
+    ) throws -> OpenAPIKit.OpenAPI.Document {
         let decoder = YAMLDecoder()
         let openapiData = input.contents
 
@@ -93,13 +92,21 @@ public struct YamsParser: ParserProtocol {
         }
     }
 
+    func parseOpenAPI(
+        _ input: InMemoryInputFile,
+        config: Config,
+        diagnostics: any DiagnosticCollector
+    ) throws -> ParsedOpenAPIRepresentation {
+        try Self.parseOpenAPIDocument(input, diagnostics: diagnostics)
+    }
+
     /// Detects specific YAML parsing errors to throw nicely formatted diagnostics for IDEs.
     ///
     /// - Parameters:
     ///   - context: The decoding error context that triggered the parsing error.
     ///   - input: The input file being worked on when the parsing error was triggered.
     /// - Throws: Throws a `Diagnostic` if the decoding error is a common parsing error.
-    private func checkParsingError(
+    private static func checkParsingError(
         context: DecodingError.Context,
         input: InMemoryInputFile
     ) throws {

--- a/Sources/_OpenAPIGeneratorCore/Parser/YamsParser.swift
+++ b/Sources/_OpenAPIGeneratorCore/Parser/YamsParser.swift
@@ -40,6 +40,18 @@ public struct YamsParser: ParserProtocol {
         return yamlKeys
     }
 
+    /// Parses a YAML file as an OpenAPI document.
+    ///
+    /// This function supports documents following any of the following OpenAPI Specifications:
+    /// - 3.0.0, 3.0.1, 3.0.2, 3.0.3
+    /// - 3.1.0
+    ///
+    /// - Parameters
+    ///   - input: The file contents of the OpenAPI document.
+    ///   - diagnostics: A diagnostics collector used for emiting parsing warnings and errors.
+    /// - Returns: Parsed OpenAPI document.
+    /// - Throws: If the OpenAPI document cannot be parsed.
+    ///           Note that errors are also emited using the diagnostics collector.
     public static func parseOpenAPIDocument(
         _ input: InMemoryInputFile,
         diagnostics: any DiagnosticCollector

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -31,7 +31,13 @@ The configuration file has the following keys:
     - `client`: Client code that can be used with any client transport (depends on code from `types`).
     - `server`: Server code that can be used with any server transport (depends on code from `types`).
 - `additionalImports` (optional): array of strings. Each string value is a Swift module name. An import statement will be added to the generated source files for each module.
+- `filter`: (optional): Filters to apply to the OpenAPI document before generation.
+    - `operations`: Operations with these operation IDs will be included in the filter.
+    - `tags`: Operations tagged with these tags will be included in the filter.
+    - `paths`: Operations for these paths will be included in the filter.
+    - `schemas`: These (additional) schemas will be included in the filter.
 - `featureFlags` (optional): array of strings. Each string must be a valid feature flag to enable. For a list of currently supported feature flags, check out [FeatureFlags.swift](https://github.com/apple/swift-openapi-generator/blob/main/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift).
+
 
 ### Example config files
 
@@ -65,4 +71,41 @@ generate:
   - client
 additionalImports:
   - APITypes
+```
+
+### Document filtering
+
+The geneartor supports filtering the OpenAPI document prior to generation, which can be useful when
+generating client code for a subset of a large API.
+
+For example, to generate client code for only the operations with a given tag, use the following config:
+
+```yaml
+generate:
+  - types
+  - client
+
+filter:
+  tags:
+    - myTag
+```
+
+When multiple filters are specified, their union will be considered for inclusion.
+
+In all cases, the transitive closure of dependencies from the components object will be included.
+
+The CLI also provides a `filter` command that takes the same configuration file as the `generate`
+command, which can be used to inspect the filtered document:
+
+```
+% swift-openapi-generator filter --config path/to/openapi-generator-config.yaml path/to/openapi.yaml
+```
+
+To use this command as a standalone filtering tool, use the following config and redirect stdout to a new file:
+
+```yaml
+generate: []
+filter:
+  tags:
+    - myTag
 ```

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -75,8 +75,8 @@ additionalImports:
 
 ### Document filtering
 
-The geneartor supports filtering the OpenAPI document prior to generation, which can be useful when
-generating client code for a subset of a large API.
+The generator supports filtering the OpenAPI document prior to generation, which can be useful when
+generating client code for a subset of a large API, or splitting an implementation of a server across multiple modules.
 
 For example, to generate client code for only the operations with a given tag, use the following config:
 

--- a/Sources/swift-openapi-generator/FilterCommand.swift
+++ b/Sources/swift-openapi-generator/FilterCommand.swift
@@ -49,7 +49,6 @@ struct _FilterCommand: AsyncParsableCommand {
             "Parsing document",
             YamsParser.parseOpenAPIDocument(documentInput, diagnostics: StdErrPrintingDiagnosticCollector())
         )
-        try document.validate()
         guard let documentFilter = config.filter else {
             FileHandle.standardError.write("warning: No filter config provided\n")
             FileHandle.standardOutput.write(try encode(document, outputFormat))

--- a/Sources/swift-openapi-generator/FilterCommand.swift
+++ b/Sources/swift-openapi-generator/FilterCommand.swift
@@ -92,6 +92,7 @@ private func timing<Output>(_ title: String, _ operation: @autoclosure () throws
 private let sampleConfig = _UserConfig(
     generate: [],
     filter: DocumentFilter(
+        operations: ["getGreeting"],
         tags: ["greetings"],
         paths: ["/greeting"],
         schemas: ["Greeting"]

--- a/Sources/swift-openapi-generator/FilterCommand.swift
+++ b/Sources/swift-openapi-generator/FilterCommand.swift
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import ArgumentParser
+import Foundation
+import _OpenAPIGeneratorCore
+import Yams
+import OpenAPIKit
+import OpenAPIKit30
+
+struct _FilterCommand: AsyncParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "filter",
+        abstract: "Filter an OpenAPI document",
+        discussion: """
+            Filtering rules are provided in a YAML configuration file.
+
+            Example configuration file contents:
+
+            ```yaml
+            \(try! YAMLEncoder().encode(sampleConfig))
+            ```
+            """
+    )
+
+    @Option(help: "Path to a YAML configuration file.")
+    var config: URL
+
+    @Argument(help: "Path to the OpenAPI document, either in YAML or JSON.")
+    var docPath: URL
+
+    func parseOpenAPIDocument(_ documentData: Data) throws -> OpenAPIKit.OpenAPI.Document {
+        let decoder = YAMLDecoder()
+
+        struct OpenAPIVersionedDocument: Decodable {
+            var openapi: String
+        }
+
+        let versionedDocument = try decoder.decode(OpenAPIVersionedDocument.self, from: documentData)
+
+        let document: OpenAPIKit.OpenAPI.Document
+        switch versionedDocument.openapi {
+        case "3.0.0", "3.0.1", "3.0.2", "3.0.3":
+            let document30x = try decoder.decode(OpenAPIKit30.OpenAPI.Document.self, from: documentData)
+            document = document30x.convert(to: .v3_1_0)
+        case "3.1.0":
+            document = try decoder.decode(OpenAPIKit.OpenAPI.Document.self, from: documentData)
+        default:
+            fatalError("Unsupported OpenAPI version found: \(versionedDocument.openapi)")
+        }
+        return document
+    }
+
+    func run() async throws {
+        let configData = try Data(contentsOf: config)
+        let config = try YAMLDecoder().decode(_UserConfig.self, from: configData)
+        let document = try timing("Parsing document", parseOpenAPIDocument(Data(contentsOf: docPath)))
+        try document.validate()
+        guard let documentFilter = config.filter else {
+            FileHandle.standardError.write("warning: No filter config provided\n")
+            FileHandle.standardOutput.write(try YAMLEncoder().encode(document))
+            return
+        }
+        let filteredDocument = try timing("Filtering document", documentFilter.filter(document))
+        FileHandle.standardOutput.write(try YAMLEncoder().encode(filteredDocument))
+    }
+}
+
+private func timing<Output>(_ title: String, operation: () throws -> Output) rethrows -> Output {
+    FileHandle.standardError.write("\(title)...\n")
+    let start = Date.timeIntervalSinceReferenceDate
+    let result = try operation()
+    let diff = Date.timeIntervalSinceReferenceDate - start
+    FileHandle.standardError.write(String(format: "\(title) complete! (%.2fs)\n", diff))
+    return result
+}
+
+private func timing<Output>(_ title: String, _ operation: @autoclosure () throws -> Output) rethrows -> Output {
+    try timing(title, operation: operation)
+}
+
+private let sampleConfig = _UserConfig(
+    generate: [],
+    filter: DocumentFilter(
+        tags: ["greetings"],
+        paths: ["/greeting"],
+        schemas: ["Greeting"]
+    )
+)

--- a/Sources/swift-openapi-generator/FilterCommand.swift
+++ b/Sources/swift-openapi-generator/FilterCommand.swift
@@ -39,32 +39,14 @@ struct _FilterCommand: AsyncParsableCommand {
     @Argument(help: "Path to the OpenAPI document, either in YAML or JSON.")
     var docPath: URL
 
-    func parseOpenAPIDocument(_ documentData: Data) throws -> OpenAPIKit.OpenAPI.Document {
-        let decoder = YAMLDecoder()
-
-        struct OpenAPIVersionedDocument: Decodable {
-            var openapi: String
-        }
-
-        let versionedDocument = try decoder.decode(OpenAPIVersionedDocument.self, from: documentData)
-
-        let document: OpenAPIKit.OpenAPI.Document
-        switch versionedDocument.openapi {
-        case "3.0.0", "3.0.1", "3.0.2", "3.0.3":
-            let document30x = try decoder.decode(OpenAPIKit30.OpenAPI.Document.self, from: documentData)
-            document = document30x.convert(to: .v3_1_0)
-        case "3.1.0":
-            document = try decoder.decode(OpenAPIKit.OpenAPI.Document.self, from: documentData)
-        default:
-            fatalError("Unsupported OpenAPI version found: \(versionedDocument.openapi)")
-        }
-        return document
-    }
-
     func run() async throws {
         let configData = try Data(contentsOf: config)
         let config = try YAMLDecoder().decode(_UserConfig.self, from: configData)
-        let document = try timing("Parsing document", parseOpenAPIDocument(Data(contentsOf: docPath)))
+        let documentInput = try InMemoryInputFile(absolutePath: docPath, contents: Data(contentsOf: docPath))
+        let document = try timing(
+            "Parsing document",
+            YamsParser.parseOpenAPIDocument(documentInput, diagnostics: StdErrPrintingDiagnosticCollector())
+        )
         try document.validate()
         guard let documentFilter = config.filter else {
             FileHandle.standardError.write("warning: No filter config provided\n")

--- a/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
@@ -38,6 +38,7 @@ extension _GenerateOptions {
             .init(
                 mode: $0,
                 additionalImports: resolvedAdditionalImports,
+                filter: config?.filter,
                 featureFlags: resolvedFeatureFlags
             )
         }

--- a/Sources/swift-openapi-generator/Tool.swift
+++ b/Sources/swift-openapi-generator/Tool.swift
@@ -19,7 +19,8 @@ struct _Tool: AsyncParsableCommand {
         commandName: "swift-openapi-generator",
         abstract: "Generate Swift client and server code from an OpenAPI document",
         subcommands: [
-            _GenerateCommand.self
+            _FilterCommand.self,
+            _GenerateCommand.self,
         ]
     )
 }

--- a/Sources/swift-openapi-generator/UserConfig.swift
+++ b/Sources/swift-openapi-generator/UserConfig.swift
@@ -39,6 +39,7 @@ struct _UserConfig: Codable {
     enum CodingKeys: String, CaseIterable, CodingKey {
         case generate
         case additionalImports
+        case filter
         case featureFlags
     }
 }

--- a/Sources/swift-openapi-generator/UserConfig.swift
+++ b/Sources/swift-openapi-generator/UserConfig.swift
@@ -27,6 +27,9 @@ struct _UserConfig: Codable {
     /// generated Swift file.
     var additionalImports: [String]?
 
+    /// Filter to apply to the OpenAPI document before generation.
+    var filter: DocumentFilter?
+
     /// A set of features to explicitly enable.
     var featureFlags: FeatureFlags?
 

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
@@ -167,19 +167,3 @@ final class FilteredDocumentTests: XCTestCase {
         )
     }
 }
-
-private func XCTAssertUnsortedEqual<T>(
-    _ expression1: @autoclosure () throws -> [T],
-    _ expression2: @autoclosure () throws -> [T],
-    _ message: @autoclosure () -> String = "",
-    file: StaticString = #filePath,
-    line: UInt = #line
-) where T: Comparable {
-    XCTAssertEqual(
-        try expression1().sorted(),
-        try expression2().sorted(),
-        message(),
-        file: file,
-        line: line
-    )
-}

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
@@ -80,7 +80,7 @@ final class FilteredDocumentTests: XCTestCase {
             filtering: document,
             filter: DocumentFilter(tags: ["t"]),
             hasPaths: ["/things/a"],
-            hasOperations: ["getA", "deleteA"],
+            hasOperations: ["getA"],
             hasSchemas: ["A"]
         )
         try assert(
@@ -129,7 +129,7 @@ final class FilteredDocumentTests: XCTestCase {
             filtering: document,
             filter: DocumentFilter(tags: ["t"], schemas: ["B"]),
             hasPaths: ["/things/a"],
-            hasOperations: ["getA", "deleteA"],
+            hasOperations: ["getA"],
             hasSchemas: ["A", "B"]
         )
     }

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
@@ -69,70 +69,70 @@ final class FilteredDocumentTests: XCTestCase {
                   description: success
             """
         let document = try YAMLDecoder().decode(OpenAPI.Document.self, from: documentYAML)
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(),
             hasPaths: [],
             hasOperations: [],
             hasSchemas: []
         )
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(tags: ["t"]),
             hasPaths: ["/things/a"],
             hasOperations: ["getA"],
             hasSchemas: ["A"]
         )
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(paths: ["/things/a"]),
             hasPaths: ["/things/a"],
             hasOperations: ["getA", "deleteA"],
             hasSchemas: ["A"]
         )
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(paths: ["/things/b"]),
             hasPaths: ["/things/b"],
             hasOperations: ["getB"],
             hasSchemas: ["A", "B"]
         )
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(paths: ["/things/a", "/things/b"]),
             hasPaths: ["/things/a", "/things/b"],
             hasOperations: ["getA", "deleteA", "getB"],
             hasSchemas: ["A", "B"]
         )
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(schemas: ["A"]),
             hasPaths: [],
             hasOperations: [],
             hasSchemas: ["A"]
         )
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(schemas: ["B"]),
             hasPaths: [],
             hasOperations: [],
             hasSchemas: ["A", "B"]
         )
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(paths: ["/things/a"], schemas: ["B"]),
             hasPaths: ["/things/a"],
             hasOperations: ["getA", "deleteA"],
             hasSchemas: ["A", "B"]
         )
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(tags: ["t"], schemas: ["B"]),
             hasPaths: ["/things/a"],
             hasOperations: ["getA"],
             hasSchemas: ["A", "B"]
         )
-        try assert(
+        assert(
             filtering: document,
             filter: DocumentFilter(operations: ["deleteA"]),
             hasPaths: ["/things/a"],
@@ -149,7 +149,7 @@ final class FilteredDocumentTests: XCTestCase {
         hasSchemas schemas: [String],
         file: StaticString = #filePath,
         line: UInt = #line
-    ) throws {
+    ) {
         let filteredDocument: OpenAPI.Document
         do {
             filteredDocument = try filter.filter(document)

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
@@ -159,13 +159,18 @@ final class FilteredDocumentTests: XCTestCase {
         }
         XCTAssertUnsortedEqual(filteredDocument.paths.keys.map(\.rawValue), paths, file: file, line: line)
         XCTAssertUnsortedEqual(filteredDocument.allOperationIds, operationIDs, file: file, line: line)
-        XCTAssertUnsortedEqual(filteredDocument.components.schemas.keys.map(\.rawValue), schemas, file: file, line: line)
+        XCTAssertUnsortedEqual(
+            filteredDocument.components.schemas.keys.map(\.rawValue),
+            schemas,
+            file: file,
+            line: line
+        )
     }
 }
 
-fileprivate func XCTAssertUnsortedEqual<T>(
-    _ expression1: @autoclosure () throws -> Array<T>,
-    _ expression2: @autoclosure () throws -> Array<T>,
+private func XCTAssertUnsortedEqual<T>(
+    _ expression1: @autoclosure () throws -> [T],
+    _ expression2: @autoclosure () throws -> [T],
     _ message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIKit
+import XCTest
+import Yams
+@testable import _OpenAPIGeneratorCore
+
+final class FilteredDocumentTests: XCTestCase {
+
+    func testFilteredDocumentBuilder() throws {
+        let documentYAML = """
+            openapi: '3.1.0'
+            info:
+              title: GreetingService
+              version: 1.0.0
+            paths:
+              /A:
+                get:
+                  operationId: getA
+                  responses:
+                    '200':
+                      description: Success.
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/A'
+              /B:
+                get:
+                  operationId: getB
+                  responses:
+                    '200':
+                      description: Success.
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/B'
+            components:
+              schemas:
+                A: {}
+                B:
+                  $ref: '#/components/schemas/A'
+            """
+        let document = try YAMLDecoder().decode(OpenAPI.Document.self, from: documentYAML)
+        do {
+            let builder = FilteredDocumentBuilder(document: document)
+            let filteredDocument = try builder.filter()
+            XCTAssertEqual(filteredDocument.paths.keys, [])
+            XCTAssertEqual(filteredDocument.allOperationIds, [])
+            XCTAssertEqual(filteredDocument.components, .noComponents)
+        }
+        do {
+            var builder = FilteredDocumentBuilder(document: document)
+            try builder.requirePath(operationID: "getA")
+            let filteredDocument = try builder.filter()
+            XCTAssertEqual(filteredDocument.paths.keys, ["/A"])
+            XCTAssertEqual(filteredDocument.allOperationIds, ["getA"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A"].sorted())
+        }
+        do {
+            var builder = FilteredDocumentBuilder(document: document)
+            try builder.requirePath(operationID: "getB")
+            let filteredDocument = try builder.filter()
+            XCTAssertEqual(filteredDocument.paths.keys, ["/B"])
+            XCTAssertEqual(filteredDocument.allOperationIds, ["getB"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A", "B"].sorted())
+        }
+        do {
+            var builder = FilteredDocumentBuilder(document: document)
+            try builder.requirePath("/A")
+            let filteredDocument = try builder.filter()
+            XCTAssertEqual(filteredDocument.paths.keys, ["/A"])
+            XCTAssertEqual(filteredDocument.allOperationIds, ["getA"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A"].sorted())
+        }
+    }
+}

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
@@ -84,4 +84,108 @@ final class FilteredDocumentTests: XCTestCase {
             XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A"].sorted())
         }
     }
+
+    func testDocumentFilter() throws {
+        let documentYAML = """
+            openapi: 3.1.0
+            info:
+              title: ExampleService
+              version: 1.0.0
+            tags:
+            - name: t
+            paths:
+              /things/a:
+                get:
+                  tags:
+                  - t
+                  responses:
+                    200:
+                      $ref: '#/components/responses/A'
+              /things/b:
+                get:
+                  responses:
+                    200:
+                      $ref: '#/components/responses/B'
+            components:
+              schemas:
+                A:
+                  type: string
+                B:
+                  $ref: '#/components/schemas/A'
+              responses:
+                A:
+                  description: success
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/A'
+                B:
+                  description: success
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/B'
+            """
+        let document = try YAMLDecoder().decode(OpenAPI.Document.self, from: documentYAML)
+        do {
+            let documentFilter = DocumentFilter()
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssert(filteredDocument.paths.isEmpty)
+            XCTAssert(filteredDocument.components.isEmpty)
+        }
+        do {
+            let documentFilter = DocumentFilter(tags: ["t"])
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssertEqual(filteredDocument.paths.keys, ["/things/a"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A"].sorted())
+        }
+        do {
+            let documentFilter = DocumentFilter(paths: ["/things/a"])
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssertEqual(filteredDocument.paths.keys, ["/things/a"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A"].sorted())
+        }
+        do {
+            let documentFilter = DocumentFilter(paths: ["/things/b"])
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssertEqual(filteredDocument.paths.keys, ["/things/b"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A", "B"].sorted())
+        }
+        do {
+            let documentFilter = DocumentFilter(paths: ["/things/a", "/things/b"])
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssertEqual(filteredDocument.paths.keys, ["/things/a", "/things/b"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A", "B"].sorted())
+        }
+        do {
+            let documentFilter = DocumentFilter(schemas: ["A"])
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssertEqual(filteredDocument.paths.keys, [])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A"].sorted())
+        }
+        do {
+            let documentFilter = DocumentFilter(schemas: ["B"])
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssertEqual(filteredDocument.paths.keys, [])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A", "B"].sorted())
+        }
+        do {
+            let documentFilter = DocumentFilter(paths: ["/things/a"], schemas: ["B"])
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssertEqual(filteredDocument.paths.keys, ["/things/a"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A", "B"].sorted())
+        }
+        do {
+            let documentFilter = DocumentFilter(tags: ["t"], schemas: ["B"])
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssertEqual(filteredDocument.paths.keys, ["/things/a"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A", "B"].sorted())
+        }
+        do {
+            let documentFilter = DocumentFilter(tags: ["t"], paths: ["/things/b"])
+            let filteredDocument = try documentFilter.filter(document)
+            XCTAssertEqual(filteredDocument.paths.keys, ["/things/a", "/things/b"])
+            XCTAssertEqual(filteredDocument.components.schemas.keys.map(\.rawValue).sorted(), ["A", "B"].sorted())
+        }
+    }
 }

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/FilteredDocumentTests.swift
@@ -132,6 +132,13 @@ final class FilteredDocumentTests: XCTestCase {
             hasOperations: ["getA"],
             hasSchemas: ["A", "B"]
         )
+        try assert(
+            filtering: document,
+            filter: DocumentFilter(operations: ["deleteA"]),
+            hasPaths: ["/things/a"],
+            hasOperations: ["deleteA"],
+            hasSchemas: []
+        )
     }
 
     func assert(

--- a/Tests/OpenAPIGeneratorCoreTests/TestUtilities.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/TestUtilities.swift
@@ -157,6 +157,22 @@ func XCTAssertEqualCodable<T>(
     XCTFail(messageLines.joined(separator: "\n"), file: file, line: line)
 }
 
+func XCTAssertUnsortedEqual<T>(
+    _ expression1: @autoclosure () throws -> [T],
+    _ expression2: @autoclosure () throws -> [T],
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) where T: Comparable {
+    XCTAssertEqual(
+        try expression1().sorted(),
+        try expression2().sorted(),
+        message(),
+        file: file,
+        line: line
+    )
+}
+
 /// Both names must have the same number of components, throws otherwise.
 func newTypeName(swiftFQName: String, jsonFQName: String) throws -> TypeName {
     var jsonComponents = jsonFQName.split(separator: "/").map(String.init)


### PR DESCRIPTION
### Motivation

When generating client code, Swift OpenAPI Generator generates code for the entire OpenAPI document, even if the user only makes use of a subset of its types and operations.

Generating code that is unused constitutes overhead for the adopter:
- The overhead of generating code for unused types and operations
- The overhead of compiling the generated code
- The overhead of unused code in the users codebase (AOT generation)

This is particularly noticeable when working with a small subset of a large API, which can result in O(100k) lines of unused code and long generation and compile times.

For a more detailed motivation and design, see the proposal in #303.

### Modifications

- Add document filter to the generator config.
- Run filter as a post-transition hook in the generator pipeline after parsing the document.
- Provide a CLI command that outputs the filtered document to stdout.

### Result

Users can filter a document before code-generation. For large APIs, this can result in >90% speedup (see proposal).

### Test Plan

- Unit tests.