### PR TITLE
Add an SSWG badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Swift OpenAPI Generator
 
+[![](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://www.swift.org/sswg/)
+
 Generate Swift client and server code from an OpenAPI document.
 
 ## Overview


### PR DESCRIPTION
### Motivation

Now that Swift OpenAPI Generator has been [accepted](https://forums.swift.org/t/sswg-0026-swift-openapi-generator/67164/8) into the [SSWG incubation process](https://github.com/swift-server/sswg/blob/master/process/incubation.md#sandbox-level), add the badge as recommended in their docs.

### Modifications

Added the badge.

### Result

Users can tell that this is an SSWG project.

### Test Plan

N/A
