### PR TITLE
Update Hummingbird example to use asyncRun() API

### DIFF
--- a/Examples/HelloWorldHummingbirdServer/Sources/HelloWorldHummingbirdServer/HelloWorldHummingbirdServer.swift
+++ b/Examples/HelloWorldHummingbirdServer/Sources/HelloWorldHummingbirdServer/HelloWorldHummingbirdServer.swift
@@ -24,11 +24,11 @@ struct Handler: APIProtocol {
 }
 
 @main struct HelloWorldHummingbirdServer {
-    static func main() throws {
+    static func main() async throws {
         let app = Hummingbird.HBApplication()
         let transport = HBOpenAPITransport(app)
         let handler = Handler()
         try handler.registerHandlers(on: transport, serverURL: URL(string: "/api")!)
-        try app.run()
+        try await app.asyncRun()
     }
 }


### PR DESCRIPTION
### Motivation

Similar to #451, Hummingbird also now provides an `asyncRun() async` API for running the server to replace the blocking `run()`. We should make an effort to use this better API in our example that uses Hummingbird.
 
### Modifications

Update the Hummingbird example to use async execute() API.

### Result

The Hummingbird examples use async execute() API.

### Test Plan

CI.