### PR TITLE
Fix a bug in path parameter ordering

### DIFF
--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -2157,6 +2157,82 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 """
         )
     }
+    func testRequestWithPathParams() throws {
+        try self.assertRequestInTypesClientServerTranslation(
+            """
+            /foo/a/{a}/b/{b}:
+              get:
+                parameters:
+                  - name: b
+                    in: path
+                    required: true
+                    schema:
+                      type: string
+                  - name: a
+                    in: path
+                    required: true
+                    schema:
+                      type: string
+                operationId: getFoo
+                responses:
+                  default:
+                    description: Response
+            """,
+            types: """
+                public struct Input: Sendable, Hashable {
+                    public struct Path: Sendable, Hashable {
+                        public var b: Swift.String
+                        public var a: Swift.String
+                        public init(
+                            b: Swift.String,
+                            a: Swift.String
+                        ) {
+                            self.b = b
+                            self.a = a
+                        }
+                    }
+                    public var path: Operations.getFoo.Input.Path
+                    public init(path: Operations.getFoo.Input.Path) {
+                        self.path = path
+                    }
+                }
+                """,
+            client: """
+                { input in
+                    let path = try converter.renderedPath(
+                        template: "/foo/a/{}/b/{}",
+                        parameters: [
+                            input.path.a,
+                            input.path.b
+                        ]
+                    )
+                    var request: HTTPTypes.HTTPRequest = .init(
+                        soar_path: path,
+                        method: .get
+                    )
+                    suppressMutabilityWarning(&request)
+                    return (request, nil)
+                }
+                """,
+            server: """
+                { request, requestBody, metadata in
+                    let path: Operations.getFoo.Input.Path = .init(
+                        b: try converter.getPathParameterAsURI(
+                            in: metadata.pathParameters,
+                            name: "b",
+                            as: Swift.String.self
+                        ),
+                        a: try converter.getPathParameterAsURI(
+                            in: metadata.pathParameters,
+                            name: "a",
+                            as: Swift.String.self
+                        )
+                    )
+                    return Operations.getFoo.Input(path: path)
+                }
+                """
+        )
+    }
 
     func testRequestRequiredBodyPrimitiveSchema() throws {
         try self.assertRequestInTypesClientServerTranslation(


### PR DESCRIPTION
### Motivation

Fixes #378.

Basically, if the path parameter order was different between the URL template `/a/{a}/b/{b}` and the list of path parameters, for example if `b` came before `a` there, we used the parameter order, not the URL template order, which was _incorrect_. I suspect this bug has been hiding for this long is because most documents use the same order in both.

### Modifications

Change the algorithm that composes the URL template and the list of parameters to respect the URL template's order.

### Result

The URL template order is now respected, regardless of the path parameter order.

### Test Plan

Added a snippet test that deliberately uses a different order between the URL template and the path paramater list. It failed before this fix, passes with it.

