### PR TITLE
Skip inferred properties

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
 
         // Read OpenAPI documents
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.0.1"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.1.0"),
         .package(url: "https://github.com/jpsim/Yams.git", "4.0.0"..<"6.0.0"),
 
         // CLI Tool

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateObjectStruct.swift
@@ -38,6 +38,20 @@ extension FileTranslator {
 
                 let foundIn = "\(typeName.description)/\(key)"
 
+                // Properties that are only defined in the `required` list but don't
+                // have a proper definition in the `properties` map are skipped, as they
+                // often imply a typo or a mistake in the document. So emit a diagnostic as well.
+                guard !value.inferred else {
+                    diagnostics.emit(
+                        .warning(
+                            message:
+                                "A property name only appears in the required list, but not in the properties map - this is likely a typo; skipping this property.",
+                            context: ["foundIn": foundIn]
+                        )
+                    )
+                    return false
+                }
+
                 // We need to catch a special case here:
                 // type: string + format: binary.
                 // It means binary data (unlike format: byte, which means base64

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -156,6 +156,38 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testComponentsSchemasObjectWithInferredProperty() throws {
+        try self.assertSchemasTranslation(
+            ignoredDiagnosticMessages: [
+                "A property name only appears in the required list, but not in the properties map - this is likely a typo; skipping this property."
+            ],
+            """
+            schemas:
+              MyObj:
+                type: object
+                properties:
+                  fooRequired:
+                    type: string
+                required:
+                  - fooRequired
+                  - fooInferred
+            """,
+            """
+            public enum Schemas {
+                public struct MyObj: Codable, Hashable, Sendable {
+                    public var fooRequired: Swift.String
+                    public init(fooRequired: Swift.String) {
+                        self.fooRequired = fooRequired
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case fooRequired
+                    }
+                }
+            }
+            """
+        )
+    }
+
     func testComponentsObjectNoAdditionalProperties() throws {
         try self.assertSchemasTranslation(
             """


### PR DESCRIPTION
### Motivation

Fixes #379.

Context:

If you define an object schema as follows:

```yaml
Foo:
  type: object
  properties:
    a:
      type: string
  required:
    - b
```

OpenAPIKit will parse it as having two properties: `a` of type `string` and `b` being a fragment, with `a` optional and `b` required.

Unfortunately, often property names appear _only_ in the `required` list as a result of a typo, leading to non-compiling code and a difficult debugging story.

It comes down to the fact that Swift OpenAPI Generator never officially supported defining properties this way, and continues not to.

If adopters want to do this intentionally, they should do this: 

```yaml
Foo:
  type: object
  properties:
    a:
      type: string
    b: {}
  required:
    - b
```

### Modifications

This PR tightens the rules around inferred properties:

1. Inferred properties are skipped, so the result of the first example will only have the property `a` generated, and the second example both `a` and `b`.
2. The generator emits a warning diagnostic when encountering an inferred property, which should help adopters who made a typo catch it much earlier in the process.
3. Bumps OpenAPIKit to 3.1.0, as the `inferred` property was added just yesterday.

### Result

Less likely typos and mismatch between `properties` and `required`, and a diagnostic to help debug this case.

### Test Plan

Added a snippet test.
