### PR TITLE
Bump OpenAPIKit to 3.0.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
 
         // Read OpenAPI documents
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.0.0"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.0.1"),
         .package(url: "https://github.com/jpsim/Yams.git", "4.0.0"..<"6.0.0"),
 
         // CLI Tool


### PR DESCRIPTION
### Motivation

OpenAPIKit fixed an issue with parsing large integers in 3.0.1 that affected some popular OpenAPI docs. While adopters can `swift package update`, let's still bump the minimum OpenAPIKit version we require to avoid our adopters accidentally running with `3.0.0` and hitting the bug.

### Modifications

Bumped the minimum OpenAPIKit version from 3.0.0 -> 3.0.1.

### Result

When this is released, adopters will always get the fixed version.

### Test Plan

All tests still pass.
