### PR TITLE
Update all examples and integration tests to 0.3.0

### DIFF
--- a/Examples/GreetingService/Package.swift
+++ b/Examples/GreetingService/Package.swift
@@ -20,9 +20,9 @@ let package = Package(
         .macOS(.v13)
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.2.0")),
-        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.2.0")),
-        .package(url: "https://github.com/swift-server/swift-openapi-vapor", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/swift-server/swift-openapi-vapor", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/vapor/vapor", from: "4.76.0"),
     ],
     targets: [

--- a/Examples/GreetingServiceClient/Package.swift
+++ b/Examples/GreetingServiceClient/Package.swift
@@ -15,14 +15,12 @@
 import PackageDescription
 
 let package = Package(
-    name: "GreetingService",
+    name: "GreetingServiceClient",
     platforms: [
         .macOS(.v13)
     ],
     dependencies: [
-        // TODO: When swift-openapi-generator is tagged with 0.3.0, stop depending on main.
-        // .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.3.0"),
-        .package(url: "https://github.com/apple/swift-openapi-generator", branch: "main"),
+        .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/apple/swift-openapi-urlsession", .upToNextMinor(from: "0.3.0")),
     ],

--- a/Examples/GreetingServiceClient/Sources/GreetingServiceClient/GreetingServiceClient.swift
+++ b/Examples/GreetingServiceClient/Sources/GreetingServiceClient/GreetingServiceClient.swift
@@ -20,8 +20,8 @@ struct GreetingServiceClient {
     static func main() async throws {
         // Create an instance of the generated client type.
         let client: APIProtocol = Client(
-            // Server.server1() is generated, derived from the server URL in the OpenAPI document.
-            serverURL: try Servers.server1(),
+            // Server.server2() is generated, derived from the server URL in the OpenAPI document.
+            serverURL: try Servers.server2(),
             // URLSessionTransport conforms to ClientTransport and is provided by a separate package.
             transport: URLSessionTransport()
         )

--- a/Examples/GreetingServiceClient/Sources/GreetingServiceClient/openapi.yaml
+++ b/Examples/GreetingServiceClient/Sources/GreetingServiceClient/openapi.yaml
@@ -5,6 +5,8 @@ info:
 servers:
   - url: https://example.com/api
     description: Example
+  - url: http://localhost:8080/api
+    description: Localhost
 paths:
   /greet:
     get:

--- a/IntegrationTest/Package.swift
+++ b/IntegrationTest/Package.swift
@@ -32,9 +32,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        // TODO: When swift-openapi-generator is tagged with 0.3.0, stop depending on main.
-        // .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.3.0"),
-        .package(url: "https://github.com/apple/swift-openapi-generator", branch: "main"),
+        .package(url: "https://github.com/apple/swift-openapi-generator", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.3.0")),
     ],
     targets: [


### PR DESCRIPTION
### Motivation

We're ready to release 0.3.0, so update all examples and integration tests, so that once tagged, the code uses the latest versions.

### Modifications

Updated integration tests and examples, also made a few minor improvements.

### Result

All code refers to 0.3.0.

### Test Plan

Verified manually, but some of these might not pass because 0.3.0 of the generator doesn't exist yet - chicken and egg, but that's understood as part of this process.
