### PR TITLE
Add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Swift OpenAPI Generator
 
 [![](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://www.swift.org/sswg/)
+[![](https://img.shields.io/badge/docc-read_documentation-blue)](https://swiftpackageindex.com/apple/swift-openapi-generator/documentation)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fapple%2Fswift-openapi-generator%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/apple/swift-openapi-generator)
 
 Generate Swift client and server code from an OpenAPI document.
 


### PR DESCRIPTION
### Motivation

Surface the Swift version support status from Swift Package Index (not the platform badge here, as it's confusing people between what the _tool_ supports vs what platforms the _generated code_ can run on; let's redo the READMEs anyway for 1.0.)

### Modifications

Added badges, plus a quick link to the docc docs, to the top of the README.

### Result

Easier to quickly see our support matrix, plus the quick link to docs.

### Test Plan

Previewed locally.
