### PR TITLE
Enable more CI warnings

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Extensions/Foundation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/Foundation.swift
@@ -13,6 +13,12 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
+#if compiler(>=5.11)
+extension FileHandle: @retroactive TextOutputStream {}
+#else
+extension FileHandle: TextOutputStream {}
+#endif
+
 extension InMemoryInputFile {
     /// Creates a new in-memory file by reading the contents at the specified path.
     /// - Parameter url: The path to the file to read.
@@ -23,7 +29,7 @@ extension InMemoryInputFile {
 /// File handle to stderr.
 let stdErrHandle = FileHandle.standardError
 
-extension FileHandle: TextOutputStream {
+extension FileHandle {
     /// Writes the given string to the file handle.
     ///
     /// This method writes the provided string to the file handle using its UTF-8

--- a/Sources/swift-openapi-generator/Extensions.swift
+++ b/Sources/swift-openapi-generator/Extensions.swift
@@ -16,7 +16,17 @@ import ArgumentParser
 import _OpenAPIGeneratorCore
 import Yams
 
-extension URL: ExpressibleByArgument {
+#if compiler(>=5.11)
+extension URL: @retroactive ExpressibleByArgument {}
+extension GeneratorMode: @retroactive ExpressibleByArgument {}
+extension FeatureFlag: @retroactive ExpressibleByArgument {}
+#else
+extension URL: ExpressibleByArgument {}
+extension GeneratorMode: ExpressibleByArgument {}
+extension FeatureFlag: ExpressibleByArgument {}
+#endif
+
+extension URL {
 
     /// Creates a `URL` instance from a string argument.
     ///
@@ -24,9 +34,6 @@ extension URL: ExpressibleByArgument {
     /// - Parameter argument: The string argument representing the path for the URL.
     public init?(argument: String) { self.init(fileURLWithPath: argument) }
 }
-
-extension GeneratorMode: ExpressibleByArgument {}
-extension FeatureFlag: ExpressibleByArgument {}
 
 extension CaseIterable where Self: RawRepresentable, Self.RawValue == String {
 

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -11,10 +11,7 @@ services:
     image: *image
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-      # SwiftSyntax currently imports a module it does not explicitly depend
-      # on and so we must disable this for the time being.
-      # - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
-
   shell:
     image: *image

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -11,20 +11,8 @@ services:
   test:
     image: *image
     environment:
-      # Because OpenAPI supports deprecation, the generated code could include
-      # deprecated symbols, which will produce warnings.
-      #
-      # We'll disable -warnings-as-errors for now and revisit this when we
-      # refactor the compilation of the generated code into a separate
-      # pipeline.
-      #
-      # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-      
-      # SwiftSyntax currently imports a module it does not explicitly depend
-      # on and so we must disable this for the time being.
-      # - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-
+      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
-
   shell:
     image: *image

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -12,10 +12,7 @@ services:
     image: *image
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-      # SwiftSyntax currently imports a module it does not explicitly depend
-      # on and so we must disable this for the time being.
-      # - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
-
   shell:
     image: *image

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -11,20 +11,8 @@ services:
   test:
     image: *image
     environment:
-      # Because OpenAPI supports deprecation, the generated code could include
-      # deprecated symbols, which will produce warnings.
-      #
-      # We'll disable -warnings-as-errors for now and revisit this when we
-      # refactor the compilation of the generated code into a separate
-      # pipeline.
-      #
-      # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-
-      # SwiftSyntax currently imports a module it does not explicitly depend
-      # on and so we must disable this for the time being.
-      # - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-
+      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
-
   shell:
     image: *image


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/332 and re-enables warnings as errors as we don't have deprecation warnings in our tests anymore.

### Modifications

Enabled a few previously disabled warnings/errors.

### Result

Stricter CI.

### Test Plan

The CI on this PR.
