### PR TITLE
Bump to OpenAPIKit 3.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
 
         // Read OpenAPI documents
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", exact: "3.0.0-rc.3"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", "4.0.0"..<"6.0.0"),
 
         // CLI Tool

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
@@ -127,7 +127,8 @@ extension FileTranslator {
             let (contentType, contentValue) = mapWithContentTypes.first(where: { $0.type.isBinary })
         {
             chosenContent = (
-                contentType, .init(contentType: contentType, schema: .b(.string(format: .binary))), contentValue
+                contentType, .init(contentType: contentType, schema: .b(.string(contentEncoding: .binary))),
+                contentValue
             )
         } else {
             diagnostics.emitUnsupported("Unsupported content", foundIn: foundIn)
@@ -185,7 +186,7 @@ extension FileTranslator {
         }
         if contentType.isUrlEncodedForm { return .init(contentType: contentType, schema: contentValue.schema) }
         if !excludeBinary, contentType.isBinary {
-            return .init(contentType: contentType, schema: .b(.string(format: .binary)))
+            return .init(contentType: contentType, schema: .b(.string(contentEncoding: .binary)))
         }
         diagnostics.emitUnsupported("Unsupported content", foundIn: foundIn)
         return nil

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
@@ -302,10 +302,7 @@ struct TypeMatcher {
             case .binary: typeName = .body
             case .base64: typeName = .base64
             default:
-                // Check the format as well, for docs converted from OpenAPI 3.0.
                 switch core.format {
-                case .binary: typeName = .body
-                case .byte: typeName = .base64
                 case .dateTime: typeName = .date
                 default: typeName = .string
                 }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
@@ -24,10 +24,8 @@ final class Test_TypeMatcher: Test_Core {
     }
 
     static let builtinTypes: [(JSONSchema, String)] = [
-        (.string, "Swift.String"), (.string(.init(format: .binary), .init()), "OpenAPIRuntime.HTTPBody"),
-        (.string(.init(), .init(contentEncoding: .binary)), "OpenAPIRuntime.HTTPBody"),
-        (.string(.init(format: .byte), .init()), "OpenAPIRuntime.Base64EncodedData"),
-        (.string(.init(), .init(contentEncoding: .base64)), "OpenAPIRuntime.Base64EncodedData"),
+        (.string, "Swift.String"), (.string(contentEncoding: .binary), "OpenAPIRuntime.HTTPBody"),
+        (.string(contentEncoding: .base64), "OpenAPIRuntime.Base64EncodedData"),
         (.string(.init(format: .date), .init()), "Swift.String"),
         (.string(.init(format: .dateTime), .init()), "Foundation.Date"),
 

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -219,7 +219,7 @@ paths:
         content:
           application/octet-stream:
             schema:
-              format: binary
+              contentEncoding: binary
               type: string
       responses:
         '200':
@@ -227,7 +227,7 @@ paths:
           content:
             application/octet-stream:
               schema:
-                format: binary
+                contentEncoding: binary
                 type: string
         '412':
           description: Avatar is not acceptable
@@ -284,7 +284,7 @@ components:
         genome:
           description: "Pet genome (base64-encoded)"
           type: string
-          format: byte
+          contentEncoding: base64
         kind:
           $ref: '#/components/schemas/PetKind'
     MixedAnyOf:
@@ -329,7 +329,7 @@ components:
           type: string
         genome:
           type: string
-          format: byte
+          contentEncoding: base64
     Pets:
       type: array
       items:

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1121,7 +1121,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             schemas:
               MyData:
                 type: string
-                format: byte
+                contentEncoding: base64
             """,
             """
             public enum Schemas {
@@ -1140,7 +1140,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 properties:
                   stuff:
                     type: string
-                    format: byte
+                    contentEncoding: base64
             """,
             """
             public enum Schemas {
@@ -2481,7 +2481,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                   application/json:
                     schema:
                       type: string
-                      format: byte
+                      contentEncoding: base64
                     examples:
                       application/json:
                         summary: "a hello response"


### PR DESCRIPTION
### Motivation

OpenAPIKit released 3.0.0, so let's move to it.

### Modifications

They (correctly) removed the `format: byte` and `format: binary` fields in the OpenAPI 3.1 mode, instead `contentEncoding: base64` and `contentEncoding: binary` should be used.

For docs that load as 3.0 and get converted to 3.1 in memory, this translation happens automatically in OpenAPIKit, so we just need to be able to handle 3.1 documents here.

### Result

Using the stable v3 version of OpenAPIKit, which will allow Swift OpenAPI Generator to coexist with other projects that depend on OpenAPIKit v3 (previously, locking to an exact version of OpenAPIKit meant more difficult version resolution for adopters.)

### Test Plan

Adapted tests, all pass now.
