### PR TITLE
Remove unneeded target dependencies from HelloWorldVaporServerTests

### DIFF
--- a/Examples/HelloWorldVaporServer/Package.swift
+++ b/Examples/HelloWorldVaporServer/Package.swift
@@ -32,14 +32,6 @@ let package = Package(
                 .product(name: "Vapor", package: "vapor"),
             ],
             plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
-        ),
-        .testTarget(
-            name: "HelloWorldVaporServerTests",
-            dependencies: [
-                "HelloWorldVaporServer", .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-                .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
-                .product(name: "Vapor", package: "vapor"),
-            ]
-        ),
+        ), .testTarget(name: "HelloWorldVaporServerTests", dependencies: ["HelloWorldVaporServer"]),
     ]
 )


### PR DESCRIPTION
### Motivation

The HelloWorld example had a test target that had the same target dependencies as the source target. These weren't necessary and, if these are going to be examples, they should be cleaned up to be as minimal as possible.

### Modifications

Remove unneeded dependencies from HelloWorldVaporServerTests target.

### Result

Simpler Package.swift

(And, annoyingly formatted Package.swift, due to swift-format)

### Test Plan

CI should still be fine.