### PR TITLE
[Examples] Add HelloWorldClient and HelloWorldServer

### DIFF
--- a/Examples/HelloWorldClient/.gitignore
+++ b/Examples/HelloWorldClient/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.vscode
+/Package.resolved
+.ci/
+.docc-build/

--- a/Examples/HelloWorldClient/Package.swift
+++ b/Examples/HelloWorldClient/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.9
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import PackageDescription
+
+let package = Package(
+    name: "HelloWorldClient",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", exact: "1.0.0-alpha.1"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "HelloWorldClient",
+            dependencies: [
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
+            ],
+            plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
+        ),
+    ]
+)

--- a/Examples/HelloWorldClient/README.md
+++ b/Examples/HelloWorldClient/README.md
@@ -1,0 +1,20 @@
+# Hello World Client
+
+An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
+
+## Overview
+
+A "hello world" command-line tool that uses a generated client to make a request to the Greeting Service running on `http://localhost:8080`.
+
+The tool uses the [URLSession](https://developer.apple.com/documentation/foundation/urlsession) API to perform the HTTP call, wrapped in the [Swift OpenAPI URLSession Transport](https://github.com/apple/swift-openapi-urlsession).
+
+The server can be started by running the `HelloWorldServer` example locally.
+
+## Usage
+
+Build and run the client CLI using:
+
+```
+$ swift run
+Hello, Stranger!
+```

--- a/Examples/HelloWorldClient/Sources/GreetingServiceClient/Tool.swift
+++ b/Examples/HelloWorldClient/Sources/GreetingServiceClient/Tool.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIRuntime
+import OpenAPIURLSession
+import Foundation
+
+@main struct Tool {
+    static func main() async throws {
+        let client = Client(
+            serverURL: URL(string: "http://localhost:8080/api")!,
+            transport: URLSessionTransport()
+        )
+        let response = try await client.getGreeting()
+        print(try response.ok.body.json.message)
+    }
+}

--- a/Examples/HelloWorldClient/Sources/GreetingServiceClient/openapi-generator-config.yaml
+++ b/Examples/HelloWorldClient/Sources/GreetingServiceClient/openapi-generator-config.yaml
@@ -1,0 +1,3 @@
+generate:
+- types
+- client

--- a/Examples/HelloWorldClient/Sources/GreetingServiceClient/openapi.yaml
+++ b/Examples/HelloWorldClient/Sources/GreetingServiceClient/openapi.yaml
@@ -1,0 +1,36 @@
+openapi: '3.1.0'
+info:
+  title: GreetingService
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+    description: Example service deployment.
+paths:
+  /greet:
+    get:
+      operationId: getGreeting
+      parameters:
+      - name: name
+        required: false
+        in: query
+        description: The name used in the returned greeting.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: A success response with a greeting.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Greeting'
+components:
+  schemas:
+    Greeting:
+      type: object
+      description: A value with the greeting contents.
+      properties:
+        message:
+          type: string
+          description: The string representation of the greeting.
+      required:
+        - message

--- a/Examples/HelloWorldServer/.gitignore
+++ b/Examples/HelloWorldServer/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.vscode
+/Package.resolved
+.ci/
+.docc-build/

--- a/Examples/HelloWorldServer/Package.swift
+++ b/Examples/HelloWorldServer/Package.swift
@@ -1,0 +1,46 @@
+// swift-tools-version:5.9
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import PackageDescription
+
+let package = Package(
+    name: "HelloWorldServer",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.76.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "HelloWorldServer",
+            dependencies: [
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
+                .product(name: "Vapor", package: "vapor"),
+            ],
+            plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
+        ),
+        .testTarget(
+            name: "HelloWorldServerTests",
+            dependencies: [
+                "HelloWorldServer",
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
+                .product(name: "Vapor", package: "vapor"),
+            ]
+        ),
+    ]
+)

--- a/Examples/HelloWorldServer/README.md
+++ b/Examples/HelloWorldServer/README.md
@@ -1,0 +1,40 @@
+# Hello World Server
+
+An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
+
+## Overview
+
+A "hello world" server that uses generated server stubs to handle requests as the Greeting Service. 
+
+The tool uses the [Vapor](https://github.com/vapor/vapor) server framework to handle HTTP requests, wrapped in the [Swift OpenAPI Vapor Transport](https://github.com/swift-server/swift-openapi-vapor).
+
+The CLI starts the server on `http://localhost:8080` and can be invoked by running the `HelloWorldClient` example client or on the command line using:
+
+```
+$ curl http://localhost:8080/api/greet
+{
+  "message" : "Hello, Stranger!"
+}
+```
+
+## Usage
+
+Build and run the server CLI using:
+
+```
+$ swift run
+2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
+...
+```
+
+## Testing
+
+Run tests using:
+
+```
+swift test
+```
+
+The testing strategy is to call the `Handler` directly from tests, as it conforms the `APIProtocol` and implements the business logic.
+
+This allows you to provide any input to the handler methods and verify that the correct outputs are returned, such as error responses when the input data is invalid, and so on.

--- a/Examples/HelloWorldServer/Sources/HelloWorldServer/Tool.swift
+++ b/Examples/HelloWorldServer/Sources/HelloWorldServer/Tool.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIRuntime
+import OpenAPIVapor
+import Vapor
+
+struct Handler: APIProtocol {
+    func getGreeting(_ input: Operations.getGreeting.Input) async throws -> Operations.getGreeting.Output {
+        let name = input.query.name ?? "Stranger"
+        return .ok(.init(body: .json(.init(message: "Hello, \(name)!"))))
+    }
+}
+
+@main struct Tool {
+    static func main() throws {
+        let app = Vapor.Application()
+        let transport = VaporTransport(routesBuilder: app)
+        let handler = Handler()
+        try handler.registerHandlers(
+            on: transport,
+            serverURL: URL(string: "/api")!
+        )
+        try app.run()
+    }
+}

--- a/Examples/HelloWorldServer/Sources/HelloWorldServer/openapi-generator-config.yaml
+++ b/Examples/HelloWorldServer/Sources/HelloWorldServer/openapi-generator-config.yaml
@@ -1,0 +1,3 @@
+generate:
+- types
+- server

--- a/Examples/HelloWorldServer/Sources/HelloWorldServer/openapi.yaml
+++ b/Examples/HelloWorldServer/Sources/HelloWorldServer/openapi.yaml
@@ -1,0 +1,36 @@
+openapi: '3.1.0'
+info:
+  title: GreetingService
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+    description: Example service deployment.
+paths:
+  /greet:
+    get:
+      operationId: getGreeting
+      parameters:
+      - name: name
+        required: false
+        in: query
+        description: The name used in the returned greeting.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: A success response with a greeting.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Greeting'
+components:
+  schemas:
+    Greeting:
+      type: object
+      description: A value with the greeting contents.
+      properties:
+        message:
+          type: string
+          description: The string representation of the greeting.
+      required:
+        - message

--- a/Examples/HelloWorldServer/Tests/HelloWorldServerTests/Tests.swift
+++ b/Examples/HelloWorldServer/Tests/HelloWorldServerTests/Tests.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+@testable import HelloWorldServer
+
+final class Tests: XCTestCase {
+    func testCustomName() async throws {
+        let handler: APIProtocol = Handler()
+        let response = try await handler.getGreeting(query: .init(name: "Jane"))
+        XCTAssertEqual(response, .ok(.init(body: .json(.init(message: "Hello, Jane!")))))
+    }
+
+    func testDefaultName() async throws {
+        let handler: APIProtocol = Handler()
+        let response = try await handler.getGreeting()
+        XCTAssertEqual(response, .ok(.init(body: .json(.init(message: "Hello, Stranger!")))))
+    }
+}

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,0 +1,8 @@
+# Examples of using Swift OpenAPI Generator
+
+All the examples are self-contained, so you can copy the package directory of your chosen example and use it as a starter template for your project.
+
+## Getting started
+
+- [`HelloWorldClient`](./HelloWorldClient) - a URLSession-based CLI client
+- [`HelloWorldServer`](./HelloWorldServer) - a Vapor-based CLI server


### PR DESCRIPTION
### Motivation

Adding examples, there'll be a bunch of these.

### Modifications

See title.

### Result

N/A

### Test Plan

Tested locally, the `examples` CI will also build and test them.

Verified that if I run the server in one Terminal tab with `swift run`, and then run the client in another with `swift run`, they successfully talk to each other.
