### PR TITLE
Safe server variable names when used in Swift identifiers

### DIFF
--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -10,9 +10,11 @@ servers:
   - url: https://example.com/api
     description: Example Petstore implementation service
   - url: /api
-  - url: https://{subdomain}.example.com:{port}/{basePath}
+  - url: '{protocol}://{subdomain}.example.com:{port}/{basePath}'
     description: A custom domain.
     variables:
+      protocol:
+        default: https
       subdomain:
         default: test
         description: A subdomain name.

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -153,17 +153,23 @@ public enum Servers {
     /// A custom domain.
     ///
     /// - Parameters:
+    ///   - _protocol:
     ///   - subdomain: A subdomain name.
     ///   - port:
     ///   - basePath: The base API path.
     public static func server3(
+        _protocol: Swift.String = "https",
         subdomain: Swift.String = "test",
         port: Swift.String = "443",
         basePath: Swift.String = "v1"
     ) throws -> Foundation.URL {
         try Foundation.URL(
-            validatingOpenAPIServerURL: "https://{subdomain}.example.com:{port}/{basePath}",
+            validatingOpenAPIServerURL: "{protocol}://{subdomain}.example.com:{port}/{basePath}",
             variables: [
+                .init(
+                    name: "protocol",
+                    value: _protocol
+                ),
                 .init(
                     name: "subdomain",
                     value: subdomain


### PR DESCRIPTION
### Motivation

In the original introduction of server variable support, we didn't properly safe the variable names coming from the OpenAPI document for use as Swift identifiers.

### Modifications

Fix that by running the name server variable name, provided in the OpenAPI document, through the function that safes the string for use as a Swift identifier.

### Result

Documents that use variable names like `protocol` compile again.

### Test Plan

Adapted the tests.
