### PR TITLE
Undeprecate tests that used to test deprecated code

### DIFF
--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -595,7 +595,7 @@ final class Test_Client: XCTestCase {
         }
     }
 
-    @available(*, deprecated) func testProbe_204() async throws {
+    func testProbe_204() async throws {
         transport = .init { request, requestBody, baseURL, operationID in
             XCTAssertEqual(operationID, "probe")
             XCTAssertEqual(request.path, "/probe/")
@@ -612,7 +612,7 @@ final class Test_Client: XCTestCase {
         }
     }
 
-    @available(*, deprecated) func testProbe_undocumented() async throws {
+    func testProbe_undocumented() async throws {
         transport = .init { request, requestBody, baseURL, operationID in (.init(status: .serviceUnavailable), nil) }
         let response = try await client.probe(.init())
         guard case let .undocumented(statusCode, _) = response else {


### PR DESCRIPTION
### Motivation

Two tests used to exercise operations in the Petstore test project that were deprecated, so to avoid warnings we deprecated the tests themselves too. We removed the deprecation of those operations a while ago, and forgot to undeprecate the tests.

### Modifications

Undeprecate the tests.

### Result

Removed an unnecessary deprecation of two tests.

### Test Plan

All tests pass.
