### PR TITLE
[Bug] Fix multipart schema inference for allOf/anyOf/oneOf of primitive types and non-binary arrays

### DIFF
--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Multipart/Test_MultipartContentInspector.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Multipart/Test_MultipartContentInspector.swift
@@ -43,6 +43,24 @@ class Test_MultipartContentInspector: Test_Core {
             schemaOut: .string(contentEncoding: .binary)
         )
         try _test(
+            schemaIn: .integer,
+            source: .infer(.primitive),
+            repetition: .single,
+            schemaOut: .string(contentEncoding: .binary)
+        )
+        try _test(
+            schemaIn: .boolean,
+            source: .infer(.primitive),
+            repetition: .single,
+            schemaOut: .string(contentEncoding: .binary)
+        )
+        try _test(
+            schemaIn: .string(allowedValues: ["foo"]),
+            source: .infer(.primitive),
+            repetition: .single,
+            schemaOut: .string(contentEncoding: .binary)
+        )
+        try _test(
             schemaIn: .array(items: .string),
             source: .infer(.primitive),
             repetition: .array,

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Multipart/Test_MultipartContentInspector.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Multipart/Test_MultipartContentInspector.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import OpenAPIKit
+@testable import _OpenAPIGeneratorCore
+
+class Test_MultipartContentInspector: Test_Core {
+    func testSerializationStrategy() throws {
+        let translator = makeTypesTranslator()
+        func _test(
+            schemaIn: JSONSchema,
+            encoding: OpenAPI.Content.Encoding? = nil,
+            source: MultipartPartInfo.ContentTypeSource,
+            repetition: MultipartPartInfo.RepetitionKind,
+            schemaOut: JSONSchema,
+            file: StaticString = #file,
+            line: UInt = #line
+        ) throws {
+            let (info, actualSchemaOut) = try XCTUnwrap(
+                translator.parseMultipartPartInfo(schema: schemaIn, encoding: encoding, foundIn: "")
+            )
+            XCTAssertEqual(info.repetition, repetition, file: file, line: line)
+            XCTAssertEqual(info.contentTypeSource, source, file: file, line: line)
+            XCTAssertEqual(actualSchemaOut, schemaOut, file: file, line: line)
+        }
+        try _test(schemaIn: .object, source: .infer(.complex), repetition: .single, schemaOut: .object)
+        try _test(schemaIn: .array(items: .object), source: .infer(.complex), repetition: .array, schemaOut: .object)
+        try _test(
+            schemaIn: .string,
+            source: .infer(.primitive),
+            repetition: .single,
+            schemaOut: .string(contentEncoding: .binary)
+        )
+        try _test(
+            schemaIn: .array(items: .string),
+            source: .infer(.primitive),
+            repetition: .array,
+            schemaOut: .string(contentEncoding: .binary)
+        )
+        try _test(
+            schemaIn: .any(of: .string, .string(allowedValues: ["foo"])),
+            source: .infer(.primitive),
+            repetition: .single,
+            schemaOut: .string(contentEncoding: .binary)
+        )
+    }
+}


### PR DESCRIPTION
### Motivation

As I started testing the multipart generation on real-world projects, I discovered two bugs:
- allOf/anyOf/oneOf of primitive types (such as string) were encoded as JSON instead of a raw string (aka HTTPBody), which was wrong
- arrays of non-binary and arrays of binary elements were treated inconsistently

### Modifications

Fixed the bug by refactoring the inferrence logic a bit.

### Result

Now e.g. an anyOf of a string still gets encoded as a primitive type, not JSON.

### Test Plan

Added a unit test for this logic with a few test cases, easier to debug this way.
