### PR TITLE
Handle malformed content types

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -346,7 +346,12 @@ struct TextBasedRenderer: RendererProtocol {
     func renderedLiteral(_ literal: LiteralDescription) -> String {
         switch literal {
         case let .string(string):
-            return "\"\(string)\""
+            // Use a raw literal if the string contains a quote/backslash.
+            if string.contains("\"") || string.contains("\\") {
+                return "#\"\(string)\"#"
+            } else {
+                return "\"\(string)\""
+            }
         case let .int(int):
             return "\(int)"
         case let .bool(bool):

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateStringEnum.swift
@@ -60,7 +60,12 @@ extension FileTranslator {
                     let caseName = swiftSafeName(for: rawValue)
                     return (caseName, .string(rawValue))
                 case .integer:
-                    guard let rawValue = anyValue as? Int else {
+                    let rawValue: Int
+                    if let intRawValue = anyValue as? Int {
+                        rawValue = intRawValue
+                    } else if let stringRawValue = anyValue as? String, let intRawValue = Int(stringRawValue) {
+                        rawValue = intRawValue
+                    } else {
                         throw GenericError(message: "Disallowed value for an integer enum '\(typeName)': \(anyValue)")
                     }
                     let caseName = rawValue < 0 ? "_n\(abs(rawValue))" : "_\(rawValue)"

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
@@ -152,7 +152,18 @@ struct ContentType: Hashable {
     ///   not be empty.
     /// - Throws: If a malformed content type string is encountered.
     init(string: String) throws {
-        precondition(!string.isEmpty, "rawValue of a ContentType cannot be empty.")
+        struct InvalidContentTypeString: Error, LocalizedError, CustomStringConvertible {
+            var string: String
+            var description: String {
+                "Invalid content type string: '\(string)', must have 2 components separated by a slash."
+            }
+            var errorDescription: String? {
+                description
+            }
+        }
+        guard !string.isEmpty else {
+            throw InvalidContentTypeString(string: "")
+        }
         var semiComponents =
             string
             .split(separator: ";")
@@ -170,15 +181,6 @@ struct ContentType: Hashable {
             rawTypeAndSubtype
             .split(separator: "/")
             .map(String.init)
-        struct InvalidContentTypeString: Error, LocalizedError, CustomStringConvertible {
-            var string: String
-            var description: String {
-                "Invalid content type string: '\(string)', must have 2 components separated by a slash."
-            }
-            var errorDescription: String? {
-                description
-            }
-        }
         guard typeAndSubtype.count == 2 else {
             throw InvalidContentTypeString(string: rawTypeAndSubtype)
         }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentType.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import OpenAPIKit
+import Foundation
 
 /// A content type of a request, response, and other types.
 ///
@@ -147,12 +148,13 @@ struct ContentType: Hashable {
     }
 
     /// Creates a new content type by parsing the specified MIME type.
-    /// - Parameter rawValue: A MIME type, for example "application/json". Must
+    /// - Parameter string: A MIME type, for example "application/json". Must
     ///   not be empty.
-    init(_ rawValue: String) {
-        precondition(!rawValue.isEmpty, "rawValue of a ContentType cannot be empty.")
+    /// - Throws: If a malformed content type string is encountered.
+    init(string: String) throws {
+        precondition(!string.isEmpty, "rawValue of a ContentType cannot be empty.")
         var semiComponents =
-            rawValue
+            string
             .split(separator: ";")
         let typeAndSubtypeComponent = semiComponents.removeFirst()
         self.originallyCasedParameterPairs = semiComponents.map { component in
@@ -168,10 +170,18 @@ struct ContentType: Hashable {
             rawTypeAndSubtype
             .split(separator: "/")
             .map(String.init)
-        precondition(
-            typeAndSubtype.count == 2,
-            "Invalid ContentType string, must have 2 components separated by a slash."
-        )
+        struct InvalidContentTypeString: Error, LocalizedError, CustomStringConvertible {
+            var string: String
+            var description: String {
+                "Invalid content type string: '\(string)', must have 2 components separated by a slash."
+            }
+            var errorDescription: String? {
+                description
+            }
+        }
+        guard typeAndSubtype.count == 2 else {
+            throw InvalidContentTypeString(string: rawTypeAndSubtype)
+        }
         self.originallyCasedType = typeAndSubtype[0]
         self.originallyCasedSubtype = typeAndSubtype[1]
     }
@@ -251,27 +261,11 @@ struct ContentType: Hashable {
 
 extension OpenAPI.ContentType {
 
-    /// A Boolean value that indicates whether the content type
-    /// is a type of JSON.
-    var isJSON: Bool {
-        asGeneratorContentType.isJSON
-    }
-
-    /// A Boolean value that indicates whether the content type
-    /// is a URL-encoded form.
-    var isUrlEncodedForm: Bool {
-        asGeneratorContentType.isUrlEncodedForm
-    }
-
-    /// A Boolean value that indicates whether the content type
-    /// is just binary data.
-    var isBinary: Bool {
-        asGeneratorContentType.isBinary
-    }
-
     /// Returns the content type wrapped in the generator's representation
     /// of a content type, as opposed to the one from OpenAPIKit.
     var asGeneratorContentType: ContentType {
-        ContentType(rawValue)
+        get throws {
+            try ContentType(string: rawValue)
+        }
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/acceptHeaderContentTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/acceptHeaderContentTypes.swift
@@ -31,7 +31,7 @@ extension FileTranslator {
             .responseOutcomes
             .flatMap { outcome in
                 let response = try outcome.response.resolve(in: components)
-                return supportedContents(response.content, foundIn: description.operationID)
+                return try supportedContents(response.content, foundIn: description.operationID)
             }
             .map { content in
                 content.contentType

--- a/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
@@ -188,6 +188,14 @@ final class Test_TextBasedRenderer: XCTestCase {
                 """#
         )
         try _test(
+            .string("this string: \"foo\""),
+            renderedBy: renderer.renderedLiteral,
+            rendersAs:
+                #"""
+                #"this string: "foo""#
+                """#
+        )
+        try _test(
             .nil,
             renderedBy: renderer.renderedLiteral,
             rendersAs:

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentSwiftName.swift
@@ -45,9 +45,9 @@ final class Test_ContentSwiftName: Test_Core {
             ("application/foo; bar=baz; boo=foo", "application_foo_bar_baz_boo_foo"),
             ("application/foo; bar = baz", "application_foo_bar_baz"),
         ]
-        for item in cases {
-            let contentType = try XCTUnwrap(ContentType(item.0))
-            XCTAssertEqual(nameMaker(contentType), item.1, "Case \(item.0) failed")
+        for (string, name) in cases {
+            let contentType = try XCTUnwrap(ContentType(string: string))
+            XCTAssertEqual(nameMaker(contentType), name, "Case \(string) failed")
         }
     }
 }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Content/Test_ContentType.swift
@@ -170,7 +170,7 @@ final class Test_ContentType: Test_Core {
             originallyCasedTypeAndSubtype,
             originallyCasedOutputWithParameters
         ) in cases {
-            let contentType = ContentType(rawValue)
+            let contentType = try ContentType(string: rawValue)
             XCTAssertEqual(contentType.category, category)
             XCTAssertEqual(contentType.lowercasedType, type)
             XCTAssertEqual(contentType.lowercasedSubtype, subtype)


### PR DESCRIPTION
### Motivation

Before this PR, when a malformed content type (one that wasn't in the format `foo/bar`) was provided in the OpenAPI document, the generator would crash on a precondition failure, making it difficult to debug.

### Modifications

Turn the precondition failure into a thrown error.

### Result

Malformed content types now produce a thrown error instead of a crash.

### Test Plan

All tests pass.
