### PR TITLE
Fix inline response headers

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/TypedResponseHeader.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/TypedResponseHeader.swift
@@ -129,7 +129,8 @@ extension FileTranslator {
                 )
             }
         }
-        let usage = type.withOptional(!header.required)
+        let isOptional = try !header.required || typeMatcher.isOptional(schema, components: components)
+        let usage = type.withOptional(isOptional)
         return .init(
             header: header,
             name: name,

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseHeader.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseHeader.swift
@@ -24,13 +24,21 @@ extension TypesFileTranslator {
     /// - Returns: A property blueprint.
     /// - Throws: An error if there's an issue while parsing the response header.
     func parseResponseHeaderAsProperty(for header: TypedResponseHeader, parent: TypeName) throws -> PropertyBlueprint {
+        let schema = header.schema
+        let typeUsage = header.typeUsage
+        let associatedDeclarations: [Declaration]
+        if TypeMatcher.isInlinable(schema) {
+            associatedDeclarations = try translateSchema(typeName: typeUsage.typeName, schema: schema, overrides: .none)
+        } else {
+            associatedDeclarations = []
+        }
         let comment = parent.docCommentWithUserDescription(header.header.description, subPath: header.name)
         return .init(
             comment: comment,
             originalName: header.name,
-            typeUsage: header.typeUsage,
+            typeUsage: typeUsage,
             default: header.header.required ? nil : .nil,
-            associatedDeclarations: [],
+            associatedDeclarations: associatedDeclarations,
             asSwiftSafeName: swiftSafeName
         )
     }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1673,6 +1673,41 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testComponentsResponsesResponseWithInlineHeader() throws {
+        try self.assertResponsesTranslation(
+            """
+            responses:
+              BadRequest:
+                description: Bad request
+                headers:
+                  X-Reason:
+                    schema:
+                      type: string
+                      enum:
+                        - badLuck
+            """,
+            """
+            public enum Responses {
+                public struct BadRequest: Sendable, Hashable {
+                    public struct Headers: Sendable, Hashable {
+                        @frozen public enum X_hyphen_ReasonPayload: String, Codable, Hashable, Sendable {
+                            case badLuck = "badLuck"
+                        }
+                        public var X_hyphen_Reason: Components.Responses.BadRequest.Headers.X_hyphen_ReasonPayload?
+                        public init(X_hyphen_Reason: Components.Responses.BadRequest.Headers.X_hyphen_ReasonPayload? = nil) {
+                            self.X_hyphen_Reason = X_hyphen_Reason
+                        }
+                    }
+                    public var headers: Components.Responses.BadRequest.Headers
+                    public init(headers: Components.Responses.BadRequest.Headers = .init()) {
+                        self.headers = headers
+                    }
+                }
+            }
+            """
+        )
+    }
+
     func testComponentsResponsesResponseWithRequiredHeader() throws {
         try self.assertResponsesTranslation(
             """


### PR DESCRIPTION
### Motivation

When generating a response header that points to an inline schema, the generator didn't generate the definition of the inline schema, so the code wouldn't compile.

### Modifications

Make changes to properly compute optionality (drive-by improvement) and generate the inline type, if needed.

### Result

Inline response header schemas now compile.

### Test Plan

Added a snippet test for this.
