### PR TITLE
scripts: Add support for SINGLE_EXAMPLE_PACKAGE to test-examples.sh

### DIFF
--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -32,6 +32,12 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
 
     EXAMPLE_PACKAGE_NAME="$(basename "${EXAMPLE_PACKAGE_PATH}")"
     EXAMPLE_COPY_DIR="${TMP_DIR}/${EXAMPLE_PACKAGE_NAME}"
+
+    if [[ "${SINGLE_EXAMPLE_PACKAGE:-${EXAMPLE_PACKAGE_NAME}}" != "${EXAMPLE_PACKAGE_NAME}" ]]; then
+        log "Skipping example: ${EXAMPLE_PACKAGE_NAME}"
+        continue
+    fi
+
     log "Copying example ${EXAMPLE_PACKAGE_NAME} to ${EXAMPLE_COPY_DIR}"
     cp -R "${EXAMPLE_PACKAGE_PATH}" "${EXAMPLE_COPY_DIR}"
 


### PR DESCRIPTION
### Motivation

The `test-examples.sh` script tests all the example packages found in `Examples/`. When iterating locally on a single example, when wanting to build for Linux, or when reproducing a CI failure, it would be useful to run just a single example.

### Modifications

Add support for building a single example package by setting `SINGLE_EXAMPLE_PACKAGE` environment variable to the name of the package to test.

When this variable is set, all other packages will be skipped. When this variable is unset, all packages will be tested.

### Result

```console
% docker-compose -f docker/docker-compose.yaml run -e SINGLE_EXAMPLE_PACKAGE=CommandLineClient examples
...
+ bash ./scripts/test-examples.sh
** Checking required executables...
** Skipping example: HelloWorldAsyncHTTPClient
** Skipping example: CommandPluginInvocationClient
** Skipping example: ContentTypesServer
** Skipping example: HelloWorldHummingbirdServer
** Skipping example: ManualGeneratorInvocationClient
** Skipping example: SwaggerUIEndpointsServer
** Skipping example: HelloWorldURLSessionClient
** Skipping example: PostgresDatabaseServer
** Skipping example: ContentTypesClient
** Copying example CommandLineClient to /tmp/test-examples.sh.CdYZmySJ9R/CommandLineClient
** Overriding dependency in CommandLineClient to use /code
...
```

### Test Plan

Tested locally.

CI should be unaffected as we do not set this variable.