### PR TITLE
Add disclaimer to each example README

### DIFF
--- a/Examples/AuthenticationClientMiddleware/README.md
+++ b/Examples/AuthenticationClientMiddleware/README.md
@@ -2,6 +2,8 @@
 
 In this example we'll implement a `ClientMiddleware` that injects an authentication header into the request.
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 This example extends the [HelloWorldURLSessionClient](../HelloWorldURLSessionClient)

--- a/Examples/AuthenticationServerMiddleware/README.md
+++ b/Examples/AuthenticationServerMiddleware/README.md
@@ -2,6 +2,8 @@
 
 In this example we'll implement a `ServerMiddleware` that verifies an authentication header in the request.
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 This example extends the [HelloWorldVaporServer](../HelloWorldVaporServer) with a new target, `AuthenticationServerMiddleware`, which is then used when registering the server handler with the transport.

--- a/Examples/CommandLineClient/README.md
+++ b/Examples/CommandLineClient/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A command-line tool using Swift Argument Parser that shows using a generated client to make a request to the Greeting Service running on `http://localhost:8080`.

--- a/Examples/CommandPluginInvocationClient/README.md
+++ b/Examples/CommandPluginInvocationClient/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A command-line tool that uses a generated client to make a request to the Greeting Service running on `http://localhost:8080`.

--- a/Examples/ContentTypesClient/README.md
+++ b/Examples/ContentTypesClient/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A command-line tool that uses a generated client to show how to work with various HTTP content types.

--- a/Examples/ContentTypesServer/README.md
+++ b/Examples/ContentTypesServer/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A server that uses generated server stubs to show how to work with various HTTP content types. 

--- a/Examples/CuratedLibraryClient/README.md
+++ b/Examples/CuratedLibraryClient/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A library package that shows wrapping a generated client to make a request to the Greeting Service running on `http://localhost:8080`.

--- a/Examples/HelloWorldAsyncHTTPClient/README.md
+++ b/Examples/HelloWorldAsyncHTTPClient/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A "hello world" command-line tool that uses a generated client to make a request to the Greeting Service running on `http://localhost:8080`.

--- a/Examples/HelloWorldHummingbirdServer/README.md
+++ b/Examples/HelloWorldHummingbirdServer/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A "hello world" server that uses generated server stubs to handle requests as the Greeting Service. 

--- a/Examples/HelloWorldURLSessionClient/README.md
+++ b/Examples/HelloWorldURLSessionClient/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A "hello world" command-line tool that uses a generated client to make a request to the Greeting Service running on `http://localhost:8080`.

--- a/Examples/HelloWorldVaporServer/README.md
+++ b/Examples/HelloWorldVaporServer/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A "hello world" server that uses generated server stubs to handle requests as the Greeting Service. 

--- a/Examples/LoggingMiddlewareOSLog/README.md
+++ b/Examples/LoggingMiddlewareOSLog/README.md
@@ -3,6 +3,8 @@
 In this example we'll implement a `ClientMiddleware` that uses `OSLog` to log
 requests and responses.
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 This example extends the [HelloWorldURLSessionClient](../HelloWorldURLSessionClient)

--- a/Examples/LoggingMiddlewareSwiftLog/README.md
+++ b/Examples/LoggingMiddlewareSwiftLog/README.md
@@ -3,6 +3,8 @@
 In this example we'll implement a `ClientMiddleware` and `ServerMiddleware`
 that use `swift-log` to log requests and responses.
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 This example extends the [HelloWorldURLSessionClient](../HelloWorldURLSessionClient)

--- a/Examples/ManualGeneratorInvocationClient/README.md
+++ b/Examples/ManualGeneratorInvocationClient/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A command-line tool that uses a generated client to make a request to the Greeting Service running on `http://localhost:8080`.

--- a/Examples/MetricsMiddleware/README.md
+++ b/Examples/MetricsMiddleware/README.md
@@ -4,6 +4,8 @@ In this example we'll implement a `ClientMiddleware` and `ServerMiddleware`
 that use `swift-metrics` and `swift-prometheus` to collect and emit metrics
 respectively.
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 This example extends the [HelloWorldVaporServer](../HelloWorldVaporServer)

--- a/Examples/PostgresDatabaseServer/README.md
+++ b/Examples/PostgresDatabaseServer/README.md
@@ -3,6 +3,8 @@
 In this example we'll integrate persistent state into the server by adding an
 integration to a database.
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 This example extends the [HelloWorldVaporServer](../HelloWorldVaporServer/)

--- a/Examples/RetryingClientMiddleware/README.md
+++ b/Examples/RetryingClientMiddleware/README.md
@@ -2,6 +2,8 @@
 
 In this example we'll implement a `ClientMiddleware` that retries certain failed responses again.
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 This example extends the [HelloWorldURLSessionClient](../HelloWorldURLSessionClient)

--- a/Examples/SwaggerUIEndpointsServer/README.md
+++ b/Examples/SwaggerUIEndpointsServer/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 A server that shows setting up endpoints that serve the OpenAPI document and also a web page with the rendered documentation, respectively. It also uses generated server stubs to handle requests as the Greeting Service.

--- a/Examples/TracingMiddleware/README.md
+++ b/Examples/TracingMiddleware/README.md
@@ -3,6 +3,8 @@
 In this example we'll implement a `ClientMiddleware` and `ServerMiddleware`
 that use `swift-otel` to emit traces for requests and responses.
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 This example extends the [HelloWorldVaporServer](../HelloWorldVaporServer)

--- a/Examples/iOSAppClient/README.md
+++ b/Examples/iOSAppClient/README.md
@@ -2,6 +2,8 @@
 
 An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
 
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
 ## Overview
 
 An iOS app that shows using a generated client to make a request to the Greeting Service running on `http://localhost:8080`.


### PR DESCRIPTION
### Motivation

As we approach 1.0, we want more examples of how to use this package and integrate with other packages in the ecosystem. However, these are deliberately meant to be illustrative, and are often deliberately not fully-featured.

#445 added a disclaimer to the REAMDE in the Examples directory, but we should remind folks in each of the per-example README files.

### Modifications

Add disclaimer to each example README.
 
### Result

Docs clearer.

### Test Plan

None.