### PR TITLE
Fix spelling of retroactive guard

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Extensions/Foundation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/Foundation.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-#if hasFeature(RetroactiveAttribute)
+#if $RetroactiveAttribute
 extension FileHandle: @retroactive TextOutputStream {}
 #else
 extension FileHandle: TextOutputStream {}

--- a/Sources/swift-openapi-generator/Extensions.swift
+++ b/Sources/swift-openapi-generator/Extensions.swift
@@ -16,7 +16,7 @@ import ArgumentParser
 import _OpenAPIGeneratorCore
 import Yams
 
-#if hasFeature(RetroactiveAttribute)
+#if $RetroactiveAttribute
 extension URL: @retroactive ExpressibleByArgument {}
 extension GeneratorMode: @retroactive ExpressibleByArgument {}
 extension FeatureFlag: @retroactive ExpressibleByArgument {}


### PR DESCRIPTION
### Motivation:

`hasFeature(RetroactiveAttribute)` doesn't work as expected, but `$RetroactiveAttribute` does.

### Modifications:

Switch from `hasFeature` to `$RetroactiveAttribute`.

### Result:

- `@retroactive` is applied appropriately
