### PR TITLE
Switch default visibility from package to public

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Config.swift
+++ b/Sources/_OpenAPIGeneratorCore/Config.swift
@@ -27,7 +27,7 @@ public struct Config: Sendable {
     public var access: AccessModifier
 
     /// The default access modifier.
-    public static let defaultAccessModifier: AccessModifier = .package
+    public static let defaultAccessModifier: AccessModifier = .public
 
     /// Additional imports to add to each generated file.
     public var additionalImports: [String]

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -31,8 +31,8 @@ The configuration file has the following keys:
     - `client`: Client code that can be used with any client transport (depends on code from `types`).
     - `server`: Server code that can be used with any server transport (depends on code from `types`).
 - `accessModifier` (optional): a string. Customizes the visibility of the API of the generated code.
-    - `public`: Generated API is accessible from other modules and other packages (if included in a product).
-    - `package` (default): Generated API is accessible from other modules within the same package or project.
+    - `public` (default): Generated API is accessible from other modules and other packages (if included in a product).
+    - `package`: Generated API is accessible from other modules within the same package or project.
     - `internal`: Generated API is accessible from the containing module only.
 - `additionalImports` (optional): array of strings. Each string value is a Swift module name. An import statement will be added to the generated source files for each module.
 - `filter`: (optional): Filters to apply to the OpenAPI document before generation.

--- a/Tests/OpenAPIGeneratorCoreTests/Test_Config.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Test_Config.swift
@@ -16,5 +16,5 @@ import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_Config: Test_Core {
-    func testDefaultAccessModifier() { XCTAssertEqual(Config.defaultAccessModifier, .package) }
+    func testDefaultAccessModifier() { XCTAssertEqual(Config.defaultAccessModifier, .public) }
 }


### PR DESCRIPTION
### Motivation

The `package` access modifier seems to have issues for files produced by plugins, so let's switch back to `public`.

### Modifications

Switch the default access modifier to `public`.

### Result

The default modifier is `public` again.

### Test Plan

Updated tests.
