### PR TITLE
Disable warnings-as-errors for nightlies

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
+++ b/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
@@ -103,20 +103,23 @@ func makeGeneratorPipeline(
     config: Config,
     diagnostics: any DiagnosticCollector
 ) -> GeneratorPipeline {
+    let filterDoc = { (doc: OpenAPI.Document) -> OpenAPI.Document in
+        guard let documentFilter = config.filter else { return doc }
+        let filteredDoc: OpenAPI.Document = try documentFilter.filter(doc)
+        return filteredDoc
+    }
+    let validateDoc = { (doc: OpenAPI.Document) -> OpenAPI.Document in
+        let validationDiagnostics = try validator(doc, config)
+        for diagnostic in validationDiagnostics { diagnostics.emit(diagnostic) }
+        return doc
+    }
     return .init(
         parseOpenAPIFileStage: .init(
             preTransitionHooks: [],
             transition: { input in try parser.parseOpenAPI(input, config: config, diagnostics: diagnostics) },
             postTransitionHooks: [
-                { document in
-                    guard let documentFilter = config.filter else { return document }
-                    return try documentFilter.filter(document)
-                },
-                { doc in
-                    let validationDiagnostics = try validator(doc, config)
-                    for diagnostic in validationDiagnostics { diagnostics.emit(diagnostic) }
-                    return doc
-                },
+                filterDoc,
+                validateDoc,
             ]
         ),
         translateOpenAPIToStructuredSwiftStage: .init(

--- a/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
+++ b/Sources/_OpenAPIGeneratorCore/GeneratorPipeline.swift
@@ -117,10 +117,7 @@ func makeGeneratorPipeline(
         parseOpenAPIFileStage: .init(
             preTransitionHooks: [],
             transition: { input in try parser.parseOpenAPI(input, config: config, diagnostics: diagnostics) },
-            postTransitionHooks: [
-                filterDoc,
-                validateDoc,
-            ]
+            postTransitionHooks: [filterDoc, validateDoc]
         ),
         translateOpenAPIToStructuredSwiftStage: .init(
             preTransitionHooks: [],

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -11,7 +11,8 @@ services:
   test:
     image: *image
     environment:
-      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      # Disable warnings as errors on nightlies as they are still in-development.
+      # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
   shell:


### PR DESCRIPTION
### Motivation

In Swift 5.11/nigtlies Swift upgraded preconcurrency diagnostics from a remark to a warning, and since we run CI with warnings-as-errors, that broke it. I tried removing the preconcurrency attribute on imports in #352, but we still need it.

Since main builds of Swift are still in-development, we shouldn't be so sensitive to changes there, so disabling warnings-as-errors for nightlies only (keeping for 5.8, 5.9, and 5.10).

### Modifications

Disable warnings as errors on CI for nightlies.

### Result

CI should pass again.

### Test Plan

CI.
