### PR TITLE
scripts: Use shared --cache-path and --scratch-path when building examples

### DIFF
--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -27,6 +27,8 @@ TMP_DIR=$(/usr/bin/mktemp -d -p "${TMPDIR-/tmp}" "$(basename "$0").XXXXXXXXXX")
 
 PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
 EXAMPLES_PACKAGE_PATH="${PACKAGE_PATH}/Examples"
+SHARED_SCRATCH_PATH="${TMP_DIR}/scratch"
+SHARED_CACHE_PATH="${TMP_DIR}/cache"
 
 for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name Package.swift -type f -print0 | xargs -0 dirname); do
 
@@ -36,16 +38,33 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
     cp -R "${EXAMPLE_PACKAGE_PATH}" "${EXAMPLE_COPY_DIR}"
 
     log "Overriding dependency in ${EXAMPLE_PACKAGE_NAME} to use ${PACKAGE_PATH}"
-    "${SWIFT_BIN}" package --package-path "${EXAMPLE_COPY_DIR}" \
-        edit swift-openapi-generator --path "${PACKAGE_PATH}"
+    "${SWIFT_BIN}" package \
+        --package-path "${EXAMPLE_COPY_DIR}" \
+        --scratch-path "${SHARED_SCRATCH_PATH}" \
+        --cache-path "${SHARED_CACHE_PATH}" \
+        edit swift-openapi-generator \
+        --path "${PACKAGE_PATH}"
 
     log "Building example package: ${EXAMPLE_PACKAGE_NAME}"
-    "${SWIFT_BIN}" build --package-path "${EXAMPLE_COPY_DIR}"
+    "${SWIFT_BIN}" build \
+        --package-path "${EXAMPLE_COPY_DIR}" \
+        --scratch-path "${SHARED_SCRATCH_PATH}" \
+        --cache-path "${SHARED_CACHE_PATH}"
     log "✅ Successfully built the example package ${EXAMPLE_PACKAGE_NAME}."
 
     if [ -d "${EXAMPLE_COPY_DIR}/Tests" ]; then
         log "Running tests for example package: ${EXAMPLE_PACKAGE_NAME}"
-        "${SWIFT_BIN}" test --package-path "${EXAMPLE_COPY_DIR}"
+        "${SWIFT_BIN}" test \
+            --package-path "${EXAMPLE_COPY_DIR}" \
+            --scratch-path "${SHARED_SCRATCH_PATH}" \
+            --cache-path "${SHARED_CACHE_PATH}"
         log "✅ Passed the tests for the example package ${EXAMPLE_PACKAGE_NAME}."
     fi
+
+    log "Unediting dependency in ${EXAMPLE_PACKAGE_NAME}"
+    "${SWIFT_BIN}" package \
+        --package-path "${EXAMPLE_COPY_DIR}" \
+        --scratch-path "${SHARED_SCRATCH_PATH}" \
+        --cache-path "${SHARED_CACHE_PATH}" \
+        unedit swift-openapi-generator
 done


### PR DESCRIPTION
### Motivation

In a small attempt to make the example pipeline run faster, we can share the cache and scratch paths. This might shave a few minutes off the CI run, until we have time to investigate it further. FWICT, it seems that there are still a number of builds of dependencies (e.g. NIO) flying past.

### Modifications

Use shared --cache-path and --scratch-path when building examples.

It's only shared for the single run of the script.

### Result

Slightly faster CI.

### Test Plan

CI.