### PR TITLE
Bump OpenAPIKit to 3.0.0-rc.3 and recognize more base64/binary encoding locations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
 
         // Read OpenAPI documents
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", exact: "3.0.0-rc.2"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", exact: "3.0.0-rc.3"),
         .package(url: "https://github.com/jpsim/Yams.git", "4.0.0"..<"6.0.0"),
 
         // CLI Tool

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
@@ -44,6 +44,9 @@ extension TypeName {
     /// - Returns: A TypeName representing the type with the given name in the HTTPTypes module.
     static func httpTypes(_ name: String) -> TypeName { TypeName(swiftKeyPath: ["HTTPTypes", name]) }
 
+    /// Returns the type name for the Date type.
+    static var date: Self { .foundation("Date") }
+
     /// Returns the type name for the URL type.
     static var url: Self { .foundation("URL") }
 
@@ -78,4 +81,7 @@ extension TypeName {
 
     /// Returns the type name for the copy-on-write box type.
     static var box: TypeName { .runtime("CopyOnWriteBox") }
+
+    /// Returns the type name for the base64 wrapper.
+    static var base64: TypeName { .runtime("Base64EncodedData") }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
@@ -293,16 +293,22 @@ struct TypeMatcher {
             case .int64: typeName = .swift("Int64")
             default: typeName = .swift("Int")
             }
-        case .string(let core, _):
+        case .string(let core, let stringContext):
             if core.allowedValues != nil {
                 // custom enum isn't a builtin
                 return nil
             }
-            switch core.format {
+            switch stringContext.contentEncoding {
             case .binary: typeName = .body
-            case .byte: typeName = .runtime("Base64EncodedData")
-            case .dateTime: typeName = .foundation("Date")
-            default: typeName = .swift("String")
+            case .base64: typeName = .base64
+            default:
+                // Check the format as well, for docs converted from OpenAPI 3.0.
+                switch core.format {
+                case .binary: typeName = .body
+                case .byte: typeName = .base64
+                case .dateTime: typeName = .date
+                default: typeName = .string
+                }
             }
         case .fragment: typeName = .valueContainer
         case let .object(_, objectContext):

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
@@ -25,7 +25,9 @@ final class Test_TypeMatcher: Test_Core {
 
     static let builtinTypes: [(JSONSchema, String)] = [
         (.string, "Swift.String"), (.string(.init(format: .binary), .init()), "OpenAPIRuntime.HTTPBody"),
+        (.string(.init(), .init(contentEncoding: .binary)), "OpenAPIRuntime.HTTPBody"),
         (.string(.init(format: .byte), .init()), "OpenAPIRuntime.Base64EncodedData"),
+        (.string(.init(), .init(contentEncoding: .base64)), "OpenAPIRuntime.Base64EncodedData"),
         (.string(.init(format: .date), .init()), "Swift.String"),
         (.string(.init(format: .dateTime), .init()), "Foundation.Date"),
 


### PR DESCRIPTION
### Motivation

In OpenAPI 3.1.0, the `format: ...` part of schemas is deprecated, and instead `contentEncoding: ...` should be used. Before this PR, we'd recognize the encodings defined in `format` but not `contentEncoding`, this PR fixes that and finds them in both locations. This required a bump of OpenAPIKit, which added support for `contentEncoding` in `3.0.0-rc.3`.

### Modifications

Change the type matching logic to first look at `contentEncoding`, if no special value is specified there, look at `format`.

### Result

`contentEncoding: base64` and `contentEncoding: binary` will now be correctly represented as their runtime types instead of a plain string.

### Test Plan

Adapted the unit tests.
