### PR TITLE
Add examples compose target for CI

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -57,3 +57,7 @@ services:
     command: /bin/bash -xcl "swift -version && uname -a && bash ./scripts/check-for-docc-warnings.sh"
     environment:
       DOCC_TARGET: swift-openapi-generator
+
+  examples:
+    <<: *common
+    command: /bin/bash -xcl "swift -version && uname -a && true" # Placeholder to bootstrap pipeline.


### PR DESCRIPTION
### Motivation

As we approach 1.0, we'd like to be adding more examples to the repo. We'd like a CI pipeline that will check these continue to compile.

### Modifications

Add a new dummy pipeline for now to stage bringing up the examples. Currently just runs `true`.

### Result

New pipeline can run.

### Test Plan

Use this PR to test the new pipeline triggering.