### PR TITLE
Use granular RetroactiveAttribute feature guard

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Extensions/Foundation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/Foundation.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-#if compiler(>=5.11)
+#if hasFeature(RetroactiveAttribute)
 extension FileHandle: @retroactive TextOutputStream {}
 #else
 extension FileHandle: TextOutputStream {}

--- a/Sources/swift-openapi-generator/Extensions.swift
+++ b/Sources/swift-openapi-generator/Extensions.swift
@@ -16,7 +16,7 @@ import ArgumentParser
 import _OpenAPIGeneratorCore
 import Yams
 
-#if compiler(>=5.11)
+#if hasFeature(RetroactiveAttribute)
 extension URL: @retroactive ExpressibleByArgument {}
 extension GeneratorMode: @retroactive ExpressibleByArgument {}
 extension FeatureFlag: @retroactive ExpressibleByArgument {}


### PR DESCRIPTION
### Motivation

To protect against corner-cases where the more coarse compiler guard is insufficient.

### Modifications

Use granular `RetroactiveAttribute` feature guard

### Result

Safer code building.

### Test Plan

Tested code building with 5.8 on Linux