### PR TITLE
Improve structured Swift representation for recursive type support

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -267,6 +267,12 @@ struct VariableDescription: Equatable, Codable {
     /// For example, in `var foo: Int { set { _foo = newValue } }`, `body`
     /// represents `{ _foo = newValue }`.
     var setter: [CodeBlock]? = nil
+
+    /// Body code for the `_modify` accessor.
+    ///
+    /// For example, in `var foo: Int { _modify { yield &_foo } }`, `body`
+    /// represents `{ yield &_foo }`.
+    var modify: [CodeBlock]? = nil
 }
 
 /// A requirement of a where clause.
@@ -832,6 +838,9 @@ enum KeywordKind: Equatable, Codable {
 
     /// The throw keyword.
     case `throw`
+
+    /// The yield keyword.
+    case `yield`
 }
 
 /// A description of an expression that places a keyword before an expression.
@@ -1087,6 +1096,7 @@ extension Declaration {
     ///   - getter: Body code for the getter of the variable.
     ///   - getterEffects: Effects of the getter.
     ///   - setter: Body code for the setter of the variable.
+    ///   - modify: Body code for the `_modify` accessor.
     /// - Returns: Variable declaration.
     static func variable(
         accessModifier: AccessModifier? = nil,
@@ -1097,7 +1107,9 @@ extension Declaration {
         right: Expression? = nil,
         getter: [CodeBlock]? = nil,
         getterEffects: [FunctionKeyword] = [],
-        setter: [CodeBlock]? = nil
+        setter: [CodeBlock]? = nil,
+        modify: [CodeBlock]? = nil
+
     ) -> Self {
         .variable(
             .init(
@@ -1109,7 +1121,8 @@ extension Declaration {
                 right: right,
                 getter: getter,
                 getterEffects: getterEffects,
-                setter: setter
+                setter: setter,
+                modify: modify
             )
         )
     }
@@ -1497,6 +1510,14 @@ extension Expression {
     /// - Returns: A new expression with the `await` keyword placed before the expression.
     static func `await`(_ expression: Expression) -> Self {
         .unaryKeyword(kind: .await, expression: expression)
+    }
+
+    /// Returns a new expression that puts the yield keyword before
+    /// an expression.
+    /// - Parameter expression: The expression to prepend.
+    /// - Returns: A new expression with the `yield` keyword placed before the expression.
+    static func `yield`(_ expression: Expression) -> Self {
+        .unaryKeyword(kind: .yield, expression: expression)
     }
 
     /// Returns a new value binding used in enums with associated values.

--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -121,10 +121,10 @@ enum LiteralDescription: Equatable, Codable {
 /// For example, in `let foo = 42`, `foo` is an identifier.
 enum IdentifierDescription: Equatable, Codable {
 
-    /// A variable identifier.
+    /// A pattern identifier.
     ///
     /// For example, `foo` in `let foo = 42`.
-    case variable(String)
+    case pattern(String)
 
     /// A type identifier.
     ///
@@ -1342,7 +1342,7 @@ extension Expression {
     /// - Returns: A new expression representing an identifier with
     ///   the specified name.
     static func identifierPattern(_ name: String) -> Self {
-        .identifier(.variable(name))
+        .identifier(.pattern(name))
     }
 
     /// Returns a new identifier expression for the provided type name.

--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -119,12 +119,17 @@ enum LiteralDescription: Equatable, Codable {
 /// A description of an identifier, such as a variable name.
 ///
 /// For example, in `let foo = 42`, `foo` is an identifier.
-struct IdentifierDescription: Equatable, Codable {
+enum IdentifierDescription: Equatable, Codable {
 
-    /// The name of the identifier.
+    /// A variable identifier.
     ///
     /// For example, `foo` in `let foo = 42`.
-    var name: String
+    case variable(String)
+
+    /// A type identifier.
+    ///
+    /// For example, `Swift.String` in `let foo: Swift.String = "hi"`.
+    case type(ExistingTypeDescription)
 }
 
 /// A description of a member access expression.
@@ -170,25 +175,40 @@ struct FunctionCallDescription: Equatable, Codable {
     var calledExpression: Expression
 
     /// The arguments to be passed to the function.
-    var arguments: [FunctionArgumentDescription] = []
+    var arguments: [FunctionArgumentDescription]
+
+    /// A trailing closure.
+    var trailingClosure: ClosureInvocationDescription?
 
     /// Creates a new function call description.
     /// - Parameters:
     ///   - calledExpression: An expression that returns the function to be called.
     ///   - arguments: Arguments to be passed to the function.
-    init(calledExpression: Expression, arguments: [FunctionArgumentDescription] = []) {
+    ///   - trailingClosure: A trailing closure.
+    init(
+        calledExpression: Expression,
+        arguments: [FunctionArgumentDescription] = [],
+        trailingClosure: ClosureInvocationDescription? = nil
+    ) {
         self.calledExpression = calledExpression
         self.arguments = arguments
+        self.trailingClosure = trailingClosure
     }
 
     /// Creates a new function call description.
     /// - Parameters:
     ///   - calledExpression: An expression that returns the function to be called.
     ///   - arguments: Arguments to be passed to the function.
-    init(calledExpression: Expression, arguments: [Expression]) {
+    ///   - trailingClosure: A trailing closure.
+    init(
+        calledExpression: Expression,
+        arguments: [Expression],
+        trailingClosure: ClosureInvocationDescription? = nil
+    ) {
         self.init(
             calledExpression: calledExpression,
-            arguments: arguments.map { .init(label: nil, expression: $0) }
+            arguments: arguments.map { .init(label: nil, expression: $0) },
+            trailingClosure: trailingClosure
         )
     }
 }
@@ -225,7 +245,7 @@ struct VariableDescription: Equatable, Codable {
     /// The type of the variable.
     ///
     /// For example, in `let foo: Int = 42`, `type` is `Int`.
-    var type: String?
+    var type: ExistingTypeDescription?
 
     /// The expression to be assigned to the variable.
     ///
@@ -241,6 +261,12 @@ struct VariableDescription: Equatable, Codable {
     ///
     /// For example, in `var foo: Int { get throws { 42 } }`, effects are `[.throws]`.
     var getterEffects: [FunctionKeyword] = []
+
+    /// Body code for the setter.
+    ///
+    /// For example, in `var foo: Int { set { _foo = newValue } }`, `body`
+    /// represents `{ _foo = newValue }`.
+    var setter: [CodeBlock]? = nil
 }
 
 /// A requirement of a where clause.
@@ -317,6 +343,10 @@ struct EnumDescription: Equatable, Codable {
     /// attribute.
     var isFrozen: Bool = false
 
+    /// A Boolean value that indicates whether the enum has the `indirect`
+    /// keyword.
+    var isIndirect: Bool = false
+
     /// An access modifier.
     var accessModifier: AccessModifier? = nil
 
@@ -332,6 +362,41 @@ struct EnumDescription: Equatable, Codable {
 
     /// The declarations that make up the enum body.
     var members: [Declaration] = []
+}
+
+/// A description of a type reference.
+indirect enum ExistingTypeDescription: Equatable, Codable {
+
+    /// A type with the `any` keyword in front of it.
+    ///
+    /// For example, `any Foo`.
+    case any(ExistingTypeDescription)
+
+    /// An optional type.
+    ///
+    /// For example, `Foo?`.
+    case optional(ExistingTypeDescription)
+
+    /// A wrapper type generic over a wrapped type.
+    ///
+    /// For example, `Wrapper<Wrapped>`.
+    case generic(wrapper: ExistingTypeDescription, wrapped: ExistingTypeDescription)
+
+    /// A type reference represented by the components.
+    ///
+    /// For example, `MyModule.Foo`.
+    case member([String])
+
+    /// An array with an element type.
+    ///
+    /// For example, `[Foo]`.
+    case array(ExistingTypeDescription)
+
+    /// A dictionary where the key is `Swift.String` and the value is
+    /// the provided type.
+    ///
+    /// For example, `[String: Foo]`.
+    case dictionaryValue(ExistingTypeDescription)
 }
 
 /// A description of a typealias declaration.
@@ -350,7 +415,7 @@ struct TypealiasDescription: Equatable, Codable {
     /// The existing type that serves as the underlying type of the alias.
     ///
     /// For example, in `typealias Foo = Int`, `existingType` is `Int`.
-    var existingType: String
+    var existingType: ExistingTypeDescription
 }
 
 /// A description of a protocol declaration.
@@ -395,7 +460,7 @@ struct ParameterDescription: Equatable, Codable {
     /// The type name of the parameter.
     ///
     /// For example, in `bar baz: String = "hi"`, `type` is `String`.
-    var type: String
+    var type: ExistingTypeDescription
 
     /// A default value of the parameter.
     ///
@@ -538,7 +603,7 @@ struct EnumCaseAssociatedValueDescription: Equatable, Codable {
     /// A variable type name.
     ///
     /// For example, in `bar: String`, `type` is `String`.
-    var type: String
+    var type: ExistingTypeDescription
 }
 
 /// An enum case kind.
@@ -1021,16 +1086,18 @@ extension Declaration {
     ///   - right: The expression to be assigned to the variable.
     ///   - getter: Body code for the getter of the variable.
     ///   - getterEffects: Effects of the getter.
+    ///   - setter: Body code for the setter of the variable.
     /// - Returns: Variable declaration.
     static func variable(
         accessModifier: AccessModifier? = nil,
         isStatic: Bool = false,
         kind: BindingKind,
         left: String,
-        type: String? = nil,
+        type: ExistingTypeDescription? = nil,
         right: Expression? = nil,
         getter: [CodeBlock]? = nil,
-        getterEffects: [FunctionKeyword] = []
+        getterEffects: [FunctionKeyword] = [],
+        setter: [CodeBlock]? = nil
     ) -> Self {
         .variable(
             .init(
@@ -1041,7 +1108,8 @@ extension Declaration {
                 type: type,
                 right: right,
                 getter: getter,
-                getterEffects: getterEffects
+                getterEffects: getterEffects,
+                setter: setter
             )
         )
     }
@@ -1072,7 +1140,7 @@ extension Declaration {
     static func `typealias`(
         accessModifier: AccessModifier? = nil,
         name: String,
-        existingType: String
+        existingType: ExistingTypeDescription
     ) -> Self {
         .typealias(
             .init(
@@ -1193,12 +1261,6 @@ extension Declaration {
     }
 }
 
-extension IdentifierDescription: ExpressibleByStringLiteral {
-    init(stringLiteral value: String) {
-        self.init(name: value)
-    }
-}
-
 extension FunctionKind {
     /// Returns a non-failable initializer, for example `init()`.
     static var initializer: Self {
@@ -1274,11 +1336,37 @@ extension Expression {
         return Self.memberAccess(.init(right: member))
     }
 
-    /// Returns a new identifier expression for the provided name.
+    /// Returns a new identifier expression for the provided pattern, such
+    /// as a variable or function name.
     /// - Parameter name: The name of the identifier.
-    /// - Returns: A new expression representing an identifier with the specified name.
-    static func identifier(_ name: String) -> Self {
-        .identifier(.init(name: name))
+    /// - Returns: A new expression representing an identifier with
+    ///   the specified name.
+    static func identifierPattern(_ name: String) -> Self {
+        .identifier(.variable(name))
+    }
+
+    /// Returns a new identifier expression for the provided type name.
+    /// - Parameter type: The description of the type.
+    /// - Returns: A new expression representing an identifier with
+    ///   the specified name.
+    static func identifierType(_ type: ExistingTypeDescription) -> Self {
+        .identifier(.type(type))
+    }
+
+    /// Returns a new identifier expression for the provided type name.
+    /// - Parameter type: The name of the type.
+    /// - Returns: A new expression representing an identifier with
+    ///   the specified name.
+    static func identifierType(_ type: TypeName) -> Self {
+        .identifier(.type(.init(type)))
+    }
+
+    /// Returns a new identifier expression for the provided type name.
+    /// - Parameter type: The usage of the type.
+    /// - Returns: A new expression representing an identifier with
+    ///   the specified name.
+    static func identifierType(_ type: TypeUsage) -> Self {
+        .identifier(.type(.init(type)))
     }
 
     /// Returns a new switch statement expression.
@@ -1326,15 +1414,18 @@ extension Expression {
     /// - Parameters:
     ///   - calledExpression: The expression to be called as a function.
     ///   - arguments: The arguments to be passed to the function call.
+    ///   - trailingClosure: A trailing closure.
     /// - Returns: A new expression representing a function call with the specified called expression and arguments.
     static func functionCall(
         calledExpression: Expression,
-        arguments: [FunctionArgumentDescription] = []
+        arguments: [FunctionArgumentDescription] = [],
+        trailingClosure: ClosureInvocationDescription? = nil
     ) -> Self {
         .functionCall(
             .init(
                 calledExpression: calledExpression,
-                arguments: arguments
+                arguments: arguments,
+                trailingClosure: trailingClosure
             )
         )
     }
@@ -1345,15 +1436,18 @@ extension Expression {
     /// - Parameters:
     ///   - calledExpression: The expression called as a function.
     ///   - arguments: The arguments passed to the function call.
+    ///   - trailingClosure: A trailing closure.
     /// - Returns: A new expression representing a function call with the specified called expression and arguments.
     static func functionCall(
         calledExpression: Expression,
-        arguments: [Expression]
+        arguments: [Expression],
+        trailingClosure: ClosureInvocationDescription? = nil
     ) -> Self {
         .functionCall(
             .init(
                 calledExpression: calledExpression,
-                arguments: arguments.map { .init(label: nil, expression: $0) }
+                arguments: arguments.map { .init(label: nil, expression: $0) },
+                trailingClosure: trailingClosure
             )
         )
     }
@@ -1604,5 +1698,88 @@ extension Declaration {
             return .deprecated(.init(), self)
         }
         return self
+    }
+
+    /// Returns the declaration one level deeper, nested inside the commentable
+    /// declaration, if present.
+    var strippingTopComment: Self {
+        guard case let .commentable(_, underlyingDecl) = self else {
+            return self
+        }
+        return underlyingDecl
+    }
+}
+
+extension Declaration {
+
+    /// An access modifier.
+    var accessModifier: AccessModifier? {
+        get {
+            switch self {
+            case .commentable(_, let declaration):
+                return declaration.accessModifier
+            case .deprecated(_, let declaration):
+                return declaration.accessModifier
+            case .variable(let variableDescription):
+                return variableDescription.accessModifier
+            case .extension(let extensionDescription):
+                return extensionDescription.accessModifier
+            case .struct(let structDescription):
+                return structDescription.accessModifier
+            case .enum(let enumDescription):
+                return enumDescription.accessModifier
+            case .typealias(let typealiasDescription):
+                return typealiasDescription.accessModifier
+            case .protocol(let protocolDescription):
+                return protocolDescription.accessModifier
+            case .function(let functionDescription):
+                return functionDescription.signature.accessModifier
+            case .enumCase:
+                return nil
+            }
+        }
+        set {
+            switch self {
+            case .commentable(let comment, var declaration):
+                declaration.accessModifier = newValue
+                self = .commentable(comment, declaration)
+            case .deprecated(let deprecationDescription, var declaration):
+                declaration.accessModifier = newValue
+                self = .deprecated(deprecationDescription, declaration)
+            case .variable(var variableDescription):
+                variableDescription.accessModifier = newValue
+                self = .variable(variableDescription)
+            case .extension(var extensionDescription):
+                extensionDescription.accessModifier = newValue
+                self = .extension(extensionDescription)
+            case .struct(var structDescription):
+                structDescription.accessModifier = newValue
+                self = .struct(structDescription)
+            case .enum(var enumDescription):
+                enumDescription.accessModifier = newValue
+                self = .enum(enumDescription)
+            case .typealias(var typealiasDescription):
+                typealiasDescription.accessModifier = newValue
+                self = .typealias(typealiasDescription)
+            case .protocol(var protocolDescription):
+                protocolDescription.accessModifier = newValue
+                self = .protocol(protocolDescription)
+            case .function(var functionDescription):
+                functionDescription.signature.accessModifier = newValue
+                self = .function(functionDescription)
+            case .enumCase:
+                break
+            }
+        }
+    }
+}
+
+extension ExistingTypeDescription {
+
+    /// Creates a member type description with the provided single component.
+    /// - Parameter singleComponent: A single component of the name.
+    /// - Returns: The new type description.
+    static func member(_ singleComponent: String) -> Self {
+        .member([singleComponent])
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -245,6 +245,8 @@ struct TextBasedRenderer: RendererProtocol {
             return "await"
         case .throw:
             return "throw"
+        case .yield:
+            return "yield"
         }
     }
 
@@ -462,12 +464,17 @@ struct TextBasedRenderer: RendererProtocol {
         var lines: [String] = [words.joinedWords()]
         if let body = variable.getter {
             lines.append("{")
-            let hasExplicitGetter = !variable.getterEffects.isEmpty || variable.setter != nil
+            let hasExplicitGetter = !variable.getterEffects.isEmpty || variable.setter != nil || variable.modify != nil
             if hasExplicitGetter {
                 lines.append("get \(variable.getterEffects.map(renderedFunctionKeyword).joined(separator: " ")) {")
             }
             lines.append(renderedCodeBlocks(body))
             if hasExplicitGetter {
+                lines.append("}")
+            }
+            if let modify = variable.modify {
+                lines.append("_modify {")
+                lines.append(renderedCodeBlocks(modify))
                 lines.append("}")
             }
             if let setter = variable.setter {

--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -118,7 +118,12 @@ struct TextBasedRenderer: RendererProtocol {
 
     /// Renders the specified identifier.
     func renderedIdentifier(_ identifier: IdentifierDescription) -> String {
-        return identifier.name
+        switch identifier {
+        case .variable(let string):
+            return string
+        case .type(let existingTypeDescription):
+            return renderedExistingTypeDescription(existingTypeDescription)
+        }
     }
 
     /// Renders the specified member access expression.
@@ -136,8 +141,15 @@ struct TextBasedRenderer: RendererProtocol {
     /// Renders the specified function call.
     func renderedFunctionCall(_ functionCall: FunctionCallDescription) -> String {
         let arguments = functionCall.arguments
+        let trailingClosureString: String
+        if let trailingClosure = functionCall.trailingClosure {
+            trailingClosureString = renderedClosureInvocation(trailingClosure)
+        } else {
+            trailingClosureString = ""
+        }
         return
             "\(renderedExpression(functionCall.calledExpression))(\(arguments.map(renderedFunctionCallArgument).joined(separator: ", ")))"
+            + trailingClosureString
     }
 
     /// Renders the specified assignment expression.
@@ -382,6 +394,24 @@ struct TextBasedRenderer: RendererProtocol {
         return lines.joinedLines()
     }
 
+    /// Renders the specified type reference to an existing type.
+    func renderedExistingTypeDescription(_ type: ExistingTypeDescription) -> String {
+        switch type {
+        case .any(let existingTypeDescription):
+            return "any \(renderedExistingTypeDescription(existingTypeDescription))"
+        case .generic(let wrapper, let wrapped):
+            return "\(renderedExistingTypeDescription(wrapper))<\(renderedExistingTypeDescription(wrapped))>"
+        case .optional(let existingTypeDescription):
+            return "\(renderedExistingTypeDescription(existingTypeDescription))?"
+        case .member(let components):
+            return components.joined(separator: ".")
+        case .array(let existingTypeDescription):
+            return "[\(renderedExistingTypeDescription(existingTypeDescription))]"
+        case .dictionaryValue(let existingTypeDescription):
+            return "[String: \(renderedExistingTypeDescription(existingTypeDescription))]"
+        }
+    }
+
     /// Renders the specified typealias declaration.
     func renderedTypealias(_ alias: TypealiasDescription) -> String {
         var words: [String] = []
@@ -392,7 +422,7 @@ struct TextBasedRenderer: RendererProtocol {
             "typealias",
             alias.name,
             "=",
-            alias.existingType,
+            renderedExistingTypeDescription(alias.existingType),
         ])
         return words.joinedWords()
     }
@@ -419,7 +449,7 @@ struct TextBasedRenderer: RendererProtocol {
         words.append(renderedBindingKind(variable.kind))
         let labelWithOptionalType: String
         if let type = variable.type {
-            labelWithOptionalType = "\(variable.left): \(type)"
+            labelWithOptionalType = "\(variable.left): \(renderedExistingTypeDescription(type))"
         } else {
             labelWithOptionalType = variable.left
         }
@@ -432,11 +462,17 @@ struct TextBasedRenderer: RendererProtocol {
         var lines: [String] = [words.joinedWords()]
         if let body = variable.getter {
             lines.append("{")
-            if !variable.getterEffects.isEmpty {
+            let hasExplicitGetter = !variable.getterEffects.isEmpty || variable.setter != nil
+            if hasExplicitGetter {
                 lines.append("get \(variable.getterEffects.map(renderedFunctionKeyword).joined(separator: " ")) {")
             }
             lines.append(renderedCodeBlocks(body))
-            if !variable.getterEffects.isEmpty {
+            if hasExplicitGetter {
+                lines.append("}")
+            }
+            if let setter = variable.setter {
+                lines.append("set {")
+                lines.append(renderedCodeBlocks(setter))
                 lines.append("}")
             }
             lines.append("}")
@@ -505,6 +541,9 @@ struct TextBasedRenderer: RendererProtocol {
         if let accessModifier = enumDesc.accessModifier {
             words.append(renderedAccessModifier(accessModifier))
         }
+        if enumDesc.isIndirect {
+            words.append("indirect")
+        }
         words.append("enum")
         words.append(enumDesc.name)
         if !enumDesc.conformances.isEmpty {
@@ -532,7 +571,7 @@ struct TextBasedRenderer: RendererProtocol {
             words.append(label)
             words.append(":")
         }
-        words.append(value.type)
+        words.append(renderedExistingTypeDescription(value.type))
         return words.joinedWords()
     }
 
@@ -663,7 +702,7 @@ struct TextBasedRenderer: RendererProtocol {
             }
         }
         words.append(":")
-        words.append(parameterDescription.type)
+        words.append(renderedExistingTypeDescription(parameterDescription.type))
         if let defaultValue = parameterDescription.defaultValue {
             words.append("=")
             words.append(renderedExpression(defaultValue))

--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -119,7 +119,7 @@ struct TextBasedRenderer: RendererProtocol {
     /// Renders the specified identifier.
     func renderedIdentifier(_ identifier: IdentifierDescription) -> String {
         switch identifier {
-        case .variable(let string):
+        case .pattern(let string):
             return string
         case .type(let existingTypeDescription):
             return renderedExistingTypeDescription(existingTypeDescription)

--- a/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/ClientTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/ClientTranslator.swift
@@ -56,7 +56,7 @@ struct ClientFileTranslator: FileTranslator {
                 accessModifier: .private,
                 kind: .let,
                 left: Constants.Client.Universal.propertyName,
-                type: Constants.Client.Universal.typeName
+                type: .member(Constants.Client.Universal.typeName)
             )
         )
 
@@ -77,43 +77,46 @@ struct ClientFileTranslator: FileTranslator {
                 accessModifier: config.access,
                 kind: .initializer,
                 parameters: [
-                    .init(label: "serverURL", type: Constants.ServerURL.underlyingType),
+                    .init(
+                        label: "serverURL",
+                        type: .init(TypeName.url)
+                    ),
                     .init(
                         label: "configuration",
-                        type: Constants.Configuration.typeName,
+                        type: .member(Constants.Configuration.typeName),
                         defaultValue: .dot("init").call([])
                     ),
                     .init(
                         label: "transport",
-                        type: Constants.Client.Transport.typeName
+                        type: .member(Constants.Client.Transport.typeName)
                     ),
                     .init(
                         label: "middlewares",
-                        type: "[\(Constants.Client.Middleware.typeName)]",
+                        type: .array(.member(Constants.Client.Middleware.typeName)),
                         defaultValue: .literal(.array([]))
                     ),
                 ],
                 body: [
                     .expression(
                         .assignment(
-                            left: .identifier("self").dot(Constants.Client.Universal.propertyName),
+                            left: .identifierPattern("self").dot(Constants.Client.Universal.propertyName),
                             right: .dot("init")
                                 .call([
                                     .init(
                                         label: "serverURL",
-                                        expression: .identifier("serverURL")
+                                        expression: .identifierPattern("serverURL")
                                     ),
                                     .init(
                                         label: "configuration",
-                                        expression: .identifier("configuration")
+                                        expression: .identifierPattern("configuration")
                                     ),
                                     .init(
                                         label: "transport",
-                                        expression: .identifier("transport")
+                                        expression: .identifierPattern("transport")
                                     ),
                                     .init(
                                         label: "middlewares",
-                                        expression: .identifier("middlewares")
+                                        expression: .identifierPattern("middlewares")
                                     ),
                                 ])
                         )
@@ -126,10 +129,10 @@ struct ClientFileTranslator: FileTranslator {
             accessModifier: .private,
             kind: .var,
             left: "converter",
-            type: Constants.Converter.typeName,
+            type: .member(Constants.Converter.typeName),
             getter: [
                 .expression(
-                    .identifier(Constants.Client.Universal.propertyName)
+                    .identifierPattern(Constants.Client.Universal.propertyName)
                         .dot("converter")
                 )
             ]

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
@@ -214,7 +214,7 @@ extension FileTranslator {
                         kind: .nameWithAssociatedValues([
                             .init(
                                 label: nil,
-                                type: childType.fullyQualifiedSwiftName
+                                type: .init(childType)
                             )
                         ])
                     )

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateArray.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateArray.swift
@@ -69,7 +69,7 @@ extension FileTranslator {
             .`typealias`(
                 accessModifier: config.access,
                 name: typeName.shortSwiftName,
-                existingType: elementType.typeName.asUsage.asArray.fullyQualifiedSwiftName
+                existingType: .init(elementType.typeName.asUsage.asArray)
             )
         )
         return inline + [arrayDecl]

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateRawRepresentableEnum.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateRawRepresentableEnum.swift
@@ -56,7 +56,7 @@ extension FileTranslator {
                 .enumCase(
                     name: unknownCaseName,
                     kind: .nameWithAssociatedValues([
-                        .init(type: "String")
+                        .init(type: .init(TypeName.string))
                     ])
                 )
             )
@@ -69,7 +69,7 @@ extension FileTranslator {
                             .expression(
                                 .assignment(
                                     Expression
-                                        .identifier("self")
+                                        .identifierPattern("self")
                                         .equals(
                                             .dot(caseName)
                                         )
@@ -84,14 +84,14 @@ extension FileTranslator {
                         .expression(
                             .assignment(
                                 Expression
-                                    .identifier("self")
+                                    .identifierPattern("self")
                                     .equals(
                                         .functionCall(
                                             calledExpression: .dot(
                                                 unknownCaseName
                                             ),
                                             arguments: [
-                                                .identifier("rawValue")
+                                                .identifierPattern("rawValue")
                                             ]
                                         )
                                     )
@@ -104,13 +104,16 @@ extension FileTranslator {
                         accessModifier: config.access,
                         kind: .initializer(failable: true),
                         parameters: [
-                            .init(label: "rawValue", type: "String")
+                            .init(
+                                label: "rawValue",
+                                type: .init(TypeName.string)
+                            )
                         ],
                         body: [
                             .expression(
                                 .switch(
                                     switchedExpression: customSwitchedExpression(
-                                        .identifier("rawValue")
+                                        .identifierPattern("rawValue")
                                     ),
                                     cases: knownCases + [unknownCase]
                                 )
@@ -141,14 +144,14 @@ extension FileTranslator {
                                     unknownCaseName
                                 ),
                                 arguments: [
-                                    .identifier("string")
+                                    .identifierPattern("string")
                                 ]
                             )
                         )
                     ),
                     body: [
                         .expression(
-                            .return(.identifier("string"))
+                            .return(.identifierPattern("string"))
                         )
                     ]
                 )
@@ -157,11 +160,11 @@ extension FileTranslator {
                     accessModifier: config.access,
                     kind: .var,
                     left: "rawValue",
-                    type: "String",
+                    type: .init(TypeName.string),
                     getter: [
                         .expression(
                             .switch(
-                                switchedExpression: .identifier("self"),
+                                switchedExpression: .identifierPattern("self"),
                                 cases: [unknownCase] + knownCases
                             )
                         )
@@ -179,16 +182,14 @@ extension FileTranslator {
                     .memberAccess(.init(right: caseName))
                 }
                 allCasesGetter = .variable(
-                    .init(
-                        accessModifier: config.access,
-                        isStatic: true,
-                        kind: .var,
-                        left: "allCases",
-                        type: "[Self]",
-                        getter: [
-                            .expression(.literal(.array(caseExpressions)))
-                        ]
-                    )
+                    accessModifier: config.access,
+                    isStatic: true,
+                    kind: .var,
+                    left: "allCases",
+                    type: .array(.member("Self")),
+                    getter: [
+                        .expression(.literal(.array(caseExpressions)))
+                    ]
                 )
             }
             otherMembers = [

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStructBlueprint.swift
@@ -91,7 +91,7 @@ extension FileTranslator {
                 (
                     ParameterDescription(
                         label: property.swiftSafeName,
-                        type: property.renderedFullyQualifiedSwiftName,
+                        type: .init(property.typeUsage),
                         defaultValue: property.defaultValue?.asExpression
                     ),
                     property.swiftSafeName
@@ -104,9 +104,9 @@ extension FileTranslator {
                 .expression(
                     .assignment(
                         Expression
-                            .identifier("self")
+                            .identifierPattern("self")
                             .dot(variableName)
-                            .equals(.identifier(variableName))
+                            .equals(.identifierPattern(variableName))
                     )
                 )
             }
@@ -132,7 +132,6 @@ extension FileTranslator {
     func translatePropertyBlueprint(
         _ property: PropertyBlueprint
     ) -> [Declaration] {
-        let propertyTypeName = property.renderedFullyQualifiedSwiftName
         let propertyDecl: Declaration = .commentable(
             property.comment,
             .variable(
@@ -140,7 +139,7 @@ extension FileTranslator {
                     accessModifier: config.access,
                     kind: .var,
                     left: property.swiftSafeName,
-                    type: propertyTypeName
+                    type: .init(property.typeUsage)
                 )
             )
             .deprecate(if: property.isDeprecated)

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateTypealias.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateTypealias.swift
@@ -30,7 +30,7 @@ extension FileTranslator {
         let typealiasDescription = TypealiasDescription(
             accessModifier: config.access,
             name: typeName.shortSwiftName,
-            existingType: existingTypeUsage.fullyQualifiedNonOptionalSwiftName
+            existingType: .init(existingTypeUsage.withOptional(false))
         )
         let typealiasComment: Comment? =
             typeName

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Annotations.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Annotations.swift
@@ -15,9 +15,9 @@ extension VariableDescription {
 
     /// Returns an expression that suppresses mutability warnings.
     var suppressMutabilityWarningExpr: Expression {
-        .identifier("suppressMutabilityWarning")
+        .identifierPattern("suppressMutabilityWarning")
             .call([
-                .init(label: nil, expression: .inOut(.identifier(left)))
+                .init(label: nil, expression: .inOut(.identifierPattern(left)))
             ])
     }
 }
@@ -42,9 +42,9 @@ extension Expression {
     /// the warning.
     /// - Returns: An expression that represents the call to suppress the unused variable warning.
     static func suppressUnusedWarning(for name: String) -> Self {
-        .identifier("suppressUnusedWarning")
+        .identifierPattern("suppressUnusedWarning")
             .call([
-                .init(label: nil, expression: .identifier(name))
+                .init(label: nil, expression: .identifierPattern(name))
             ])
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -48,9 +48,6 @@ enum Constants {
 
         /// The prefix of each generated method name.
         static let propertyPrefix: String = "server"
-
-        /// The underlying type.
-        static let underlyingType: String = "URL"
     }
 
     /// Constants related to the configuration type, which is used by both

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
@@ -158,11 +158,6 @@ extension PropertyBlueprint {
         asSwiftSafeName(originalName)
     }
 
-    /// A human-readable, fully qualified name of the Swift property.
-    var renderedFullyQualifiedSwiftName: String {
-        typeUsage.fullyQualifiedSwiftName
-    }
-
     /// The JSON path to the property.
     ///
     /// Nil if the parent JSON path is nil.

--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -262,11 +262,11 @@ extension OperationDescription {
             parameters: [
                 .init(
                     name: Constants.Operation.Input.variableName,
-                    type: inputTypeName.fullyQualifiedSwiftName
+                    type: .init(inputTypeName)
                 )
             ],
             keywords: [.async, .throws],
-            returnType: .identifier(outputTypeName.fullyQualifiedSwiftName)
+            returnType: .identifierType(outputTypeName)
         )
     }
 
@@ -277,12 +277,24 @@ extension OperationDescription {
             accessModifier: nil,
             kind: .function(name: methodName),
             parameters: [
-                .init(label: "request", type: "HTTPRequest"),
-                .init(label: "body", type: "HTTPBody?"),
-                .init(label: "metadata", type: "ServerRequestMetadata"),
+                .init(
+                    label: "request",
+                    type: .init(TypeName.request)
+                ),
+                .init(
+                    label: "body",
+                    type: .optional(.init(TypeName.body))
+                ),
+                .init(
+                    label: "metadata",
+                    type: .init(TypeName.serverRequestMetadata)
+                ),
             ],
             keywords: [.async, .throws],
-            returnType: .tuple([.identifier("HTTPResponse"), .identifier("HTTPBody?")])
+            returnType: .tuple([
+                .identifierType(TypeName.response),
+                .identifierType(TypeName.body.asUsage.asOptional),
+            ])
         )
     }
 
@@ -305,7 +317,9 @@ extension OperationDescription {
             let names: [Expression] =
                 pathParameters
                 .map { param in
-                    .identifier("input.path.\(asSwiftSafeName(param.name))")
+                    .identifierPattern("input")
+                        .dot("path")
+                        .dot(asSwiftSafeName(param.name))
                 }
             let arrayExpr: Expression = .literal(.array(names))
             return (template, arrayExpr)

--- a/Sources/_OpenAPIGeneratorCore/Translator/Parameters/translateParameter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Parameters/translateParameter.swift
@@ -127,11 +127,11 @@ extension ClientFileTranslator {
         switch parameter.location {
         case .header:
             methodPrefix = "HeaderField"
-            containerExpr = .identifier(requestVariableName).dot("headerFields")
+            containerExpr = .identifierPattern(requestVariableName).dot("headerFields")
             supportsStyleAndExplode = false
         case .query:
             methodPrefix = "QueryItem"
-            containerExpr = .identifier(requestVariableName)
+            containerExpr = .identifierPattern(requestVariableName)
             supportsStyleAndExplode = true
         default:
             diagnostics.emitUnsupported(
@@ -150,7 +150,7 @@ extension ClientFileTranslator {
             styleAndExplodeArgs = []
         }
         return .try(
-            .identifier("converter")
+            .identifierPattern("converter")
                 .dot("set\(methodPrefix)As\(parameter.codingStrategy.runtimeName)")
                 .call(
                     [
@@ -162,7 +162,7 @@ extension ClientFileTranslator {
                         .init(label: "name", expression: .literal(parameter.name)),
                         .init(
                             label: "value",
-                            expression: .identifier(inputVariableName)
+                            expression: .identifierPattern(inputVariableName)
                                 .dot(parameter.location.shortVariableName)
                                 .dot(parameter.variableName)
                         ),
@@ -183,9 +183,9 @@ extension ServerFileTranslator {
         _ typedParameter: TypedParameter
     ) throws -> FunctionArgumentDescription? {
         let parameter = typedParameter.parameter
-        let parameterTypeName = typedParameter
+        let parameterTypeUsage = typedParameter
             .typeUsage
-            .fullyQualifiedNonOptionalSwiftName
+            .withOptional(false)
 
         func methodName(_ parameterLocationName: String, _ requiresOptionality: Bool = true) -> String {
             let optionality: String
@@ -201,40 +201,40 @@ extension ServerFileTranslator {
         switch parameter.location {
         case .path:
             convertExpr = .try(
-                .identifier("converter").dot(methodName("PathParameter", false))
+                .identifierPattern("converter").dot(methodName("PathParameter", false))
                     .call([
-                        .init(label: "in", expression: .identifier("metadata").dot("pathParameters")),
+                        .init(label: "in", expression: .identifierPattern("metadata").dot("pathParameters")),
                         .init(label: "name", expression: .literal(parameter.name)),
                         .init(
                             label: "as",
-                            expression: .identifier(parameterTypeName).dot("self")
+                            expression: .identifierType(parameterTypeUsage).dot("self")
                         ),
                     ])
             )
         case .query:
             convertExpr = .try(
-                .identifier("converter").dot(methodName("QueryItem"))
+                .identifierPattern("converter").dot(methodName("QueryItem"))
                     .call([
-                        .init(label: "in", expression: .identifier("request").dot("soar_query")),
+                        .init(label: "in", expression: .identifierPattern("request").dot("soar_query")),
                         .init(label: "style", expression: .dot(typedParameter.style.runtimeName)),
                         .init(label: "explode", expression: .literal(.bool(typedParameter.explode))),
                         .init(label: "name", expression: .literal(parameter.name)),
                         .init(
                             label: "as",
-                            expression: .identifier(parameterTypeName).dot("self")
+                            expression: .identifierType(parameterTypeUsage).dot("self")
                         ),
                     ])
             )
         case .header:
             convertExpr = .try(
-                .identifier("converter")
+                .identifierPattern("converter")
                     .dot(methodName("HeaderField"))
                     .call([
-                        .init(label: "in", expression: .identifier("request").dot("headerFields")),
+                        .init(label: "in", expression: .identifierPattern("request").dot("headerFields")),
                         .init(label: "name", expression: .literal(parameter.name)),
                         .init(
                             label: "as",
-                            expression: .identifier(parameterTypeName).dot("self")
+                            expression: .identifierType(parameterTypeUsage).dot("self")
                         ),
                     ])
             )

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponse.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponse.swift
@@ -101,7 +101,7 @@ extension TypesFileTranslator {
                     .enumCase(
                         name: identifier,
                         kind: .nameWithAssociatedValues([
-                            .init(type: associatedType.fullyQualifiedSwiftName)
+                            .init(type: .init(associatedType))
                         ])
                     )
                 )
@@ -109,8 +109,8 @@ extension TypesFileTranslator {
 
                 var throwingGetterSwitchCases = [
                     SwitchCaseDescription(
-                        kind: .case(.identifier(".\(identifier)"), ["body"]),
-                        body: [.expression(.return(.identifier("body")))]
+                        kind: .case(.dot(identifier), ["body"]),
+                        body: [.expression(.return(.identifierPattern("body")))]
                     )
                 ]
                 // We only generate the default branch if there is more than one case to prevent
@@ -122,13 +122,13 @@ extension TypesFileTranslator {
                             body: [
                                 .expression(
                                     .try(
-                                        .identifier("throwUnexpectedResponseBody")
+                                        .identifierPattern("throwUnexpectedResponseBody")
                                             .call([
                                                 .init(
                                                     label: "expectedContent",
                                                     expression: .literal(.string(contentType.headerValueForValidation))
                                                 ),
-                                                .init(label: "body", expression: .identifier("self")),
+                                                .init(label: "body", expression: .identifierPattern("self")),
                                             ])
                                     )
                                 )
@@ -141,11 +141,11 @@ extension TypesFileTranslator {
                     isStatic: false,
                     kind: .var,
                     left: identifier,
-                    type: associatedType.fullyQualifiedSwiftName,
+                    type: .init(associatedType),
                     getter: [
                         .expression(
                             .switch(
-                                switchedExpression: .identifier("self"),
+                                switchedExpression: .identifierPattern("self"),
                                 cases: throwingGetterSwitchCases
                             )
                         )

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseHeader.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseHeader.swift
@@ -105,22 +105,20 @@ extension ClientFileTranslator {
         .init(
             label: header.variableName,
             expression: .try(
-                .identifier("converter")
+                .identifierPattern("converter")
                     .dot(
                         "get\(header.isOptional ? "Optional" : "Required")HeaderFieldAs\(header.codingStrategy.runtimeName)"
                     )
                     .call([
                         .init(
                             label: "in",
-                            expression: .identifier(responseVariableName).dot("headerFields")
+                            expression: .identifierPattern(responseVariableName).dot("headerFields")
                         ),
                         .init(label: "name", expression: .literal(header.name)),
                         .init(
                             label: "as",
                             expression:
-                                .identifier(
-                                    header.typeUsage.fullyQualifiedNonOptionalSwiftName
-                                )
+                                .identifierType(header.typeUsage.withOptional(false))
                                 .dot("self")
                         ),
                     ])
@@ -144,20 +142,20 @@ extension ServerFileTranslator {
         responseVariableName: String
     ) throws -> Expression {
         return .try(
-            .identifier("converter")
+            .identifierPattern("converter")
                 .dot("setHeaderFieldAs\(header.codingStrategy.runtimeName)")
                 .call([
                     .init(
                         label: "in",
                         expression: .inOut(
-                            .identifier(responseVariableName)
+                            .identifierPattern(responseVariableName)
                                 .dot("headerFields")
                         )
                     ),
                     .init(label: "name", expression: .literal(header.name)),
                     .init(
                         label: "value",
-                        expression: .identifier("value")
+                        expression: .identifierPattern("value")
                             .dot("headers")
                             .dot(header.variableName)
                     ),

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/ServerTranslator.swift
@@ -109,13 +109,27 @@ struct ServerFileTranslator: FileTranslator {
             let registerHandlerServerVarDecl: Declaration = .variable(
                 kind: .let,
                 left: "server",
-                right: .identifier(Constants.Server.Universal.typeName)
-                    .call([
-                        .init(label: "serverURL", expression: .identifier("serverURL")),
-                        .init(label: "handler", expression: .identifier("self")),
-                        .init(label: "configuration", expression: .identifier("configuration")),
-                        .init(label: "middlewares", expression: .identifier("middlewares")),
-                    ])
+                right: .identifierType(.member(Constants.Server.Universal.typeName))
+                    .call(
+                        [
+                            .init(
+                                label: "serverURL",
+                                expression: .identifierPattern("serverURL")
+                            ),
+                            .init(
+                                label: "handler",
+                                expression: .identifierPattern("self")
+                            ),
+                            .init(
+                                label: "configuration",
+                                expression: .identifierPattern("configuration")
+                            ),
+                            .init(
+                                label: "middlewares",
+                                expression: .identifierPattern("middlewares")
+                            ),
+                        ]
+                    )
             )
 
             registerHandlersDeclBody.append(.declaration(registerHandlerServerVarDecl))
@@ -141,21 +155,21 @@ struct ServerFileTranslator: FileTranslator {
                     .init(
                         label: "on",
                         name: "transport",
-                        type: Constants.Server.Transport.typeName
+                        type: .member(Constants.Server.Transport.typeName)
                     ),
                     .init(
                         label: "serverURL",
-                        type: "\(Constants.ServerURL.underlyingType)",
+                        type: .init(TypeName.url),
                         defaultValue: .dot("defaultOpenAPIServerURL")
                     ),
                     .init(
                         label: "configuration",
-                        type: Constants.Configuration.typeName,
+                        type: .member(Constants.Configuration.typeName),
                         defaultValue: .dot("init").call([])
                     ),
                     .init(
                         label: "middlewares",
-                        type: "[\(Constants.Server.Middleware.typeName)]",
+                        type: .array(.member(Constants.Server.Middleware.typeName)),
                         defaultValue: .literal(.array([]))
                     ),
                 ],

--- a/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ServerTranslator/translateServerMethod.swift
@@ -33,7 +33,7 @@ extension ServerFileTranslator {
         ) -> FunctionArgumentDescription {
             .init(
                 label: location.shortVariableName,
-                expression: .identifier(location.shortVariableName)
+                expression: .identifierPattern(location.shortVariableName)
             )
         }
 
@@ -60,7 +60,7 @@ extension ServerFileTranslator {
             let decl: Declaration = .variable(
                 kind: .let,
                 left: variableName,
-                type: type.fullyQualifiedSwiftName,
+                type: .init(type),
                 right: .dot("init").call(arguments)
             )
             let argument = functionArgumentForLocation(location)
@@ -76,12 +76,12 @@ extension ServerFileTranslator {
                 .init(
                     label: Constants.Operation.AcceptableContentType.variableName,
                     expression: .try(
-                        .identifier("converter")
+                        .identifierPattern("converter")
                             .dot("extractAcceptHeaderIfPresent")
                             .call([
                                 .init(
                                     label: "in",
-                                    expression: .identifier("request").dot("headerFields")
+                                    expression: .identifierPattern("request").dot("headerFields")
                                 )
                             ])
                     )
@@ -126,14 +126,14 @@ extension ServerFileTranslator {
                     bodyCodeBlocks,
                     .init(
                         label: "body",
-                        expression: .identifier("body")
+                        expression: .identifierPattern("body")
                     )
                 )
             )
         }
 
         let returnExpr: Expression = .return(
-            .identifier(inputTypeName.fullyQualifiedSwiftName)
+            .identifierType(inputTypeName)
                 .call(inputMembers.map(\.argument))
         )
 
@@ -167,7 +167,7 @@ extension ServerFileTranslator {
                 .tuple([
                     .dot("init")
                         .call([
-                            .init(label: "soar_statusCode", expression: .identifier("statusCode"))
+                            .init(label: "soar_statusCode", expression: .identifierPattern("statusCode"))
                         ]),
                     nil,
                 ])
@@ -188,7 +188,7 @@ extension ServerFileTranslator {
             )
         }
         let switchStatusCodeExpr: Expression = .switch(
-            switchedExpression: .identifier("output"),
+            switchedExpression: .identifierPattern("output"),
             cases: cases
         )
         return .closureInvocation(
@@ -215,7 +215,7 @@ extension ServerFileTranslator {
 
         let operationTypeExpr =
             Expression
-            .identifier(Constants.Operations.namespace)
+            .identifierType(.member(Constants.Operations.namespace))
             .dot(description.methodName)
 
         let operationArg = FunctionArgumentDescription(
@@ -224,25 +224,25 @@ extension ServerFileTranslator {
         )
         let requestArg = FunctionArgumentDescription(
             label: "request",
-            expression: .identifier("request")
+            expression: .identifierPattern("request")
         )
         let requestBodyArg = FunctionArgumentDescription(
             label: "requestBody",
-            expression: .identifier("body")
+            expression: .identifierPattern("body")
         )
         let metadataArg = FunctionArgumentDescription(
             label: "metadata",
-            expression: .identifier("metadata")
+            expression: .identifierPattern("metadata")
         )
         let methodArg = FunctionArgumentDescription(
             label: "using",
             expression: .closureInvocation(
                 body: [
                     .expression(
-                        .identifier(Constants.Server.Universal.apiHandlerName)
+                        .identifierPattern(Constants.Server.Universal.apiHandlerName)
                             .dot(description.methodName)
                             .call([
-                                .init(label: nil, expression: .identifier("$0"))
+                                .init(label: nil, expression: .identifierPattern("$0"))
                             ])
                     )
                 ]
@@ -262,12 +262,12 @@ extension ServerFileTranslator {
                 .expression(
                     .try(
                         .await(
-                            .identifier(serverUrlVariableName)
+                            .identifierPattern(serverUrlVariableName)
                                 .dot(description.methodName)
                                 .call([
-                                    .init(label: "request", expression: .identifier("$0")),
-                                    .init(label: "body", expression: .identifier("$1")),
-                                    .init(label: "metadata", expression: .identifier("$2")),
+                                    .init(label: "request", expression: .identifierPattern("$0")),
+                                    .init(label: "body", expression: .identifierPattern("$1")),
+                                    .init(label: "metadata", expression: .identifierPattern("$2")),
                                 ])
                         )
                     )
@@ -275,13 +275,13 @@ extension ServerFileTranslator {
             ]
         )
         let registerCall: Expression = .try(
-            .identifier("transport").dot("register")
+            .identifierPattern("transport").dot("register")
                 .call([
                     .init(label: nil, expression: wrapperClosureExpr),
                     .init(label: "method", expression: .dot(description.httpMethodLowercased)),
                     .init(
                         label: "path",
-                        expression: .identifier(serverUrlVariableName)
+                        expression: .identifierPattern(serverUrlVariableName)
                             .dot("apiPathComponentsWithServerPrefix")
                             .call([
                                 .init(
@@ -297,7 +297,7 @@ extension ServerFileTranslator {
 
         let handleExpr: Expression = .try(
             .await(
-                .identifier("handle")
+                .identifierPattern("handle")
                     .call([
                         requestArg,
                         requestBodyArg,

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
@@ -56,6 +56,16 @@ extension TypeName {
         TypeName(swiftKeyPath: ["HTTPTypes", name])
     }
 
+    /// Returns the type name for the URL type.
+    static var url: Self {
+        .foundation("URL")
+    }
+
+    /// Returns the type name for the DecodingError type.
+    static var decodingError: Self {
+        .swift("DecodingError")
+    }
+
     /// Returns the type name for the UndocumentedPayload type.
     static var undocumentedPayload: Self {
         .runtime(Constants.Operation.Output.undocumentedCaseAssociatedValueTypeName)
@@ -81,8 +91,18 @@ extension TypeName {
         .httpTypes("HTTPRequest")
     }
 
+    /// Returns the type name for the response type.
+    static var response: TypeName {
+        .httpTypes("HTTPResponse")
+    }
+
     /// Returns the type name for the body type.
     static var body: TypeName {
         .runtime("HTTPBody")
+    }
+
+    /// Returns the type name for the server request metadata type.
+    static var serverRequestMetadata: TypeName {
+        .runtime("ServerRequestMetadata")
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeName.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeName.swift
@@ -40,7 +40,7 @@ struct TypeName: Hashable {
     private let components: [Component]
 
     /// The list of Swift path components.
-    private var swiftKeyPathComponents: [String] {
+    var swiftKeyPathComponents: [String] {
         components.compactMap(\.swift)
     }
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeUsage.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeUsage.swift
@@ -217,3 +217,41 @@ extension TypeName {
         TypeUsage(wrapped: .name(self), usage: .identity)
     }
 }
+
+extension ExistingTypeDescription {
+
+    /// Creates a new type description from the provided type usage's wrapped
+    /// value.
+    /// - Parameter wrapped: The wrapped value.
+    private init(_ wrapped: TypeUsage.Wrapped) {
+        switch wrapped {
+        case .name(let typeName):
+            self = .init(typeName)
+        case .usage(let typeUsage):
+            self = .init(typeUsage)
+        }
+    }
+
+    /// Creates a new type description from the provided type name.
+    /// - Parameter typeName: A type name.
+    init(_ typeName: TypeName) {
+        self = .member(typeName.swiftKeyPathComponents)
+    }
+
+    /// Creates a new type description from the provided type usage.
+    /// - Parameter typeUsage: A type usage.
+    init(_ typeUsage: TypeUsage) {
+        switch typeUsage.usage {
+        case .generic(wrapper: let wrapper):
+            self = .generic(wrapper: .init(wrapper), wrapped: .init(typeUsage.wrapped))
+        case .optional:
+            self = .optional(.init(typeUsage.wrapped))
+        case .identity:
+            self = .init(typeUsage.wrapped)
+        case .array:
+            self = .array(.init(typeUsage.wrapped))
+        case .dictionaryValue:
+            self = .dictionaryValue(.init(typeUsage.wrapped))
+        }
+    }
+}

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
@@ -69,15 +69,15 @@ extension TypesFileTranslator {
                     kind: .function(name: operation.methodName),
                     parameters: initializer.signature.parameters,
                     keywords: [.async, .throws],
-                    returnType: .identifier(operation.outputTypeName.fullyQualifiedSwiftName),
+                    returnType: .identifierType(operation.outputTypeName),
                     body: [
                         .try(
                             .await(
-                                .identifier(operation.methodName)
+                                .identifierPattern(operation.methodName)
                                     .call([
                                         FunctionArgumentDescription(
                                             label: nil,
-                                            expression: .identifier(operation.inputTypeName.fullyQualifiedSwiftName)
+                                            expression: .identifierType(operation.inputTypeName)
                                                 .call(
                                                     initializer.signature.parameters.map { parameter in
                                                         guard let label = parameter.label else {
@@ -85,7 +85,7 @@ extension TypesFileTranslator {
                                                         }
                                                         return FunctionArgumentDescription(
                                                             label: label,
-                                                            expression: .identifier(label)
+                                                            expression: .identifierPattern(label)
                                                         )
                                                     }
                                                 )

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
@@ -178,8 +178,13 @@ extension TypesFileTranslator {
                 .enumCase(
                     name: Constants.Operation.Output.undocumentedCaseName,
                     kind: .nameWithAssociatedValues([
-                        .init(label: "statusCode", type: TypeName.int.shortSwiftName),
-                        .init(type: TypeName.undocumentedPayload.fullyQualifiedSwiftName),
+                        .init(
+                            label: "statusCode",
+                            type: .init(TypeName.int)
+                        ),
+                        .init(
+                            type: .init(TypeName.undocumentedPayload)
+                        ),
                     ])
                 )
             )
@@ -248,7 +253,7 @@ extension TypesFileTranslator {
                 isStatic: true,
                 kind: .let,
                 left: "id",
-                type: "String",
+                type: .init(TypeName.string),
                 right: .literal(operation.operationID)
             )
         )

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateServers.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateServers.swift
@@ -37,11 +37,11 @@ extension TypesFileTranslator {
                 keywords: [
                     .throws
                 ],
-                returnType: .identifier(Constants.ServerURL.underlyingType),
+                returnType: .identifierType(TypeName.url),
                 body: [
                     .expression(
                         .try(
-                            .identifier(Constants.ServerURL.underlyingType)
+                            .identifierType(TypeName.url)
                                 .call([
                                     .init(
                                         label: "validatingOpenAPIServerURL",

--- a/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
@@ -236,7 +236,7 @@ final class Test_TextBasedRenderer: XCTestCase {
                 """#
         )
         try _test(
-            .identifier("foo"),
+            .identifierPattern("foo"),
             renderedBy: renderer.renderedExpression,
             rendersAs:
                 #"""
@@ -246,7 +246,7 @@ final class Test_TextBasedRenderer: XCTestCase {
         try _test(
             .memberAccess(
                 .init(
-                    left: .identifier("foo"),
+                    left: .identifierPattern("foo"),
                     right: "bar"
                 )
             ),
@@ -259,11 +259,11 @@ final class Test_TextBasedRenderer: XCTestCase {
         try _test(
             .functionCall(
                 .init(
-                    calledExpression: .identifier("callee"),
+                    calledExpression: .identifierPattern("callee"),
                     arguments: [
                         .init(
                             label: nil,
-                            expression: .identifier("foo")
+                            expression: .identifierPattern("foo")
                         )
                     ]
                 )
@@ -324,11 +324,11 @@ final class Test_TextBasedRenderer: XCTestCase {
                 """#
         )
         try _test(
-            .typealias(.init(name: "foo", existingType: "bar")),
+            .typealias(.init(name: "foo", existingType: .member(["Foo", "Bar"]))),
             renderedBy: renderer.renderedDeclaration,
             rendersAs:
                 #"""
-                typealias foo = bar
+                typealias foo = Foo.Bar
                 """#
         )
         try _test(
@@ -402,7 +402,7 @@ final class Test_TextBasedRenderer: XCTestCase {
             .init(
                 label: "l",
                 name: "n",
-                type: "T",
+                type: .member("T"),
                 defaultValue: .literal(.nil)
             ),
             renderedBy: renderer.renderedParameter,
@@ -416,7 +416,7 @@ final class Test_TextBasedRenderer: XCTestCase {
             .init(
                 label: nil,
                 name: "n",
-                type: "T",
+                type: .member("T"),
                 defaultValue: .literal(.nil)
             ),
             renderedBy: renderer.renderedParameter,
@@ -430,7 +430,7 @@ final class Test_TextBasedRenderer: XCTestCase {
             .init(
                 label: "l",
                 name: nil,
-                type: "T",
+                type: .member("T"),
                 defaultValue: .literal(.nil)
             ),
             renderedBy: renderer.renderedParameter,
@@ -444,7 +444,7 @@ final class Test_TextBasedRenderer: XCTestCase {
             .init(
                 label: nil,
                 name: nil,
-                type: "T",
+                type: .member("T"),
                 defaultValue: .literal(.nil)
             ),
             renderedBy: renderer.renderedParameter,
@@ -458,7 +458,7 @@ final class Test_TextBasedRenderer: XCTestCase {
             .init(
                 label: nil,
                 name: nil,
-                type: "T",
+                type: .member("T"),
                 defaultValue: nil
             ),
             renderedBy: renderer.renderedParameter,
@@ -492,7 +492,7 @@ final class Test_TextBasedRenderer: XCTestCase {
                     .init(
                         label: "a",
                         name: "b",
-                        type: "C",
+                        type: .member("C"),
                         defaultValue: nil
                     )
                 ],
@@ -512,13 +512,13 @@ final class Test_TextBasedRenderer: XCTestCase {
                     .init(
                         label: "a",
                         name: "b",
-                        type: "C",
+                        type: .member("C"),
                         defaultValue: nil
                     ),
                     .init(
                         label: nil,
                         name: "d",
-                        type: "E",
+                        type: .member("E"),
                         defaultValue: .literal(.string("f"))
                     ),
                 ],
@@ -535,19 +535,19 @@ final class Test_TextBasedRenderer: XCTestCase {
                 kind: .function(name: "f"),
                 parameters: [],
                 keywords: [.async, .throws],
-                returnType: .identifier("String")
+                returnType: .identifierType(TypeName.string)
             ),
             renderedBy: renderer.renderedFunction,
             rendersAs:
                 #"""
-                func f() async throws -> String
+                func f() async throws -> Swift.String
                 """#
         )
     }
 
     func testIdentifiers() throws {
         try _test(
-            .init(name: "foo"),
+            .variable("foo"),
             renderedBy: renderer.renderedIdentifier,
             rendersAs:
                 #"""
@@ -558,7 +558,7 @@ final class Test_TextBasedRenderer: XCTestCase {
 
     func testMemberAccess() throws {
         try _test(
-            .init(left: .identifier("foo"), right: "bar"),
+            .init(left: .identifierPattern("foo"), right: "bar"),
             renderedBy: renderer.renderedMemberAccess,
             rendersAs:
                 #"""
@@ -579,7 +579,7 @@ final class Test_TextBasedRenderer: XCTestCase {
         try _test(
             .init(
                 label: "foo",
-                expression: .identifier("bar")
+                expression: .identifierPattern("bar")
             ),
             renderedBy: renderer.renderedFunctionCallArgument,
             rendersAs:
@@ -591,7 +591,7 @@ final class Test_TextBasedRenderer: XCTestCase {
         try _test(
             .init(
                 label: nil,
-                expression: .identifier("bar")
+                expression: .identifierPattern("bar")
             ),
             renderedBy: renderer.renderedFunctionCallArgument,
             rendersAs:
@@ -605,7 +605,7 @@ final class Test_TextBasedRenderer: XCTestCase {
         try _test(
             .functionCall(
                 .init(
-                    calledExpression: .identifier("callee")
+                    calledExpression: .identifierPattern("callee")
                 )
             ),
             renderedBy: renderer.renderedExpression,
@@ -617,11 +617,11 @@ final class Test_TextBasedRenderer: XCTestCase {
         try _test(
             .functionCall(
                 .init(
-                    calledExpression: .identifier("callee"),
+                    calledExpression: .identifierPattern("callee"),
                     arguments: [
                         .init(
                             label: "foo",
-                            expression: .identifier("bar")
+                            expression: .identifierPattern("bar")
                         )
                     ]
                 )
@@ -635,15 +635,15 @@ final class Test_TextBasedRenderer: XCTestCase {
         try _test(
             .functionCall(
                 .init(
-                    calledExpression: .identifier("callee"),
+                    calledExpression: .identifierPattern("callee"),
                     arguments: [
                         .init(
                             label: "foo",
-                            expression: .identifier("bar")
+                            expression: .identifierPattern("bar")
                         ),
                         .init(
                             label: "baz",
-                            expression: .identifier("boo")
+                            expression: .identifierPattern("boo")
                         ),
                     ]
                 )
@@ -663,7 +663,7 @@ final class Test_TextBasedRenderer: XCTestCase {
                 onType: "Info",
                 declarations: [
                     .variable(
-                        .init(kind: .let, left: "foo", type: "Int")
+                        .init(kind: .let, left: "foo", type: .member("Int"))
                     )
                 ]
             ),
@@ -744,13 +744,13 @@ final class Test_TextBasedRenderer: XCTestCase {
                 isStatic: true,
                 kind: .let,
                 left: "foo",
-                type: "String",
+                type: .init(TypeName.string),
                 right: .literal(.string("bar"))
             ),
             renderedBy: renderer.renderedVariable,
             rendersAs:
                 #"""
-                public static let foo: String = "bar"
+                public static let foo: Swift.String = "bar"
                 """#,
             normalizing: false
         )
@@ -774,13 +774,13 @@ final class Test_TextBasedRenderer: XCTestCase {
             .init(
                 kind: .var,
                 left: "foo",
-                type: "Int",
+                type: .init(TypeName.int),
                 getter: [CodeBlock.expression(.literal(.int(42)))]
             ),
             renderedBy: renderer.renderedVariable,
             rendersAs:
                 #"""
-                var foo: Int { 42 }
+                var foo: Swift.Int { 42 }
                 """#,
             normalizing: true
         )
@@ -788,14 +788,14 @@ final class Test_TextBasedRenderer: XCTestCase {
             .init(
                 kind: .var,
                 left: "foo",
-                type: "Int",
+                type: .init(TypeName.int),
                 getter: [CodeBlock.expression(.literal(.int(42)))],
                 getterEffects: [.throws]
             ),
             renderedBy: renderer.renderedVariable,
             rendersAs:
                 #"""
-                var foo: Int { get throws { 42 } }
+                var foo: Swift.Int { get throws { 42 } }
                 """#,
             normalizing: true
         )
@@ -912,7 +912,7 @@ final class Test_TextBasedRenderer: XCTestCase {
         try _test(
             .init(
                 name: "inty",
-                existingType: "Int"
+                existingType: .member("Int")
             ),
             renderedBy: renderer.renderedTypealias,
             rendersAs:
@@ -924,7 +924,7 @@ final class Test_TextBasedRenderer: XCTestCase {
             .init(
                 accessModifier: .private,
                 name: "inty",
-                existingType: "Int"
+                existingType: .member("Int")
             ),
             renderedBy: renderer.renderedTypealias,
             rendersAs:

--- a/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
@@ -547,7 +547,7 @@ final class Test_TextBasedRenderer: XCTestCase {
 
     func testIdentifiers() throws {
         try _test(
-            .variable("foo"),
+            .pattern("foo"),
             renderedBy: renderer.renderedIdentifier,
             rendersAs:
                 #"""

--- a/Tests/OpenAPIGeneratorCoreTests/StructureHelpers.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/StructureHelpers.swift
@@ -114,13 +114,6 @@ struct UnexpectedDeclError: Error, CustomStringConvertible, LocalizedError {
 }
 
 extension Declaration {
-    var strippingTopComment: Self {
-        guard case let .commentable(_, underlyingDecl) = self else {
-            return self
-        }
-        return underlyingDecl
-    }
-
     var info: DeclInfo {
         switch strippingTopComment {
         case .deprecated:
@@ -203,7 +196,14 @@ extension Expression {
         case .literal(let value):
             return .init(name: value.name, kind: .literal)
         case .identifier(let value):
-            return .init(name: value.name, kind: .identifier)
+            let name: String
+            switch value {
+            case .variable(let variable):
+                name = variable
+            case .type(let type):
+                name = TextBasedRenderer().renderedExistingTypeDescription(type)
+            }
+            return .init(name: name, kind: .identifier)
         case .memberAccess(let value):
             return .init(name: value.right, kind: .memberAccess)
         case .functionCall(let value):

--- a/Tests/OpenAPIGeneratorCoreTests/StructureHelpers.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/StructureHelpers.swift
@@ -175,6 +175,8 @@ extension KeywordKind {
             return "await"
         case .throw:
             return "throw"
+        case .yield:
+            return "yield"
         }
     }
 }

--- a/Tests/OpenAPIGeneratorCoreTests/StructureHelpers.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/StructureHelpers.swift
@@ -198,8 +198,8 @@ extension Expression {
         case .identifier(let value):
             let name: String
             switch value {
-            case .variable(let variable):
-                name = variable
+            case .pattern(let pattern):
+                name = pattern
             case .type(let type):
                 name = TextBasedRenderer().renderedExistingTypeDescription(type)
             }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateCodable.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/CommonTranslations/Test_translateCodable.swift
@@ -21,7 +21,7 @@ final class Test_translateCodable: Test_Core {
         let members = try _testDecoder(
             properties: [],
             trailingCodeBlocks: [
-                .expression(.identifier("foo"))
+                .expression(.identifierPattern("foo"))
             ]
         )
         XCTAssertEqual(
@@ -38,7 +38,7 @@ final class Test_translateCodable: Test_Core {
                 makeProperty(originalName: "bar", typeUsage: TypeName.string.asUsage)
             ],
             trailingCodeBlocks: [
-                .expression(.identifier("foo"))
+                .expression(.identifierPattern("foo"))
             ]
         )
         XCTAssertEqual(
@@ -86,7 +86,7 @@ final class Test_translateCodable: Test_Core {
         let members = try _testEncoder(
             properties: [],
             trailingCodeBlocks: [
-                .expression(.identifier("foo"))
+                .expression(.identifierPattern("foo"))
             ]
         )
         XCTAssertEqual(
@@ -103,7 +103,7 @@ final class Test_translateCodable: Test_Core {
                 makeProperty(originalName: "bar", typeUsage: TypeName.string.asUsage)
             ],
             trailingCodeBlocks: [
-                .expression(.identifier("foo"))
+                .expression(.identifierPattern("foo"))
             ]
         )
         XCTAssertEqual(

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -25,7 +25,7 @@ public struct Client: APIProtocol {
     ///   - transport: A transport that performs HTTP operations.
     ///   - middlewares: A list of middlewares to call before the transport.
     public init(
-        serverURL: URL,
+        serverURL: Foundation.URL,
         configuration: Configuration = .init(),
         transport: any ClientTransport,
         middlewares: [any ClientMiddleware] = []

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -20,7 +20,7 @@ extension APIProtocol {
     ///   - middlewares: A list of middlewares to call before the handler.
     public func registerHandlers(
         on transport: any ServerTransport,
-        serverURL: URL = .defaultOpenAPIServerURL,
+        serverURL: Foundation.URL = .defaultOpenAPIServerURL,
         configuration: Configuration = .init(),
         middlewares: [any ServerMiddleware] = []
     ) throws {
@@ -80,9 +80,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     ///
     /// - Remark: HTTP `GET /pets`.
     /// - Remark: Generated from `#/paths//pets/get(listPets)`.
-    func listPets(request: HTTPRequest, body: HTTPBody?, metadata: ServerRequestMetadata) async throws -> (
-        HTTPResponse, HTTPBody?
-    ) {
+    func listPets(
+        request: HTTPTypes.HTTPRequest,
+        body: OpenAPIRuntime.HTTPBody?,
+        metadata: OpenAPIRuntime.ServerRequestMetadata
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         try await handle(
             request: request,
             requestBody: body,
@@ -134,7 +136,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .ok(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 200)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 200)
                     suppressMutabilityWarning(&response)
                     try converter.setHeaderFieldAsURI(
                         in: &response.headerFields,
@@ -146,7 +148,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                         name: "My-Tracing-Header",
                         value: value.headers.My_hyphen_Tracing_hyphen_Header
                     )
-                    let body: HTTPBody
+                    let body: OpenAPIRuntime.HTTPBody
                     switch value.body {
                     case let .json(value):
                         try converter.validateAcceptIfPresent("application/json", in: request.headerFields)
@@ -159,9 +161,9 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     return (response, body)
                 case let .`default`(statusCode, value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: statusCode)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: statusCode)
                     suppressMutabilityWarning(&response)
-                    let body: HTTPBody
+                    let body: OpenAPIRuntime.HTTPBody
                     switch value.body {
                     case let .json(value):
                         try converter.validateAcceptIfPresent("application/json", in: request.headerFields)
@@ -180,9 +182,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     ///
     /// - Remark: HTTP `POST /pets`.
     /// - Remark: Generated from `#/paths//pets/post(createPet)`.
-    func createPet(request: HTTPRequest, body: HTTPBody?, metadata: ServerRequestMetadata) async throws -> (
-        HTTPResponse, HTTPBody?
-    ) {
+    func createPet(
+        request: HTTPTypes.HTTPRequest,
+        body: OpenAPIRuntime.HTTPBody?,
+        metadata: OpenAPIRuntime.ServerRequestMetadata
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         try await handle(
             request: request,
             requestBody: body,
@@ -217,14 +221,14 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .created(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 201)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 201)
                     suppressMutabilityWarning(&response)
                     try converter.setHeaderFieldAsJSON(
                         in: &response.headerFields,
                         name: "X-Extra-Arguments",
                         value: value.headers.X_hyphen_Extra_hyphen_Arguments
                     )
-                    let body: HTTPBody
+                    let body: OpenAPIRuntime.HTTPBody
                     switch value.body {
                     case let .json(value):
                         try converter.validateAcceptIfPresent("application/json", in: request.headerFields)
@@ -237,14 +241,14 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     return (response, body)
                 case let .clientError(statusCode, value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: statusCode)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: statusCode)
                     suppressMutabilityWarning(&response)
                     try converter.setHeaderFieldAsURI(
                         in: &response.headerFields,
                         name: "X-Reason",
                         value: value.headers.X_hyphen_Reason
                     )
-                    let body: HTTPBody
+                    let body: OpenAPIRuntime.HTTPBody
                     switch value.body {
                     case let .json(value):
                         try converter.validateAcceptIfPresent("application/json", in: request.headerFields)
@@ -264,9 +268,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     ///
     /// - Remark: HTTP `POST /pets/create`.
     /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)`.
-    func createPetWithForm(request: HTTPRequest, body: HTTPBody?, metadata: ServerRequestMetadata) async throws -> (
-        HTTPResponse, HTTPBody?
-    ) {
+    func createPetWithForm(
+        request: HTTPTypes.HTTPRequest,
+        body: OpenAPIRuntime.HTTPBody?,
+        metadata: OpenAPIRuntime.ServerRequestMetadata
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         try await handle(
             request: request,
             requestBody: body,
@@ -296,7 +302,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .noContent(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 204)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 204)
                     suppressMutabilityWarning(&response)
                     return (response, nil)
                 case let .undocumented(statusCode, _): return (.init(soar_statusCode: statusCode), nil)
@@ -306,9 +312,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     }
     /// - Remark: HTTP `GET /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
-    func getStats(request: HTTPRequest, body: HTTPBody?, metadata: ServerRequestMetadata) async throws -> (
-        HTTPResponse, HTTPBody?
-    ) {
+    func getStats(
+        request: HTTPTypes.HTTPRequest,
+        body: OpenAPIRuntime.HTTPBody?,
+        metadata: OpenAPIRuntime.ServerRequestMetadata
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         try await handle(
             request: request,
             requestBody: body,
@@ -325,9 +333,9 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .ok(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 200)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 200)
                     suppressMutabilityWarning(&response)
-                    let body: HTTPBody
+                    let body: OpenAPIRuntime.HTTPBody
                     switch value.body {
                     case let .json(value):
                         try converter.validateAcceptIfPresent("application/json", in: request.headerFields)
@@ -359,9 +367,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     }
     /// - Remark: HTTP `POST /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/post(postStats)`.
-    func postStats(request: HTTPRequest, body: HTTPBody?, metadata: ServerRequestMetadata) async throws -> (
-        HTTPResponse, HTTPBody?
-    ) {
+    func postStats(
+        request: HTTPTypes.HTTPRequest,
+        body: OpenAPIRuntime.HTTPBody?,
+        metadata: OpenAPIRuntime.ServerRequestMetadata
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         try await handle(
             request: request,
             requestBody: body,
@@ -403,7 +413,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .accepted(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 202)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 202)
                     suppressMutabilityWarning(&response)
                     return (response, nil)
                 case let .undocumented(statusCode, _): return (.init(soar_statusCode: statusCode), nil)
@@ -413,9 +423,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     }
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
-    func probe(request: HTTPRequest, body: HTTPBody?, metadata: ServerRequestMetadata) async throws -> (
-        HTTPResponse, HTTPBody?
-    ) {
+    func probe(
+        request: HTTPTypes.HTTPRequest,
+        body: OpenAPIRuntime.HTTPBody?,
+        metadata: OpenAPIRuntime.ServerRequestMetadata
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         try await handle(
             request: request,
             requestBody: body,
@@ -427,7 +439,7 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .noContent(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 204)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 204)
                     suppressMutabilityWarning(&response)
                     return (response, nil)
                 case let .undocumented(statusCode, _): return (.init(soar_statusCode: statusCode), nil)
@@ -439,9 +451,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     ///
     /// - Remark: HTTP `PATCH /pets/{petId}`.
     /// - Remark: Generated from `#/paths//pets/{petId}/patch(updatePet)`.
-    func updatePet(request: HTTPRequest, body: HTTPBody?, metadata: ServerRequestMetadata) async throws -> (
-        HTTPResponse, HTTPBody?
-    ) {
+    func updatePet(
+        request: HTTPTypes.HTTPRequest,
+        body: OpenAPIRuntime.HTTPBody?,
+        metadata: OpenAPIRuntime.ServerRequestMetadata
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         try await handle(
             request: request,
             requestBody: body,
@@ -478,14 +492,14 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .noContent(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 204)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 204)
                     suppressMutabilityWarning(&response)
                     return (response, nil)
                 case let .badRequest(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 400)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 400)
                     suppressMutabilityWarning(&response)
-                    let body: HTTPBody
+                    let body: OpenAPIRuntime.HTTPBody
                     switch value.body {
                     case let .json(value):
                         try converter.validateAcceptIfPresent("application/json", in: request.headerFields)
@@ -505,9 +519,11 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
     ///
     /// - Remark: HTTP `PUT /pets/{petId}/avatar`.
     /// - Remark: Generated from `#/paths//pets/{petId}/avatar/put(uploadAvatarForPet)`.
-    func uploadAvatarForPet(request: HTTPRequest, body: HTTPBody?, metadata: ServerRequestMetadata) async throws -> (
-        HTTPResponse, HTTPBody?
-    ) {
+    func uploadAvatarForPet(
+        request: HTTPTypes.HTTPRequest,
+        body: OpenAPIRuntime.HTTPBody?,
+        metadata: OpenAPIRuntime.ServerRequestMetadata
+    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         try await handle(
             request: request,
             requestBody: body,
@@ -544,9 +560,9 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                 switch output {
                 case let .ok(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 200)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 200)
                     suppressMutabilityWarning(&response)
-                    let body: HTTPBody
+                    let body: OpenAPIRuntime.HTTPBody
                     switch value.body {
                     case let .binary(value):
                         try converter.validateAcceptIfPresent("application/octet-stream", in: request.headerFields)
@@ -559,9 +575,9 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     return (response, body)
                 case let .preconditionFailed(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 412)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 412)
                     suppressMutabilityWarning(&response)
-                    let body: HTTPBody
+                    let body: OpenAPIRuntime.HTTPBody
                     switch value.body {
                     case let .json(value):
                         try converter.validateAcceptIfPresent("application/json", in: request.headerFields)
@@ -574,9 +590,9 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                     return (response, body)
                 case let .internalServerError(value):
                     suppressUnusedWarning(value)
-                    var response = HTTPResponse(soar_statusCode: 500)
+                    var response = HTTPTypes.HTTPResponse(soar_statusCode: 500)
                     suppressMutabilityWarning(&response)
-                    let body: HTTPBody
+                    let body: OpenAPIRuntime.HTTPBody
                     switch value.body {
                     case let .plainText(value):
                         try converter.validateAcceptIfPresent("text/plain", in: request.headerFields)

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -119,8 +119,10 @@ extension APIProtocol {
 /// Server URLs defined in the OpenAPI document.
 public enum Servers {
     /// Example Petstore implementation service
-    public static func server1() throws -> URL { try URL(validatingOpenAPIServerURL: "https://example.com/api") }
-    public static func server2() throws -> URL { try URL(validatingOpenAPIServerURL: "/api") }
+    public static func server1() throws -> Foundation.URL {
+        try Foundation.URL(validatingOpenAPIServerURL: "https://example.com/api")
+    }
+    public static func server2() throws -> Foundation.URL { try Foundation.URL(validatingOpenAPIServerURL: "/api") }
 }
 /// Types generated from the components section of the OpenAPI document.
 public enum Components {
@@ -208,7 +210,7 @@ public enum Components {
                 value2 = try? decoder.decodeFromSingleValueContainer()
                 value3 = try? .init(from: decoder)
                 value4 = try? decoder.decodeFromSingleValueContainer()
-                try DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                     [value1, value2, value3, value4],
                     type: Self.self,
                     codingPath: decoder.codingPath
@@ -240,7 +242,7 @@ public enum Components {
                     self = .Pet(try .init(from: decoder))
                     return
                 } catch {}
-                throw DecodingError.failedToDecodeOneOfSchema(type: Self.self, codingPath: decoder.codingPath)
+                throw Swift.DecodingError.failedToDecodeOneOfSchema(type: Self.self, codingPath: decoder.codingPath)
             }
             public func encode(to encoder: any Encoder) throws {
                 switch self {
@@ -528,7 +530,7 @@ public enum Components {
             public init(from decoder: any Decoder) throws {
                 value1 = try? .init(from: decoder)
                 value2 = try? .init(from: decoder)
-                try DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                     [value1, value2],
                     type: Self.self,
                     codingPath: decoder.codingPath
@@ -577,7 +579,7 @@ public enum Components {
                     self = .case4(try .init(from: decoder))
                     return
                 } catch {}
-                throw DecodingError.failedToDecodeOneOfSchema(type: Self.self, codingPath: decoder.codingPath)
+                throw Swift.DecodingError.failedToDecodeOneOfSchema(type: Self.self, codingPath: decoder.codingPath)
             }
             public func encode(to encoder: any Encoder) throws {
                 switch self {
@@ -666,12 +668,13 @@ public enum Components {
             public enum CodingKeys: String, CodingKey { case kind }
             public init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
-                let discriminator = try container.decode(String.self, forKey: .kind)
+                let discriminator = try container.decode(Swift.String.self, forKey: .kind)
                 switch discriminator {
                 case "Walk", "#/components/schemas/Walk": self = .Walk(try .init(from: decoder))
                 case "MessagedExercise", "#/components/schemas/MessagedExercise":
                     self = .MessagedExercise(try .init(from: decoder))
-                default: throw DecodingError.failedToDecodeOneOfSchema(type: Self.self, codingPath: decoder.codingPath)
+                default:
+                    throw Swift.DecodingError.failedToDecodeOneOfSchema(type: Self.self, codingPath: decoder.codingPath)
                 }
             }
             public func encode(to encoder: any Encoder) throws {
@@ -821,7 +824,7 @@ public enum Operations {
     /// - Remark: HTTP `GET /pets`.
     /// - Remark: Generated from `#/paths//pets/get(listPets)`.
     public enum listPets {
-        public static let id: String = "listPets"
+        public static let id: Swift.String = "listPets"
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/GET/query`.
             public struct Query: Sendable, Hashable {
@@ -1010,7 +1013,7 @@ public enum Operations {
             /// - Remark: Generated from `#/paths//pets/get(listPets)/responses/default`.
             ///
             /// HTTP response code: `default`.
-            case `default`(statusCode: Int, Operations.listPets.Output.Default)
+            case `default`(statusCode: Swift.Int, Operations.listPets.Output.Default)
             /// The associated value of the enum case if `self` is `.`default``.
             ///
             /// - Throws: An error if `self` is not `.`default``.
@@ -1026,14 +1029,14 @@ public enum Operations {
         }
         @frozen public enum AcceptableContentType: AcceptableProtocol {
             case json
-            case other(String)
-            public init?(rawValue: String) {
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
                 switch rawValue.lowercased() {
                 case "application/json": self = .json
                 default: self = .other(rawValue)
                 }
             }
-            public var rawValue: String {
+            public var rawValue: Swift.String {
                 switch self {
                 case let .other(string): return string
                 case .json: return "application/json"
@@ -1047,7 +1050,7 @@ public enum Operations {
     /// - Remark: HTTP `POST /pets`.
     /// - Remark: Generated from `#/paths//pets/post(createPet)`.
     public enum createPet {
-        public static let id: String = "createPet"
+        public static let id: Swift.String = "createPet"
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/POST/header`.
             public struct Headers: Sendable, Hashable {
@@ -1159,7 +1162,7 @@ public enum Operations {
             /// - Remark: Generated from `#/paths//pets/post(createPet)/responses/4XX`.
             ///
             /// HTTP response code: `400...499 clientError`.
-            case clientError(statusCode: Int, Components.Responses.ErrorBadRequest)
+            case clientError(statusCode: Swift.Int, Components.Responses.ErrorBadRequest)
             /// The associated value of the enum case if `self` is `.clientError`.
             ///
             /// - Throws: An error if `self` is not `.clientError`.
@@ -1175,18 +1178,18 @@ public enum Operations {
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
-            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
         @frozen public enum AcceptableContentType: AcceptableProtocol {
             case json
-            case other(String)
-            public init?(rawValue: String) {
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
                 switch rawValue.lowercased() {
                 case "application/json": self = .json
                 default: self = .other(rawValue)
                 }
             }
-            public var rawValue: String {
+            public var rawValue: Swift.String {
                 switch self {
                 case let .other(string): return string
                 case .json: return "application/json"
@@ -1200,7 +1203,7 @@ public enum Operations {
     /// - Remark: HTTP `POST /pets/create`.
     /// - Remark: Generated from `#/paths//pets/create/post(createPetWithForm)`.
     public enum createPetWithForm {
-        public static let id: String = "createPetWithForm"
+        public static let id: Swift.String = "createPetWithForm"
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/create/POST/requestBody`.
             @frozen public enum Body: Sendable, Hashable {
@@ -1240,13 +1243,13 @@ public enum Operations {
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
-            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
     }
     /// - Remark: HTTP `GET /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/get(getStats)`.
     public enum getStats {
-        public static let id: String = "getStats"
+        public static let id: Swift.String = "getStats"
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/stats/GET/header`.
             public struct Headers: Sendable, Hashable {
@@ -1344,14 +1347,14 @@ public enum Operations {
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
-            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
         @frozen public enum AcceptableContentType: AcceptableProtocol {
             case json
             case plainText
             case binary
-            case other(String)
-            public init?(rawValue: String) {
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
                 switch rawValue.lowercased() {
                 case "application/json": self = .json
                 case "text/plain": self = .plainText
@@ -1359,7 +1362,7 @@ public enum Operations {
                 default: self = .other(rawValue)
                 }
             }
-            public var rawValue: String {
+            public var rawValue: Swift.String {
                 switch self {
                 case let .other(string): return string
                 case .json: return "application/json"
@@ -1373,7 +1376,7 @@ public enum Operations {
     /// - Remark: HTTP `POST /pets/stats`.
     /// - Remark: Generated from `#/paths//pets/stats/post(postStats)`.
     public enum postStats {
-        public static let id: String = "postStats"
+        public static let id: Swift.String = "postStats"
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/stats/POST/requestBody`.
             @frozen public enum Body: Sendable, Hashable {
@@ -1417,13 +1420,13 @@ public enum Operations {
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
-            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
     }
     /// - Remark: HTTP `POST /probe/`.
     /// - Remark: Generated from `#/paths//probe//post(probe)`.
     public enum probe {
-        public static let id: String = "probe"
+        public static let id: Swift.String = "probe"
         public struct Input: Sendable, Hashable {
             /// Creates a new `Input`.
             public init() {}
@@ -1454,7 +1457,7 @@ public enum Operations {
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
-            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
     }
     /// Update just a specific property of an existing pet. Nothing is updated if no request body is provided.
@@ -1462,7 +1465,7 @@ public enum Operations {
     /// - Remark: HTTP `PATCH /pets/{petId}`.
     /// - Remark: Generated from `#/paths//pets/{petId}/patch(updatePet)`.
     public enum updatePet {
-        public static let id: String = "updatePet"
+        public static let id: Swift.String = "updatePet"
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/{petId}/PATCH/path`.
             public struct Path: Sendable, Hashable {
@@ -1587,18 +1590,18 @@ public enum Operations {
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
-            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
         @frozen public enum AcceptableContentType: AcceptableProtocol {
             case json
-            case other(String)
-            public init?(rawValue: String) {
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
                 switch rawValue.lowercased() {
                 case "application/json": self = .json
                 default: self = .other(rawValue)
                 }
             }
-            public var rawValue: String {
+            public var rawValue: Swift.String {
                 switch self {
                 case let .other(string): return string
                 case .json: return "application/json"
@@ -1612,7 +1615,7 @@ public enum Operations {
     /// - Remark: HTTP `PUT /pets/{petId}/avatar`.
     /// - Remark: Generated from `#/paths//pets/{petId}/avatar/put(uploadAvatarForPet)`.
     public enum uploadAvatarForPet {
-        public static let id: String = "uploadAvatarForPet"
+        public static let id: Swift.String = "uploadAvatarForPet"
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/pets/{petId}/avatar/PUT/path`.
             public struct Path: Sendable, Hashable {
@@ -1797,14 +1800,14 @@ public enum Operations {
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
-            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
         @frozen public enum AcceptableContentType: AcceptableProtocol {
             case binary
             case json
             case plainText
-            case other(String)
-            public init?(rawValue: String) {
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
                 switch rawValue.lowercased() {
                 case "application/octet-stream": self = .binary
                 case "application/json": self = .json
@@ -1812,7 +1815,7 @@ public enum Operations {
                 default: self = .other(rawValue)
                 }
             }
-            public var rawValue: String {
+            public var rawValue: Swift.String {
                 switch self {
                 case let .other(string): return string
                 case .binary: return "application/octet-stream"

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -411,7 +411,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         value2 = try? .init(from: decoder)
                         value3 = try? decoder.decodeFromSingleValueContainer()
                         value4 = try? decoder.decodeFromSingleValueContainer()
-                        try DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                        try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                             [value1, value2, value3, value4],
                             type: Self.self,
                             codingPath: decoder.codingPath
@@ -472,12 +472,12 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public enum CodingKeys: String, CodingKey { case which }
                     public init(from decoder: any Decoder) throws {
                         let container = try decoder.container(keyedBy: CodingKeys.self)
-                        let discriminator = try container.decode(String.self, forKey: .which)
+                        let discriminator = try container.decode(Swift.String.self, forKey: .which)
                         switch discriminator {
                         case "A", "#/components/schemas/A": self = .A(try .init(from: decoder))
                         case "B", "#/components/schemas/B": self = .B(try .init(from: decoder))
                         default:
-                            throw DecodingError.failedToDecodeOneOfSchema(
+                            throw Swift.DecodingError.failedToDecodeOneOfSchema(
                                 type: Self.self,
                                 codingPath: decoder.codingPath
                             )
@@ -551,14 +551,14 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public enum CodingKeys: String, CodingKey { case which }
                     public init(from decoder: any Decoder) throws {
                         let container = try decoder.container(keyedBy: CodingKeys.self)
-                        let discriminator = try container.decode(String.self, forKey: .which)
+                        let discriminator = try container.decode(Swift.String.self, forKey: .which)
                         switch discriminator {
                         case "a": self = .a(try .init(from: decoder))
                         case "a2": self = .a2(try .init(from: decoder))
                         case "b": self = .b(try .init(from: decoder))
                         case "C", "#/components/schemas/C": self = .C(try .init(from: decoder))
                         default:
-                            throw DecodingError.failedToDecodeOneOfSchema(
+                            throw Swift.DecodingError.failedToDecodeOneOfSchema(
                                 type: Self.self,
                                 codingPath: decoder.codingPath
                             )
@@ -609,7 +609,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                             self = .A(try .init(from: decoder))
                             return
                         } catch {}
-                        throw DecodingError.failedToDecodeOneOfSchema(
+                        throw Swift.DecodingError.failedToDecodeOneOfSchema(
                             type: Self.self,
                             codingPath: decoder.codingPath
                         )
@@ -668,7 +668,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                                 self = .A(try .init(from: decoder))
                                 return
                             } catch {}
-                            throw DecodingError.failedToDecodeOneOfSchema(
+                            throw Swift.DecodingError.failedToDecodeOneOfSchema(
                                 type: Self.self,
                                 codingPath: decoder.codingPath
                             )
@@ -693,7 +693,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public init(from decoder: any Decoder) throws {
                         value1 = try? .init(from: decoder)
                         value2 = try? .init(from: decoder)
-                        try DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                        try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                             [value1, value2],
                             type: Self.self,
                             codingPath: decoder.codingPath
@@ -882,7 +882,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public init(from decoder: any Decoder) throws {
                         value1 = try? decoder.decodeFromSingleValueContainer()
                         value2 = try? decoder.decodeFromSingleValueContainer()
-                        try DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                        try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                             [value1, value2],
                             type: Self.self,
                             codingPath: decoder.codingPath
@@ -1335,7 +1335,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public func registerHandlers(
                 on transport: any ServerTransport,
-                serverURL: URL = .defaultOpenAPIServerURL,
+                serverURL: Foundation.URL = .defaultOpenAPIServerURL,
                 configuration: Configuration = .init(),
                 middlewares: [any ServerMiddleware] = []
             ) throws {
@@ -1363,7 +1363,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public func registerHandlers(
                 on transport: any ServerTransport,
-                serverURL: URL = .defaultOpenAPIServerURL,
+                serverURL: Foundation.URL = .defaultOpenAPIServerURL,
                 configuration: Configuration = .init(),
                 middlewares: [any ServerMiddleware] = []
             ) throws {


### PR DESCRIPTION
### Motivation

The recursive type support required some improvements to our structured Swift representation layer, so I split out just these noisy, mechanical, but not very interesting changes separate from the actual recursive type support here, into this PR.

### Modifications

- Improves `IdentifierDescription` to be an enum of a "pattern" (usually a variable) and "type" (represents a type, like `Foo`, `any Foo`, `Foo?`, `[Foo]`, etc.) The lattern required more logic, so we propagate the distinction all the way to the renderer.
- Added `trailingClosure` support to a `FunctionCallDescription`.
- Introduced `ExistingTypeDescription`, kind of like the equivalent of `TypeUsage`, but on the structured Swift layer side. Moved to this type in a bunch of other types, most of which previously just had a `String`.
- Allowed defining a setter on a computed variable.
- Allowed marking an enum as indirect.

### Result

Added the functionality required for the next PR adding recursive type support.

But _mostly_ this should be a refactoring and apart from the next point, not change any functionality.

The most visible change to the reference tests is that more types are now fully qualified, such as going from `String` -> `Swift.String`.

### Test Plan

Adapted all tests, all still pass.
