### PR TITLE
Add visionOS to Package.swift to emit useful compilation errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         // The platforms below are not currently supported for running
         // the generator itself. We include them here to allow the generator
         // to emit a more descriptive compiler error.
-        .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
+        .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1),
     ],
     products: [
         .executable(name: "swift-openapi-generator", targets: ["swift-openapi-generator"]),

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ The generator is used during development and is supported on macOS and Linux.
 
 The generated code, runtime library, and transports are supported on more platforms, listed below.
 
-| Component | macOS | Linux | iOS | tvOS | watchOS |
-| -: | :-: | :-: | :-: | :-: | :-: |
-| Generator plugin and CLI            | ✅ 10.15+  | ✅     | ❌     | ❌     | ❌    |
-| Generated code, runtime, transports | ✅ 10.15+  | ✅     | ✅ 13+ | ✅ 13+ | ✅ 6+ |
+| Component | macOS | Linux | iOS | tvOS | watchOS | visionOS |
+| -: | :-: | :-: | :-: | :-: | :-: | :-: |
+| Generator plugin and CLI            | ✅ 10.15+  | ✅     | ❌     | ❌     | ❌    | ❌    |
+| Generated code, runtime, transports | ✅ 10.15+  | ✅     | ✅ 13+ | ✅ 13+ | ✅ 6+ | ✅ 1+ |
 
 ## Documentation
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
@@ -55,10 +55,10 @@ The generator is used during development and is supported on macOS and Linux.
 
 The generated code, runtime library, and transports are supported on more platforms, listed below.
 
-| Component | macOS | Linux | iOS | tvOS | watchOS |
-| -: | :-: | :-: | :-: | :-: | :-: |
-| Generator plugin and CLI            | ✅ 10.15+  | ✅     | ❌     | ❌     | ❌    |
-| Generated code, runtime, transports | ✅ 10.15+  | ✅     | ✅ 13+ | ✅ 13+ | ✅ 6+ |
+| Component | macOS | Linux | iOS | tvOS | watchOS | visionOS |
+| -: | :-: | :-: | :-: | :-: | :-: | :-: |
+| Generator plugin and CLI            | ✅ 10.15+  | ✅     | ❌     | ❌     | ❌    | ❌    |
+| Generated code, runtime, transports | ✅ 10.15+  | ✅     | ✅ 13+ | ✅ 13+ | ✅ 6+ | ✅ 1+ |
 
 ## Topics
 


### PR DESCRIPTION
### Motivation

We have provision for emitting a useful compilation error when trying to link the _generator_ to an application on darwin platforms, e.g. iOS, tvOS, watchOS. To support this, we add those platforms to the Package.swift so that the code at least tries to compile and then we can emit the `#error`. This list does not currently include visionOS so users will not get the same useful compilation error.

### Modifications

Add visionOS to the platforms in Package.swift. While there, also add this to the platforms in the Package.swift for the client used in the tutorial.

### Result

When compiling for visionOS and trying to link the generator, a useful compiler error will be emitted.

### Test Plan

Manual.
