### PR TITLE
Respect the input order when filtering

### DIFF
--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_FilteredDocument.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_FilteredDocument.swift
@@ -16,7 +16,7 @@ import XCTest
 import Yams
 @testable import _OpenAPIGeneratorCore
 
-final class FilteredDocumentTests: XCTestCase {
+final class Test_FilteredDocument: XCTestCase {
 
     func testDocumentFilter() throws {
         let documentYAML = """


### PR DESCRIPTION
### Motivation

The original implementation of document filtering iterated over a Set and a Dictionary, which do not guarantee a stable order, meaning that every time the filter command was invoked with identical inptus, it could produce different outputs, potentially leading to needless rebuilds when used as a plugin, and needless commits when using ahead-of-time generation. It also made debugging of the generator itself more difficult.

### Modifications

Respect the input order of operations and components.

### Result

Invoking the generator multiple times with the same input produces the same output every time, improving cachability.

### Test Plan

Renamed the filter test to be consistent with the rest and manually tested on a larger document.
