### PR TITLE
Log the access modifier for clarity

### DIFF
--- a/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
@@ -30,13 +30,13 @@ extension _GenerateOptions {
     func runGenerator(outputDirectory: URL, pluginSource: PluginSource?, isDryRun: Bool) async throws {
         let config = try loadedConfig()
         let sortedModes = try resolvedModes(config)
-        let resolvedAccessModifier = resolvedAccessModifier(config)
+        let resolvedAccessModifier = resolvedAccessModifier(config) ?? Config.defaultAccessModifier
         let resolvedAdditionalImports = resolvedAdditionalImports(config)
         let resolvedFeatureFlags = resolvedFeatureFlags(config)
         let configs: [Config] = sortedModes.map {
             .init(
                 mode: $0,
-                access: resolvedAccessModifier ?? Config.defaultAccessModifier,
+                access: resolvedAccessModifier,
                 additionalImports: resolvedAdditionalImports,
                 filter: config?.filter,
                 featureFlags: resolvedFeatureFlags
@@ -60,6 +60,7 @@ extension _GenerateOptions {
             - OpenAPI document path: \(doc.path)
             - Configuration path: \(self.config?.path ?? "<none>")
             - Generator modes: \(sortedModes.map(\.rawValue).joined(separator: ", "))
+            - Access modifier: \(resolvedAccessModifier.rawValue)
             - Feature flags: \(resolvedFeatureFlags.isEmpty ? "<none>" : resolvedFeatureFlags.map(\.rawValue).joined(separator: ", "))
             - Output file names: \(sortedModes.map(\.outputFileName).joined(separator: ", "))
             - Output directory: \(outputDirectory.path)


### PR DESCRIPTION
### Motivation

The access modifier is now customizable, but adopters might not be aware that we also changed the default from `public` to `package`. We should log that fact in the summary we print by the CLI, hopefully making it more discoverable during debugging.

### Modifications

Log the resolved access modifier when the CLI runs (also printed when the plugin invokes it).

### Result

Should be clearer what the chosen access modifier is and why some API might be either leaking out, or not visible.

### Test Plan

N/A, it's a log line.
