### PR TITLE
Update NOTICE.txt with projects used in examples

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -120,10 +120,71 @@ This product contains OpenAPI document(s) for compatibility testing from:
 
 -------------------------------------------------------------------------------
 
-This product contains an example Swift package that shows how to use swagger-ui.
+This product contains samples of how to use Swift OpenAPI Generator with the
+following other projects:
 
-  * swagger-ui
+  * AsyncHTTPClient
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/swift-server/swift-openapi-async-http-client
+
+  * Hummingbird
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/hummingbird-project/hummingbird
+
+  * Swagger UI
     * LICENSE (Apache License 2.0):
       * https://www.apache.org/licenses/LICENSE-2.0
     * HOMEPAGE:
       * https://github.com/swagger-api/swagger-ui
+
+  * Swift Argument Parser
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/apple/swift-argument-parser
+
+  * Swift Distributed Tracing
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/apple/swift-distributed-tracing
+
+  * Swift Logging API
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/apple/swift-log
+
+  * Swift Metrics
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/apple/swift-metrics
+
+  * SwiftNIO
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/apple/swift-nio
+
+  * Swift OTel
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/slashmo/swift-otel
+
+  * SwiftPrometheus
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/swift-server/swift-prometheus
+
+  * Vapor
+    * LICENSE (MIT License):
+      * https://mit-license.org
+    * HOMEPAGE:
+      * https://github.com/vapor/vapor


### PR DESCRIPTION
### Motivation

We've recently added a bunch of example projects that show how to integrate with other packages and projects in the Swift and OpenAPI ecosystems. We should make sure that these projects and their associated licenses are mentioned in `NOTICE.txt`.

### Modifications

Update NOTICE.txt with projects used in examples.

### Result

Updated NOTICE.txt with projects used in examples.

### Test Plan

None.