### PR TITLE
[Bugfix] Detect more schema type reference cycles.

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Development/Supporting-recursive-types.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Development/Supporting-recursive-types.md
@@ -118,9 +118,7 @@ The algorithm outputs a list of type names that require boxing.
 
 It iterates over the types defined in `#/components/schemas`, in the order defined in the OpenAPI document, and for each type walks all of its references.
 
-Once it detects a reference cycle, it checks whether any of the types involved in the current cycle are already in the list, and if so, considers this cycle to already be addressed.
-
-If no type in the current cycle is found in the list, it adds the first type in the cycle, in other words the one to which the last reference closed the cycle.
+Once it detects a reference cycle, it adds the first type in the cycle, in other words the one to which the last reference closed the cycle.
 
 For example, walking the following:
 ```

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_RecursionDetector_Generic.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_RecursionDetector_Generic.swift
@@ -214,6 +214,28 @@ class Test_RecursionDetector_Generic: Test_Core {
         )
     }
 
+    func testMultipleCycles3() throws {
+        try _test(
+            rootNodes: [
+                "A",
+                "B",
+                "C",
+                "D",
+            ],
+            putIntoContainer: [
+                "A -> C",
+                "B -> D,A",
+                "C -> B,D",
+                "D -> B,C",
+            ],
+            expected: [
+                "A",
+                "B",
+                "C",
+            ]
+        )
+    }
+
     func testNested() throws {
         try _test(
             rootNodes: [
@@ -270,6 +292,25 @@ class Test_RecursionDetector_Generic: Test_Core {
                 "D -> B",
             ],
             expected: ["B"]
+        )
+    }
+
+    func testDifferentCyclesForSameNode() throws {
+        try _test(
+            rootNodes: [
+                "C",
+                "A",
+                "B",
+            ],
+            putIntoContainer: [
+                "A -> B",
+                "B -> C,A",
+                "C -> A",
+            ],
+            expected: [
+                "C",
+                "A",
+            ]
         )
     }
 


### PR DESCRIPTION
### Motivation

The newly introduced recursive type support had a slight optimization to minimize the number of boxed types, but it contained a bug that only surfaced on larger real-world documents. It's not really necessary, so removed it and the number of boxed types is still reasonable, plus it doesn't lead to non-compiling code anymore.

### Modifications

Removed an optimization that tried to further reduce the number of boxed types, because it actually missed some cycles and produced non-compiling code for some larger OpenAPI documents.

### Result

Code now compiles even for more complex cycles.

### Test Plan

Added more unit tests, plus tested on some real-world docs with cycles that failed before this change.
