### PR TITLE
Bump swift-format to 5.9

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -15,7 +15,9 @@
 // Emit a compiler error if this library is linked with a target in an adopter
 // project.
 #if !(os(macOS) || os(Linux))
-#error("_OpenAPIGeneratorCore is only to be used by swift-openapi-generator itself—your target should not link this library or the command line tool directly.")
+#error(
+    "_OpenAPIGeneratorCore is only to be used by swift-openapi-generator itself—your target should not link this library or the command line tool directly."
+)
 #endif
 
 #if SWIFT_OPENAPI_STRICT_CONCURRENCY

--- a/Tests/OpenAPIGeneratorCoreTests/TestUtilities.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/TestUtilities.swift
@@ -18,6 +18,8 @@ import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 class Test_Core: XCTestCase {
+
+    /// Setup method called before the invocation of each test method in the class.
     override func setUp() async throws {
         try await super.setUp()
         continueAfterFailure = false

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
@@ -17,6 +17,7 @@ import OpenAPIKit
 
 final class Test_TypeMatcher: Test_Core {
 
+    /// Setup method called before the invocation of each test method in the class.
     override func setUp() async throws {
         try await super.setUp()
         continueAfterFailure = false

--- a/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
@@ -28,6 +28,7 @@ final class CompatibilityTest: XCTestCase {
     let compatibilityTestParallelCodegen = getBoolEnv("SWIFT_OPENAPI_COMPATIBILITY_TEST_PARALLEL_CODEGEN") ?? false
     let compatibilityTestNumBuildJobs = getIntEnv("SWIFT_OPENAPI_COMPATIBILITY_TEST_NUM_BUILD_JOBS")
 
+    /// Setup method called before the invocation of each test method in the class.
     override func setUp() async throws {
         continueAfterFailure = false
         try XCTSkipUnless(compatibilityTestEnabled)

--- a/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
@@ -36,6 +36,8 @@ extension TestConfig {
 
 /// Tests that the generator produces Swift files that match a reference.
 class FileBasedReferenceTests: XCTestCase {
+
+    /// Setup method called before the invocation of each test method in the class.
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
@@ -56,6 +58,7 @@ class FileBasedReferenceTests: XCTestCase {
 
     var referenceTestResourcesDirectory: URL! = nil
 
+    /// Setup method called before the invocation of each test method in the class.
     override func setUpWithError() throws {
         self.referenceTestResourcesDirectory = try XCTUnwrap(
             Bundle.module.url(forResource: "Resources", withExtension: nil),

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -28,6 +28,7 @@ final class Test_Client: XCTestCase {
         }
     }
 
+    /// Setup method called before the invocation of each test method in the class.
     override func setUp() async throws {
         try await super.setUp()
         continueAfterFailure = false

--- a/Tests/PetstoreConsumerTests/Test_Playground.swift
+++ b/Tests/PetstoreConsumerTests/Test_Playground.swift
@@ -16,6 +16,8 @@ import OpenAPIRuntime
 import PetstoreConsumerTestCore
 
 final class Test_Playground: XCTestCase {
+
+    /// Setup method called before the invocation of each test method in the class.
     override func setUp() async throws {
         try await super.setUp()
         continueAfterFailure = false

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -25,6 +25,7 @@ final class Test_Server: XCTestCase {
         }
     }
 
+    /// Setup method called before the invocation of each test method in the class.
     override func setUp() async throws {
         try await super.setUp()
         continueAfterFailure = false

--- a/Tests/PetstoreConsumerTests/Test_Types.swift
+++ b/Tests/PetstoreConsumerTests/Test_Types.swift
@@ -17,6 +17,7 @@ import PetstoreConsumerTestCore
 
 final class Test_Types: XCTestCase {
 
+    /// Setup method called before the invocation of each test method in the class.
     override func setUp() async throws {
         try await super.setUp()
         continueAfterFailure = false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p $HOME/.tools
 RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swift-format
-ARG swiftformat_version=508.0.0
+ARG swiftformat_version=509.0.0
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/apple/swift-format $HOME/.tools/swift-format-source
 RUN cd $HOME/.tools/swift-format-source && swift build -c release
 RUN ln -s $HOME/.tools/swift-format-source/.build/release/swift-format $HOME/.tools/swift-format


### PR DESCRIPTION
### Motivation

As per https://github.com/apple/swift-openapi-generator/issues/175.

### Modifications

Updated to swift-format 5.9, updated code to pass soundness.

### Result

Using swift-format 5.9.

### Test Plan

Soundness passed.
