### PR TITLE
Ensure accessModifier is in all example config files

### DIFF
--- a/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/openapi-generator-config.yaml
+++ b/Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/openapi-generator-config.yaml
@@ -1,3 +1,4 @@
 generate:
   - types
   - server
+accessModifier: internal


### PR DESCRIPTION
### Motivation

We want all examples to explicitly spell out the `accessModifier` in the `openapi-generator-config.yaml`. There was just one missing:

```console
% git ls-files "**/openapi-generator-config.yaml" | xargs grep -L accessModifier
Examples/MetricsMiddleware/Sources/HelloWorldVaporServer/openapi-generator-config.yaml
```

### Modifications

Add missing `accessModifier` to metrics middleware example.

### Result

All examples have `accessModifier` in their `openapi-generator-config.yaml`.

### Test Plan

None.