### PR TITLE
Add example of metrics middleware using swift-metrics

### DIFF
--- a/Examples/MetricsMiddleware/.dockerignore
+++ b/Examples/MetricsMiddleware/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Examples/MetricsMiddleware/.gitignore
+++ b/Examples/MetricsMiddleware/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.vscode
+/Package.resolved
+.ci/
+.docc-build/

--- a/Examples/MetricsMiddleware/Package.swift
+++ b/Examples/MetricsMiddleware/Package.swift
@@ -1,0 +1,47 @@
+// swift-tools-version:5.9
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import PackageDescription
+
+let package = Package(
+    name: "MetricsMiddleware",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/apple/swift-metrics", from: "2.4.1"),
+        .package(url: "https://github.com/swift-server/swift-prometheus", exact: "2.0.0-alpha.1"),
+    ],
+    targets: [
+        .target(
+            name: "MetricsMiddleware",
+            dependencies: [
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "Metrics", package: "swift-metrics"),
+            ]
+        ),
+        .executableTarget(
+            name: "HelloWorldVaporServer",
+            dependencies: [
+                "MetricsMiddleware", .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
+                .product(name: "Vapor", package: "vapor"), .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "Prometheus", package: "swift-prometheus"),
+            ],
+            plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
+        ),
+    ]
+)

--- a/Examples/MetricsMiddleware/README.md
+++ b/Examples/MetricsMiddleware/README.md
@@ -1,0 +1,155 @@
+# Metrics middleware using Swift Metrics and Swift Prometheus
+
+In this example we'll implement a `ClientMiddleware` and `ServerMiddleware`
+that use `swift-metrics` and `swift-prometheus` to collect and emit metrics
+respectively.
+
+## Overview
+
+This example extends the [HelloWorldVaporServer](../HelloWorldVaporServer)
+with a new target, `MetricsMiddleware`, which is then used when creating
+the `Server`.
+
+The metrics can now be accessed my making a HTTP GET request to `/metrics`.
+
+## Testing
+
+### Running the server and querying the metrics endpoint
+
+First, in one terminal, start the server.
+
+```console
+% swift run
+```
+
+Then, in another terminal, make some requests:
+
+```console
+% xargs -n1 -I% curl "localhost:8080/api/greet?name=%" <<< "Juan Mei Tom Bill Anne Ravi Maria"
+{
+  "message" : "Hello, Juan!"
+}
+{
+  "message" : "Hello, Mei!"
+}
+{
+  "message" : "Hello, Tom!"
+}
+{
+  "message" : "Hello, Bill!"
+}
+{
+  "message" : "Hello, Anne!"
+}
+{
+  "message" : "Hello, Ravi!"
+}
+{
+  "message" : "Hello, Maria!"
+}
+```
+
+Now you can query the `/metrics` endpoint of the server:
+
+```console
+% curl "localhost:8080/metrics"
+# TYPE http_requests_total counter
+http_requests_total{method="GET",path="/metrics",status="200"} 1
+http_requests_total{method="GET",path="//api/greet",status="200"} 7
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="0.005"} 5
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="0.01"} 6
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="0.025"} 7
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="0.05"} 7
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="0.1"} 7
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="0.25"} 7
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="0.5"} 7
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="1.0"} 7
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="2.5"} 7
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="5.0"} 7
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="10.0"} 7
+http_request_duration_seconds_bucket{method="GET",path="//api/greet",status="200",le="+Inf"} 7
+http_request_duration_seconds_sum{method="GET",path="//api/greet",status="200"} 0.025902709
+http_request_duration_seconds_count{method="GET",path="//api/greet",status="200"} 7
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="0.005"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="0.01"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="0.025"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="0.05"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="0.1"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="0.25"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="0.5"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="1.0"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="2.5"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="5.0"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="10.0"} 1
+http_request_duration_seconds_bucket{method="GET",path="/metrics",status="200",le="+Inf"} 1
+http_request_duration_seconds_sum{method="GET",path="/metrics",status="200"} 0.001705458
+http_request_duration_seconds_count{method="GET",path="/metrics",status="200"} 1
+# TYPE HelloWorldServer.getGreeting.200 counter
+HelloWorldServer.getGreeting.200 7
+```
+
+The response contains the Prometheus metrics. You should see `http_requests_total{status="200", path="/api/greet", method="GET"} 7` for the seven requests made in the previous step.
+
+### Visualizing the metrics with Prometheus
+
+We'll use [Compose](https://docs.docker.com/compose) to run a set of containers
+to collect and visualize the metrics.
+
+The Compose file defines two services: `api` and `prometheus`. The `api`
+service uses an image built using the `Dockerfile` in the current directory.
+The `prometheus` service uses a public Prometheus image.
+
+The `prometheus` service is configured using the `prometheus.yml` file in the
+current directory. This configures Prometheus to scrape the /metrics endpoint
+of the API server every 5 seconds.
+
+Build and run the Compose application. You should see logging in the console
+from the API server and Prometheus.
+
+> NOTE: You need to keep this terminal window open for the remaining steps. Pressing Ctrl-C will shut down the application.
+
+```console
+% docker compose up
+[+] Building 12/122
+...
+[+] Running 2/0
+ ⠿ Container metricsmiddleware-prometheus-1  Created                                                    0.0s
+ ⠿ Container metricsmiddleware-api-1         Created                                                    0.0s
+...
+metricsmiddleware-api-1         | 2023-06-08T14:34:24+0000 notice codes.vapor.application : [Vapor] Server starting on http://0.0.0.0:8080
+...
+metricsmiddleware-prometheus-1  | ts=2023-06-08T14:34:24.914Z caller=web.go:562 level=info component=web msg="Start listening for connections" address=0.0.0.0:9090
+...
+```
+
+At this point you can make requests to the server, as before:
+
+```console
+% % echo "Juan Mei Tom Bill Anne Ravi Maria" | xargs -n1 -I% curl "localhost:8080/api/greet?name=%"
+{
+  "message" : "Hello, Juan!"
+}
+{
+  "message" : "Hello, Mei!"
+}
+{
+  "message" : "Hello, Tom!"
+}
+{
+  "message" : "Hello, Bill!"
+}
+{
+  "message" : "Hello, Anne!"
+}
+{
+  "message" : "Hello, Ravi!"
+}
+{
+  "message" : "Hello, Maria!"
+}
+```
+
+Now open the Prometheus UI in your web browser by visiting [localhost:9090](http://localhost:9090). Click the graph tab and update the query to `http_requests_total`, or use [this pre-canned link](http://localhost:9090/graph?g0.expr=http_requests_total&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=5m).
+
+You should see the graph showing the seven recent requests.

--- a/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
+++ b/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIRuntime
+import OpenAPIVapor
+import Vapor
+import MetricsMiddleware
+import Metrics
+import Prometheus
+
+struct Handler: APIProtocol {
+    func getGreeting(_ input: Operations.getGreeting.Input) async throws -> Operations.getGreeting.Output {
+        let name = input.query.name ?? "Stranger"
+        return .ok(.init(body: .json(.init(message: "Hello, \(name)!"))))
+    }
+}
+
+@main struct HelloWorldVaporServer {
+    static func main() throws {
+        let registry = PrometheusCollectorRegistry()
+        MetricsSystem.bootstrap(PrometheusMetricsFactory(registry: registry))
+
+        let app = Vapor.Application()
+
+        app.get("metrics") { request in
+            var buffer: [UInt8] = []
+            buffer.reserveCapacity(1024)
+            registry.emit(into: &buffer)
+            return String(decoding: buffer, as: UTF8.self)
+        }
+
+        let transport = VaporTransport(routesBuilder: app)
+        let handler = Handler()
+        try handler.registerHandlers(
+            on: transport,
+            serverURL: URL(string: "/api")!,
+            middlewares: [MetricsMiddleware(counterPrefix: "HelloWorldServer")]
+        )
+
+        let host = ProcessInfo.processInfo.environment["HOST"] ?? "localhost"
+        let port = ProcessInfo.processInfo.environment["PORT"].flatMap(Int.init) ?? 8080
+        app.http.server.configuration.address = .hostname(host, port: port)
+        try app.run()
+    }
+}

--- a/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/openapi-generator-config.yaml
+++ b/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/openapi-generator-config.yaml
@@ -1,0 +1,3 @@
+generate:
+  - types
+  - server

--- a/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/openapi.yaml
+++ b/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/openapi.yaml
@@ -1,0 +1,36 @@
+openapi: '3.1.0'
+info:
+  title: GreetingService
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+    description: Example service deployment.
+paths:
+  /greet:
+    get:
+      operationId: getGreeting
+      parameters:
+        - name: name
+          required: false
+          in: query
+          description: The name used in the returned greeting.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A success response with a greeting.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Greeting'
+components:
+  schemas:
+    Greeting:
+      type: object
+      description: A value with the greeting contents.
+      properties:
+        message:
+          type: string
+          description: The string representation of the greeting.
+      required:
+        - message

--- a/Examples/MetricsMiddleware/Sources/MetricsMiddleware/MetricsMiddleware.swift
+++ b/Examples/MetricsMiddleware/Sources/MetricsMiddleware/MetricsMiddleware.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import HTTPTypes
+import Metrics
+import OpenAPIRuntime
+
+package struct MetricsMiddleware {
+    package var counterPrefix: String
+
+    package init(counterPrefix: String) { self.counterPrefix = counterPrefix }
+}
+
+extension MetricsMiddleware: ClientMiddleware {
+    package func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        do {
+            let (response, responseBody) = try await next(request, body, baseURL)
+            Counter(label: "\(counterPrefix).\(operationID).\(response.status.code.description)").increment()
+            return (response, responseBody)
+        } catch {
+            Counter(label: "\(counterPrefix).\(operationID).error").increment()
+            throw error
+        }
+    }
+}
+
+extension MetricsMiddleware: ServerMiddleware {
+    package func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        metadata: ServerRequestMetadata,
+        operationID: String,
+        next: (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        func recordResult(_ result: String) { Counter(label: "\(counterPrefix).\(operationID).\(result)").increment() }
+        do {
+            let (response, responseBody) = try await next(request, body, metadata)
+            Counter(label: "\(counterPrefix).\(operationID).\(response.status.code.description)").increment()
+            return (response, responseBody)
+        } catch {
+            Counter(label: "\(counterPrefix).\(operationID).error").increment()
+            throw error
+        }
+    }
+}

--- a/Examples/MetricsMiddleware/docker/Dockerfile
+++ b/Examples/MetricsMiddleware/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM swift:5.9 AS builder
+COPY ../Sources/ /code/Sources/
+COPY ../Package.swift /code/Package.swift
+WORKDIR /code
+RUN swift build -c release
+
+FROM swift:5.9-slim AS runtime
+COPY --from=builder /code/.build/release/HelloWorldVaporServer /HelloWorldVaporServer
+ENV HOST=0.0.0.0
+ENV PORT=8080
+ENTRYPOINT [ "/HelloWorldVaporServer" ]

--- a/Examples/MetricsMiddleware/docker/docker-compose.yaml
+++ b/Examples/MetricsMiddleware/docker/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "3.5"
+services:
+  api:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - 127.0.0.1:8080:8080
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - 127.0.0.1:9090:9090

--- a/Examples/MetricsMiddleware/docker/prometheus.yml
+++ b/Examples/MetricsMiddleware/docker/prometheus.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: "greeting.server"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["api:8080"]

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -67,6 +67,8 @@ read -ra PATHS_TO_CHECK_FOR_LICENSE <<< "$( \
   ":(exclude)**/openapi-generator-config.yaml" \
   ":(exclude)**/openapi-generator-config.yml" \
   ":(exclude)**/docker-compose.yaml" \
+  ":(exclude)**/docker/*" \
+  ":(exclude)**/.dockerignore" \
   ":(exclude)Plugins/OpenAPIGenerator/PluginsShared" \
   ":(exclude)Plugins/OpenAPIGeneratorCommand/PluginsShared" \
   ":(exclude)Examples/iOSAppClient/iOSAppClient.*" \


### PR DESCRIPTION
### Motivation

As we approach 1.0, we want more examples of how to use this package and integrate with other packages in the ecosystem.

### Modifications

Add an example that uses swift-metrics and swift-prometheus to collect and emit metrics respectively.
 
### Result

More examples.

### Test Plan

```console
% docker-compose -f docker/docker-compose.yaml run -e SINGLE_EXAMPLE_PACKAGE=MetricsMiddleware examples
...
** Copying example MetricsMiddleware to /tmp/test-examples.sh.zgACTExtGC/MetricsMiddleware
...
** ✅ Successfully built the example package MetricsMiddleware.
```