### PR TITLE
Remove the base64 feature flag

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
+++ b/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
@@ -28,11 +28,6 @@
 public enum FeatureFlag: String, Hashable, Codable, CaseIterable, Sendable {
     // needs to be here for the enum to compile
     case empty
-
-    /// Base64 encoding and decoding.
-    ///
-    /// Enable interpretation of `type: string, format: byte` as base64-encoded data.
-    case base64DataEncodingDecoding
 }
 
 /// A set of enabled feature flags.

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
@@ -45,9 +45,6 @@ struct TypeAssigner {
     /// safe to be used as a Swift identifier.
     var asSwiftSafeName: (String) -> String
 
-    ///Enable decoding and encoding of as base64-encoded data strings.
-    var enableBase64EncodingDecoding: Bool
-
     /// Returns a type name for an OpenAPI-named component type.
     ///
     /// A component type is any type in `#/components` in the OpenAPI document.
@@ -331,10 +328,7 @@ struct TypeAssigner {
         inParent parent: TypeName,
         subtype: SubtypeNamingMethod
     ) throws -> TypeUsage {
-        let typeMatcher = TypeMatcher(
-            asSwiftSafeName: asSwiftSafeName,
-            enableBase64EncodingDecoding: enableBase64EncodingDecoding
-        )
+        let typeMatcher = TypeMatcher(asSwiftSafeName: asSwiftSafeName)
         // Check if this type can be simply referenced without
         // creating a new inline type.
         if let referenceableType = try typeMatcher.tryMatchReferenceableType(for: schema, components: components) {
@@ -551,20 +545,10 @@ struct TypeAssigner {
 extension FileTranslator {
 
     /// A configured type assigner.
-    var typeAssigner: TypeAssigner {
-        TypeAssigner(
-            asSwiftSafeName: swiftSafeName,
-            enableBase64EncodingDecoding: config.featureFlags.contains(.base64DataEncodingDecoding)
-        )
-    }
+    var typeAssigner: TypeAssigner { TypeAssigner(asSwiftSafeName: swiftSafeName) }
 
     /// A configured type matcher.
-    var typeMatcher: TypeMatcher {
-        TypeMatcher(
-            asSwiftSafeName: swiftSafeName,
-            enableBase64EncodingDecoding: config.featureFlags.contains(.base64DataEncodingDecoding)
-        )
-    }
+    var typeMatcher: TypeMatcher { TypeMatcher(asSwiftSafeName: swiftSafeName) }
 }
 
 /// An error used during the parsing of JSON references specified in an

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
@@ -20,9 +20,6 @@ struct TypeMatcher {
     /// safe to be used as a Swift identifier.
     var asSwiftSafeName: (String) -> String
 
-    ///Enable decoding and encoding of as base64-encoded data strings.
-    var enableBase64EncodingDecoding: Bool
-
     /// Returns the type name of a built-in type that matches the specified
     /// schema.
     ///
@@ -72,11 +69,7 @@ struct TypeMatcher {
             test: { (schema) -> TypeUsage? in
                 if let builtinType = Self._tryMatchBuiltinNonRecursive(for: schema) { return builtinType }
                 guard case let .reference(ref, _) = schema else { return nil }
-                return try TypeAssigner(
-                    asSwiftSafeName: asSwiftSafeName,
-                    enableBase64EncodingDecoding: enableBase64EncodingDecoding
-                )
-                .typeName(for: ref).asUsage
+                return try TypeAssigner(asSwiftSafeName: asSwiftSafeName).typeName(for: ref).asUsage
             },
             matchedArrayHandler: { elementType in elementType.asArray },
             genericArrayHandler: { TypeName.arrayContainer.asUsage }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -4671,7 +4671,6 @@ final class SnippetBasedReferenceTests: XCTestCase {
 
     func testResponseWithExampleWithOnlyValueByte() throws {
         try self.assertResponsesTranslation(
-            featureFlags: [.base64DataEncodingDecoding],
             """
             responses:
               MyResponse:


### PR DESCRIPTION
### Motivation

In preparation for 1.0.0-alpha.1, we enable and remove all feature flags.

### Modifications

Remove the feature flag.

Now, the fun thing I just discovered is that the feature flag wasn't correctly wired up, so we accidentally broke some users in 0.3.x when base64 landed, as it changed `Swift.String` to `OpenAPIRuntime.Base64EncodedData` _unconditionally_. This wasn't caught in PR review and unfortunately didn't have a negative test that would have caught this.

### Result

Removed a stale feature flag.

### Test Plan

All tests pass.
