### PR TITLE
Delete example temp data on CI

### DIFF
--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -74,4 +74,11 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
         --scratch-path "${SHARED_SCRATCH_PATH}" \
         --cache-path "${SHARED_CACHE_PATH}" \
         unedit swift-openapi-generator
+
+    log "Deleting example ${EXAMPLE_PACKAGE_NAME} at ${EXAMPLE_COPY_DIR}"
+    rm -rf "${EXAMPLE_COPY_DIR}"
 done
+
+log "Deleting cache directories"
+rm -rf "${SHARED_SCRATCH_PATH}"
+rm -rf "${SHARED_CACHE_PATH}"


### PR DESCRIPTION
### Motivation

We're not properly cleaning up temporary files in our scripts for examples, leading to CI running out of disk space.

### Modifications

Delete each example copy, and the scratch/cache space at the end of the script.

### Result

Hopefully will recover CI.

### Test Plan

N/A, PR CI will show if this fixes things.
