### PR TITLE
Update all Vapor examples to use async execute() API

### DIFF
--- a/Examples/AuthenticationServerMiddleware/Package.swift
+++ b/Examples/AuthenticationServerMiddleware/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .target(

--- a/Examples/AuthenticationServerMiddleware/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
+++ b/Examples/AuthenticationServerMiddleware/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
@@ -31,7 +31,7 @@ struct Handler: APIProtocol {
 }
 
 @main struct HelloWorldVaporServer {
-    static func main() throws {
+    static func main() async throws {
         let app = Vapor.Application()
         let transport = VaporTransport(routesBuilder: app)
         let handler = Handler()
@@ -58,6 +58,6 @@ struct Handler: APIProtocol {
                 })
             ]
         )
-        try app.run()
+        try await app.execute()
     }
 }

--- a/Examples/ContentTypesServer/Package.swift
+++ b/Examples/ContentTypesServer/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/ContentTypesServer/Sources/ContentTypesServer/ContentTypesServer.swift
+++ b/Examples/ContentTypesServer/Sources/ContentTypesServer/ContentTypesServer.swift
@@ -158,11 +158,11 @@ struct Handler: APIProtocol {
 }
 
 @main struct ContentTypesServer {
-    static func main() throws {
+    static func main() async throws {
         let app = Vapor.Application()
         let transport = VaporTransport(routesBuilder: app)
         let handler = Handler()
         try handler.registerHandlers(on: transport, serverURL: URL(string: "/api")!)
-        try app.run()
+        try await app.execute()
     }
 }

--- a/Examples/GreetingService/Package.swift
+++ b/Examples/GreetingService/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.76.0"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/GreetingService/Sources/GreetingService/GreetingService.swift
+++ b/Examples/GreetingService/Sources/GreetingService/GreetingService.swift
@@ -41,7 +41,7 @@ struct Handler: APIProtocol {
     /// }
     /// ```
     /// - Throws: An error of type `Error` if there's an issue creating or running the Vapor application.
-    public static func main() throws {
+    public static func main() async throws {
         // Create a Vapor application.
         let app = Vapor.Application()
 
@@ -55,6 +55,6 @@ struct Handler: APIProtocol {
         try handler.registerHandlers(on: transport, serverURL: Servers.server2())
 
         // Start the Vapor application, in the same way as if it was manually configured.
-        try app.run()
+        try await app.execute()
     }
 }

--- a/Examples/HelloWorldVaporServer/Package.swift
+++ b/Examples/HelloWorldVaporServer/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/HelloWorldVaporServer/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
+++ b/Examples/HelloWorldVaporServer/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
@@ -23,11 +23,11 @@ struct Handler: APIProtocol {
 }
 
 @main struct HelloWorldVaporServer {
-    static func main() throws {
+    static func main() async throws {
         let app = Vapor.Application()
         let transport = VaporTransport(routesBuilder: app)
         let handler = Handler()
         try handler.registerHandlers(on: transport, serverURL: URL(string: "/api")!)
-        try app.run()
+        try await app.execute()
     }
 }

--- a/Examples/MetricsMiddleware/Package.swift
+++ b/Examples/MetricsMiddleware/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
         .package(url: "https://github.com/apple/swift-metrics", from: "2.4.1"),
         .package(url: "https://github.com/swift-server/swift-prometheus", exact: "2.0.0-alpha.1"),
     ],

--- a/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
+++ b/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
@@ -26,7 +26,7 @@ struct Handler: APIProtocol {
 }
 
 @main struct HelloWorldVaporServer {
-    static func main() throws {
+    static func main() async throws {
         let registry = PrometheusCollectorRegistry()
         MetricsSystem.bootstrap(PrometheusMetricsFactory(registry: registry))
 
@@ -50,6 +50,6 @@ struct Handler: APIProtocol {
         let host = ProcessInfo.processInfo.environment["HOST"] ?? "localhost"
         let port = ProcessInfo.processInfo.environment["PORT"].flatMap(Int.init) ?? 8080
         app.http.server.configuration.address = .hostname(host, port: port)
-        try app.run()
+        try await app.execute()
     }
 }

--- a/Examples/PostgresDatabaseServer/Package.swift
+++ b/Examples/PostgresDatabaseServer/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.16.0"),
     ],
     targets: [

--- a/Examples/PostgresDatabaseServer/Sources/PostgresDatabaseServer/PostgresDatabaseServer.swift
+++ b/Examples/PostgresDatabaseServer/Sources/PostgresDatabaseServer/PostgresDatabaseServer.swift
@@ -74,6 +74,6 @@ actor Handler: APIProtocol {
         let transport = VaporTransport(routesBuilder: app)
         let handler = try await Handler()
         try handler.registerHandlers(on: transport, serverURL: URL(string: "/api")!)
-        try app.run()
+        try await app.execute()
     }
 }

--- a/Examples/SwaggerUIEndpointsServer/Package.swift
+++ b/Examples/SwaggerUIEndpointsServer/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/SwaggerUIEndpointsServer/Sources/SwaggerUIEndpointsServer/SwaggerUIEndpointsServer.swift
+++ b/Examples/SwaggerUIEndpointsServer/Sources/SwaggerUIEndpointsServer/SwaggerUIEndpointsServer.swift
@@ -23,7 +23,7 @@ struct Handler: APIProtocol {
 }
 
 @main struct SwaggerUIEndpointsServer {
-    static func main() throws {
+    static func main() async throws {
         let app = Vapor.Application()
         let transport = VaporTransport(routesBuilder: app)
 
@@ -38,6 +38,6 @@ struct Handler: APIProtocol {
         // Redirect `GET /openapi` to `GET /openapi.html`, for convenience.
         app.get("openapi") { request in request.redirect(to: "openapi.html", redirectType: .permanent) }
 
-        try app.run()
+        try await app.execute()
     }
 }

--- a/Examples/TracingMiddleware/Package.swift
+++ b/Examples/TracingMiddleware/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing", from: "1.0.1"),
         .package(url: "https://github.com/apple/swift-distributed-tracing-extras", exact: "1.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.62.0"),

--- a/Examples/TracingMiddleware/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
+++ b/Examples/TracingMiddleware/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
@@ -28,7 +28,7 @@ struct Handler: APIProtocol {
 }
 
 @main struct HelloWorldVaporServer {
-    static func main() throws {
+    static func main() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
         let otel = OTel(
             serviceName: "HelloWorldServer",
@@ -38,7 +38,7 @@ struct Handler: APIProtocol {
                 eventLoopGroup: eventLoopGroup
             )
         )
-        try otel.start().wait()
+        try await otel.start().get()
         defer { try? otel.shutdown().wait() }
         InstrumentationSystem.bootstrap(otel.tracer())
 
@@ -46,6 +46,6 @@ struct Handler: APIProtocol {
         let transport = VaporTransport(routesBuilder: app)
         let handler = Handler()
         try handler.registerHandlers(on: transport, serverURL: URL(string: "/api")!, middlewares: [TracingMiddleware()])
-        try app.run()
+        try await app.execute()
     }
 }

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Practicing-spec-driven-API-development.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Practicing-spec-driven-API-development.md
@@ -142,7 +142,7 @@ let app = Vapor.Application()
 app.get("foo") { ... a, b, c ... }
 app.post("foo") { ... a, b, c ... }
 app.get("bar") { ... a, b, c ... }
-try app.run()
+try await app.execute()
 ```
 
 Each request handler is responsible for three things:
@@ -187,7 +187,7 @@ let transport = VaporTransport(routesBuilder: app)
 // Registers your generated routes from the OpenAPI document. Right now, there are 0.
 try handler.registerHandlers(on: transport, serverURL: ...)
 
-try app.run()
+try await app.execute()
 ```
 
 At this point, you have two sets of endpoints, your existing 3 ones, and 0 generated ones (because your OpenAPI document is still empty).
@@ -228,7 +228,7 @@ struct Handler: APIProtocol {} // <<< this is where you now get a build error
 let transport = VaporTransport(routesBuilder: app)
 try handler.registerHandlers(on: transport, serverURL: ...)
 
-try app.run()
+try await app.execute()
 ```
 
 When you compile the example above, you'll get a build error because `APIProtocol` contains the requirement to implement the `getFoo` operation, but it isn't yet implemented.
@@ -251,7 +251,7 @@ struct Handler: APIProtocol {
 let transport = VaporTransport(routesBuilder: app)
 try handler.registerHandlers(on: transport, serverURL: ...)
 
-try app.run()
+try await app.execute()
 ```
 
 Now, build and run!
@@ -293,7 +293,7 @@ struct Handler: APIProtocol {
 let transport = VaporTransport(routesBuilder: app)
 try handler.registerHandlers(on: transport, serverURL: ...)
 
-try app.run()
+try await app.execute()
 ```
 
 By migrating your service step-by-step, you can minimize risk and get increasing value from spec-driven development as you move operations into the hand-written OpenAPI document.

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.0.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.0.swift
@@ -29,4 +29,4 @@ let handler = GreetingServiceAPIImpl()
 try handler.registerHandlers(on: transport, serverURL: Servers.server1())
 
 // Start the app as you would normally.
-try app.run()
+try await app.execute()

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.1.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.1.swift
@@ -32,4 +32,4 @@ try handler.registerHandlers(on: transport, serverURL: Servers.server1())
 app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
 
 // Start the app as you would normally.
-try app.run()
+try await app.execute()

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.2.swift
@@ -35,4 +35,4 @@ app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory
 app.get("openapi") { $0.redirect(to: "/openapi.html", redirectType: .permanent) }
 
 // Start the app as you would normally.
-try app.run()
+try await app.execute()

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.2.swift
@@ -10,7 +10,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.3.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.3.swift
@@ -10,7 +10,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.4.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.4.swift
@@ -10,7 +10,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.5.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.Package.5.swift
@@ -10,7 +10,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-openapi-generator", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", exact: "1.0.0-alpha.1"),
-        .package(url: "https://github.com/vapor/vapor", from: "4.87.1"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.1.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.1.2.swift
@@ -29,4 +29,4 @@ let handler = GreetingServiceAPIImpl()
 try handler.registerHandlers(on: transport, serverURL: Servers.server1())
 
 // Start the app as you would normally.
-try app.run()
+try await app.execute()

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.2.swift
@@ -37,4 +37,4 @@ let handler = GreetingServiceAPIImpl()
 try handler.registerHandlers(on: transport, serverURL: Servers.server1())
 
 // Start the app as you would normally.
-try app.run()
+try await app.execute()


### PR DESCRIPTION
### Motivation

Recently Vapor introduced the `execute() async` API for running the server to replace the blocking `run()`. We should make an effort to use this better API in our examples that use Vapor.
 
### Modifications

Update all Vapor examples to use Vapor 4.89.0+ and async execute() API.

### Result

All Vapor examples use async execute() API.

### Test Plan

CI.