### PR TITLE
[CI] Start testing examples

### DIFF
--- a/Examples/.gitignore
+++ b/Examples/.gitignore
@@ -1,0 +1,1 @@
+**/Package.resolved

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -60,4 +60,4 @@ services:
 
   examples:
     <<: *common
-    command: /bin/bash -xcl "swift -version && uname -a && true" # Placeholder to bootstrap pipeline.
+    command: /bin/bash -xcl "swift -version && uname -a && bash ./scripts/test-examples.sh"

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -30,7 +30,7 @@ EXAMPLES_PACKAGE_PATH="${PACKAGE_PATH}/Examples"
 
 for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name Package.swift -type f -print0 | xargs -0 dirname); do
 
-    EXAMPLE_PACKAGE_NAME=$(basename "${EXAMPLE_PACKAGE_PATH}")
+    EXAMPLE_PACKAGE_NAME="$(basename "${EXAMPLE_PACKAGE_PATH}")"
     EXAMPLE_COPY_DIR="${TMP_DIR}/${EXAMPLE_PACKAGE_NAME}"
     log "Copying example ${EXAMPLE_PACKAGE_NAME} to ${EXAMPLE_COPY_DIR}"
     cp -R "${EXAMPLE_PACKAGE_PATH}" "${EXAMPLE_COPY_DIR}"

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -40,7 +40,7 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
         edit swift-openapi-generator --path "${PACKAGE_PATH}"
 
     log "Building example package: ${EXAMPLE_PACKAGE_NAME}"
-    swift build --package-path "${EXAMPLE_COPY_DIR}"
+    "${SWIFT_BIN}" build --package-path "${EXAMPLE_COPY_DIR}"
     log "✅ Successfully built the example package ${EXAMPLE_PACKAGE_NAME}."
 
     if [ -d "${EXAMPLE_COPY_DIR}/Tests" ]; then

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -29,7 +29,7 @@ TMP_DIR=$(/usr/bin/mktemp -d -p "${TMPDIR-/tmp}" "$(basename "$0").XXXXXXXXXX")
 PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
 EXAMPLES_PACKAGE_PATH="${PACKAGE_PATH}/Examples"
 
-for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -name Package.swift -type f -maxdepth 2 | xargs dirname); do
+for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name Package.swift -type f | xargs dirname); do
 
     EXAMPLE_PACKAGE_NAME=$(basename "${EXAMPLE_PACKAGE_PATH}")
     EXAMPLE_COPY_DIR="${TMP_DIR}/${EXAMPLE_PACKAGE_NAME}"

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -20,7 +20,6 @@ fatal() { error "$@"; exit 1; }
 
 log "Checking required executables..."
 SWIFT_BIN=${SWIFT_BIN:-$(command -v swift || xcrun -f swift)} || fatal "SWIFT_BIN unset and no swift on PATH"
-JQ_BIN=${JQ_BIN:-$(command -v jq)} || fatal "JQ_BIN unset and no jq on PATH"
 
 CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftOpenAPIGenerator open source project
+##
+## Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+log "Checking required executables..."
+SWIFT_BIN=${SWIFT_BIN:-$(command -v swift || xcrun -f swift)} || fatal "SWIFT_BIN unset and no swift on PATH"
+JQ_BIN=${JQ_BIN:-$(command -v jq)} || fatal "JQ_BIN unset and no jq on PATH"
+
+CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
+TMP_DIR=$(/usr/bin/mktemp -d -p "${TMPDIR-/tmp}" "$(basename "$0").XXXXXXXXXX")
+
+PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
+EXAMPLES_PACKAGE_PATH="${PACKAGE_PATH}/Examples"
+
+# TODO: do this in tmpdir
+
+for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -name Package.swift -type f -maxdepth 2 | xargs dirname); do
+
+    log "Overriding dependency in ${EXAMPLE_PACKAGE_PATH} to use ${PACKAGE_PATH}"
+    swift package --package-path "${EXAMPLE_PACKAGE_PATH}" \
+        edit swift-openapi-generator --path "${PACKAGE_PATH}"
+
+    log "Building example package: ${EXAMPLE_PACKAGE_PATH}"
+    swift build --package-path "${EXAMPLE_PACKAGE_PATH}"
+    log "✅ Successfully built the example package ${EXAMPLE_PACKAGE_PATH}."
+
+    if [ -d "${EXAMPLE_PACKAGE_PATH}/Tests" ]; then
+        swift test --package-path "${EXAMPLE_PACKAGE_PATH}"
+        log "✅ Passed the tests for the example package ${EXAMPLE_PACKAGE_PATH}."
+    fi
+done

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -28,7 +28,7 @@ TMP_DIR=$(/usr/bin/mktemp -d -p "${TMPDIR-/tmp}" "$(basename "$0").XXXXXXXXXX")
 PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
 EXAMPLES_PACKAGE_PATH="${PACKAGE_PATH}/Examples"
 
-for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name Package.swift -type f | xargs dirname); do
+for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name Package.swift -type f -print0 | xargs -0 dirname); do
 
     EXAMPLE_PACKAGE_NAME=$(basename "${EXAMPLE_PACKAGE_PATH}")
     EXAMPLE_COPY_DIR="${TMP_DIR}/${EXAMPLE_PACKAGE_NAME}"

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -36,7 +36,7 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
     cp -R "${EXAMPLE_PACKAGE_PATH}" "${EXAMPLE_COPY_DIR}"
 
     log "Overriding dependency in ${EXAMPLE_PACKAGE_NAME} to use ${PACKAGE_PATH}"
-    swift package --package-path "${EXAMPLE_COPY_DIR}" \
+    "${SWIFT_BIN}" package --package-path "${EXAMPLE_COPY_DIR}" \
         edit swift-openapi-generator --path "${PACKAGE_PATH}"
 
     log "Building example package: ${EXAMPLE_PACKAGE_NAME}"

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -44,7 +44,8 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
     log "✅ Successfully built the example package ${EXAMPLE_PACKAGE_NAME}."
 
     if [ -d "${EXAMPLE_COPY_DIR}/Tests" ]; then
-        swift test --package-path "${EXAMPLE_COPY_DIR}"
+        log "Running tests for example package: ${EXAMPLE_PACKAGE_NAME}"
+        "${SWIFT_BIN}" test --package-path "${EXAMPLE_COPY_DIR}"
         log "✅ Passed the tests for the example package ${EXAMPLE_PACKAGE_NAME}."
     fi
 done


### PR DESCRIPTION
### Motivation

We're expanding the Examples section and want to verify that they continue to work as the project evolves.

That means that they successfully build, and for those with tests, that the tests are passing.

### Modifications

Added a script that is now triggered by the new `examples` pipeline.

It goes through all the packages in Examples and builds them, and for those with a Tests directory, also tests them.

### Result

More confidence that our Examples are working.

### Test Plan

Ran the test on macOS, ran it in docker-compose, all passed, so did the new CI. Verified in CI logs that the script is actually running and the two existing examples were exercised.

