### PR TITLE
[Docs] Use the percent sign as the prompt symbol consistently

### DIFF
--- a/Examples/auth-client-middleware-example/README.md
+++ b/Examples/auth-client-middleware-example/README.md
@@ -22,8 +22,8 @@ The server can be started by running the `AuthenticationServerMiddleware` exampl
 Build and run the client CLI using:
 
 ```
-$ swift run HelloWorldURLSessionClient token_for_Fr
+% swift run HelloWorldURLSessionClient token_for_Fr
 Hello, Stranger! (Requested by: Frank)
-$ swift run HelloWorldURLSessionClient invalid_token
+% swift run HelloWorldURLSessionClient invalid_token
 Unauthorized
 ```

--- a/Examples/auth-client-middleware-example/README.md
+++ b/Examples/auth-client-middleware-example/README.md
@@ -21,8 +21,8 @@ The server can be started by running the `AuthenticationServerMiddleware` exampl
 
 Build and run the client CLI using:
 
-```
-% swift run HelloWorldURLSessionClient token_for_Fr
+```console
+% swift run HelloWorldURLSessionClient token_for_Frank
 Hello, Stranger! (Requested by: Frank)
 % swift run HelloWorldURLSessionClient invalid_token
 Unauthorized

--- a/Examples/auth-server-middleware-example/README.md
+++ b/Examples/auth-server-middleware-example/README.md
@@ -16,7 +16,7 @@ The tool uses the [Vapor](https://github.com/vapor/vapor) server framework to ha
 The CLI starts the server on `http://localhost:8080` and can be invoked by running the `AuthenticationClientMiddleware` example client or on the command line using:
 
 ```
-$ curl -H 'Authorization: token_for_Frank' 'http://localhost:8080/api/greet?name=Jane'
+% curl -H 'Authorization: token_for_Frank' 'http://localhost:8080/api/greet?name=Jane'
 {
   "message" : "Hello, Jane! (Requested by: Frank)"
 }
@@ -27,7 +27,7 @@ $ curl -H 'Authorization: token_for_Frank' 'http://localhost:8080/api/greet?name
 Build and run the server CLI using:
 
 ```
-$ swift run
+% swift run
 2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
 ...
 ```

--- a/Examples/auth-server-middleware-example/README.md
+++ b/Examples/auth-server-middleware-example/README.md
@@ -15,7 +15,7 @@ The tool uses the [Vapor](https://github.com/vapor/vapor) server framework to ha
 
 The CLI starts the server on `http://localhost:8080` and can be invoked by running the `AuthenticationClientMiddleware` example client or on the command line using:
 
-```
+```console
 % curl -H 'Authorization: token_for_Frank' 'http://localhost:8080/api/greet?name=Jane'
 {
   "message" : "Hello, Jane! (Requested by: Frank)"
@@ -26,7 +26,7 @@ The CLI starts the server on `http://localhost:8080` and can be invoked by runni
 
 Build and run the server CLI using:
 
-```
+```console
 % swift run
 2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
 ...

--- a/Examples/command-line-client-example/README.md
+++ b/Examples/command-line-client-example/README.md
@@ -17,6 +17,6 @@ The server can be started by running any of the Hello World server examples loca
 Build and run the client CLI using:
 
 ```
-$ swift run CommandLineClient greet --name CLI
+% swift run CommandLineClient greet --name CLI
 Hello, CLI!
 ```

--- a/Examples/command-line-client-example/README.md
+++ b/Examples/command-line-client-example/README.md
@@ -16,7 +16,7 @@ The server can be started by running any of the Hello World server examples loca
 
 Build and run the client CLI using:
 
-```
+```console
 % swift run CommandLineClient greet --name CLI
 Hello, CLI!
 ```

--- a/Examples/curated-client-library-example/README.md
+++ b/Examples/curated-client-library-example/README.md
@@ -33,7 +33,7 @@ print("Received the greeting message: \(message)")
 Run tests using:
 
 ```
-swift test
+% swift test
 ```
 
 The testing strategy is to use a test implementation of the generated `APIProtocol` that allows simulating various conditions, including errors.

--- a/Examples/curated-client-library-example/README.md
+++ b/Examples/curated-client-library-example/README.md
@@ -20,7 +20,7 @@ In another package, add this one as a package dependency.
 
 Then, use the provided client API:
 
-```
+```swift
 import CuratedLibraryClient
 
 let client = GreetingClient()
@@ -32,7 +32,7 @@ print("Received the greeting message: \(message)")
 
 Run tests using:
 
-```
+```console
 % swift test
 ```
 

--- a/Examples/hello-world-async-http-client-example/README.md
+++ b/Examples/hello-world-async-http-client-example/README.md
@@ -17,6 +17,6 @@ The server can be started by running any of the Hello World server examples loca
 Build and run the client CLI using:
 
 ```
-$ swift run
+% swift run
 Hello, Stranger!
 ```

--- a/Examples/hello-world-async-http-client-example/README.md
+++ b/Examples/hello-world-async-http-client-example/README.md
@@ -16,7 +16,7 @@ The server can be started by running any of the Hello World server examples loca
 
 Build and run the client CLI using:
 
-```
+```console
 % swift run
 Hello, Stranger!
 ```

--- a/Examples/hello-world-hummingbird-server-example/README.md
+++ b/Examples/hello-world-hummingbird-server-example/README.md
@@ -12,7 +12,7 @@ The tool uses the [Hummingbird](https://github.com/hummingbird-project/hummingbi
 
 The CLI starts the server on `http://localhost:8080` and can be invoked by running any of the Hello World example clients or on the command line using:
 
-```
+```console
 % curl http://localhost:8080/api/greet
 {
   "message" : "Hello, Stranger!"
@@ -23,7 +23,7 @@ The CLI starts the server on `http://localhost:8080` and can be invoked by runni
 
 Build and run the server CLI using:
 
-```
+```console
 % swift run
 2023-12-01T14:14:35+0100 info HummingBird : [HummingbirdCore] Server started and listening on 127.0.0.1:8080
 ...
@@ -33,7 +33,7 @@ Build and run the server CLI using:
 
 Run tests using:
 
-```
+```console
 % swift test
 ```
 

--- a/Examples/hello-world-hummingbird-server-example/README.md
+++ b/Examples/hello-world-hummingbird-server-example/README.md
@@ -13,7 +13,7 @@ The tool uses the [Hummingbird](https://github.com/hummingbird-project/hummingbi
 The CLI starts the server on `http://localhost:8080` and can be invoked by running any of the Hello World example clients or on the command line using:
 
 ```
-$ curl http://localhost:8080/api/greet
+% curl http://localhost:8080/api/greet
 {
   "message" : "Hello, Stranger!"
 }
@@ -24,7 +24,7 @@ $ curl http://localhost:8080/api/greet
 Build and run the server CLI using:
 
 ```
-$ swift run
+% swift run
 2023-12-01T14:14:35+0100 info HummingBird : [HummingbirdCore] Server started and listening on 127.0.0.1:8080
 ...
 ```
@@ -34,7 +34,7 @@ $ swift run
 Run tests using:
 
 ```
-swift test
+% swift test
 ```
 
 The testing strategy is to call the `Handler` directly from tests, as it conforms the `APIProtocol` and implements the business logic.

--- a/Examples/hello-world-urlsession-client-example/README.md
+++ b/Examples/hello-world-urlsession-client-example/README.md
@@ -17,6 +17,6 @@ The server can be started by running any of the Hello World server examples loca
 Build and run the client CLI using:
 
 ```
-$ swift run
+% swift run
 Hello, Stranger!
 ```

--- a/Examples/hello-world-urlsession-client-example/README.md
+++ b/Examples/hello-world-urlsession-client-example/README.md
@@ -16,7 +16,7 @@ The server can be started by running any of the Hello World server examples loca
 
 Build and run the client CLI using:
 
-```
+```console
 % swift run
 Hello, Stranger!
 ```

--- a/Examples/hello-world-vapor-server-example/README.md
+++ b/Examples/hello-world-vapor-server-example/README.md
@@ -13,7 +13,7 @@ The tool uses the [Vapor](https://github.com/vapor/vapor) server framework to ha
 The CLI starts the server on `http://localhost:8080` and can be invoked by running any of the Hello World example clients or on the command line using:
 
 ```
-$ curl http://localhost:8080/api/greet
+% curl http://localhost:8080/api/greet
 {
   "message" : "Hello, Stranger!"
 }
@@ -24,7 +24,7 @@ $ curl http://localhost:8080/api/greet
 Build and run the server CLI using:
 
 ```
-$ swift run
+% swift run
 2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
 ...
 ```
@@ -34,7 +34,7 @@ $ swift run
 Run tests using:
 
 ```
-swift test
+% swift test
 ```
 
 The testing strategy is to call the `Handler` directly from tests, as it conforms the `APIProtocol` and implements the business logic.

--- a/Examples/hello-world-vapor-server-example/README.md
+++ b/Examples/hello-world-vapor-server-example/README.md
@@ -12,7 +12,7 @@ The tool uses the [Vapor](https://github.com/vapor/vapor) server framework to ha
 
 The CLI starts the server on `http://localhost:8080` and can be invoked by running any of the Hello World example clients or on the command line using:
 
-```
+```console
 % curl http://localhost:8080/api/greet
 {
   "message" : "Hello, Stranger!"
@@ -23,7 +23,7 @@ The CLI starts the server on `http://localhost:8080` and can be invoked by runni
 
 Build and run the server CLI using:
 
-```
+```console
 % swift run
 2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
 ...
@@ -33,7 +33,7 @@ Build and run the server CLI using:
 
 Run tests using:
 
-```
+```console
 % swift test
 ```
 

--- a/Examples/manual-generation-generator-cli-example/README.md
+++ b/Examples/manual-generation-generator-cli-example/README.md
@@ -19,7 +19,7 @@ The server can be started by running any of the Hello World server examples loca
 Whenever the `openapi.yaml` document changes, rerun the code generation:
 
 ```
-make generate
+% make generate
 ```
 
 And then check in the changed files in `./Sources/ManualGeneratorInvocationClient/Generated/*`.
@@ -29,6 +29,6 @@ And then check in the changed files in `./Sources/ManualGeneratorInvocationClien
 Build and run the client CLI using:
 
 ```
-$ swift run
+% swift run
 Hello, Stranger!
 ```

--- a/Examples/manual-generation-generator-cli-example/README.md
+++ b/Examples/manual-generation-generator-cli-example/README.md
@@ -18,7 +18,7 @@ The server can be started by running any of the Hello World server examples loca
 
 Whenever the `openapi.yaml` document changes, rerun the code generation:
 
-```
+```console
 % make generate
 ```
 
@@ -28,7 +28,7 @@ And then check in the changed files in `./Sources/ManualGeneratorInvocationClien
 
 Build and run the client CLI using:
 
-```
+```console
 % swift run
 Hello, Stranger!
 ```

--- a/Examples/manual-generation-package-plugin-example/README.md
+++ b/Examples/manual-generation-package-plugin-example/README.md
@@ -18,7 +18,7 @@ The server can be started by running any of the Hello World server examples loca
 
 Whenever the `openapi.yaml` document changes, rerun the code generation:
 
-```
+```console
 % swift package generate-code-from-openapi
 Plugin ‘OpenAPIGeneratorCommand’ wants permission to write to the package directory.
 Stated reason: “To write the generated Swift files back into the source directory of the package.”.
@@ -33,7 +33,7 @@ And then check in the changed files in `./Sources/CommandPluginInvocationClient/
 
 Build and run the client CLI using:
 
-```
+```console
 % swift run
 Hello, Stranger!
 ```

--- a/Examples/manual-generation-package-plugin-example/README.md
+++ b/Examples/manual-generation-package-plugin-example/README.md
@@ -19,7 +19,7 @@ The server can be started by running any of the Hello World server examples loca
 Whenever the `openapi.yaml` document changes, rerun the code generation:
 
 ```
-$ swift package generate-code-from-openapi
+% swift package generate-code-from-openapi
 Plugin ‘OpenAPIGeneratorCommand’ wants permission to write to the package directory.
 Stated reason: “To write the generated Swift files back into the source directory of the package.”.
 Allow this plugin to write to the package directory? (yes/no) yes
@@ -34,6 +34,6 @@ And then check in the changed files in `./Sources/CommandPluginInvocationClient/
 Build and run the client CLI using:
 
 ```
-$ swift run
+% swift run
 Hello, Stranger!
 ```

--- a/Examples/retrying-middleware-example/README.md
+++ b/Examples/retrying-middleware-example/README.md
@@ -25,7 +25,7 @@ The server can be started by running any of the Hello World server examples loca
 Build and run the client CLI using:
 
 ```
-$ swift run
+% swift run
 Attempt 1
 Retrying with code 500
 Attempt 2

--- a/Examples/swagger-ui-endpoint-example/README.md
+++ b/Examples/swagger-ui-endpoint-example/README.md
@@ -29,7 +29,7 @@ The CLI starts the server on `http://localhost:8080` and you can go to `http://l
 
 Build and run the server CLI using:
 
-```
+```console
 % swift run
 2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
 ...

--- a/Examples/swagger-ui-endpoint-example/README.md
+++ b/Examples/swagger-ui-endpoint-example/README.md
@@ -30,7 +30,7 @@ The CLI starts the server on `http://localhost:8080` and you can go to `http://l
 Build and run the server CLI using:
 
 ```
-$ swift run
+% swift run
 2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
 ...
 ```

--- a/Examples/various-content-types-client-example/README.md
+++ b/Examples/various-content-types-client-example/README.md
@@ -16,6 +16,6 @@ The server can be started by running the `ContentTypesServer` example locally.
 
 Build and run the client CLI using:
 
-```
+```console
 % swift run
 ```

--- a/Examples/various-content-types-client-example/README.md
+++ b/Examples/various-content-types-client-example/README.md
@@ -17,5 +17,5 @@ The server can be started by running the `ContentTypesServer` example locally.
 Build and run the client CLI using:
 
 ```
-$ swift run
+% swift run
 ```

--- a/Examples/various-content-types-server-example/README.md
+++ b/Examples/various-content-types-server-example/README.md
@@ -12,7 +12,7 @@ The tool uses the [Vapor](https://github.com/vapor/vapor) server framework to ha
 
 The CLI starts the server on `http://localhost:8080` and can be invoked by running the `ContentTypesClient` example client or on the command line using:
 
-```
+```console
 % curl http://localhost:8080/api/exampleJSON
 {
   "message" : "Hello, Stranger!"
@@ -23,7 +23,7 @@ The CLI starts the server on `http://localhost:8080` and can be invoked by runni
 
 Build and run the server CLI using:
 
-```
+```console
 % swift run
 2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
 ...
@@ -33,7 +33,7 @@ Build and run the server CLI using:
 
 Run tests using:
 
-```
+```console
 % swift test
 ```
 

--- a/Examples/various-content-types-server-example/README.md
+++ b/Examples/various-content-types-server-example/README.md
@@ -13,7 +13,7 @@ The tool uses the [Vapor](https://github.com/vapor/vapor) server framework to ha
 The CLI starts the server on `http://localhost:8080` and can be invoked by running the `ContentTypesClient` example client or on the command line using:
 
 ```
-$ curl http://localhost:8080/api/exampleJSON
+% curl http://localhost:8080/api/exampleJSON
 {
   "message" : "Hello, Stranger!"
 }
@@ -24,7 +24,7 @@ $ curl http://localhost:8080/api/exampleJSON
 Build and run the server CLI using:
 
 ```
-$ swift run
+% swift run
 2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
 ...
 ```
@@ -34,7 +34,7 @@ $ swift run
 Run tests using:
 
 ```
-swift test
+% swift test
 ```
 
 The testing strategy is to call the `Handler` directly from tests, as it conforms the `APIProtocol` and implements the business logic.

--- a/IntegrationTest/README.md
+++ b/IntegrationTest/README.md
@@ -8,21 +8,16 @@ This package can be used when testing changes in another project.
 
 For example, from the pull request pipeline for that project, you can do the following:
 
-```sh
-# Clone the generator repo and go into the integration test directory
+```console
 % git clone https://github.com/apple/swift-openapi-generator
 % cd swift-openapi-generator/IntegrationTests
-
-# Use Swift PM to override the dependency for the package you want to test
 % swift package edit swift-openapi-runtime path/to/checkout/of/swift-openapi-runtime
-
-# Run the build for the integration test
 % swift build
 ```
 
 If you're working manually on this, you may wish to reset any overrides, you
 can do this using the following command:
 
-```sh
+```console
 % swift package reset
 ```

--- a/IntegrationTest/README.md
+++ b/IntegrationTest/README.md
@@ -10,19 +10,19 @@ For example, from the pull request pipeline for that project, you can do the fol
 
 ```sh
 # Clone the generator repo and go into the integration test directory
-git clone https://github.com/apple/swift-openapi-generator
-cd swift-openapi-generator/IntegrationTests
+% git clone https://github.com/apple/swift-openapi-generator
+% cd swift-openapi-generator/IntegrationTests
 
 # Use Swift PM to override the dependency for the package you want to test
-swift package edit swift-openapi-runtime path/to/checkout/of/swift-openapi-runtime
+% swift package edit swift-openapi-runtime path/to/checkout/of/swift-openapi-runtime
 
 # Run the build for the integration test
-swift build
+% swift build
 ```
 
 If you're working manually on this, you may wish to reset any overrides, you
 can do this using the following command:
 
 ```sh
-swift package reset
+% swift package reset
 ```

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -110,7 +110,7 @@ In all cases, the transitive closure of dependencies from the components object 
 The CLI also provides a `filter` command that takes the same configuration file as the `generate`
 command, which can be used to inspect the filtered document:
 
-```
+```console
 % swift-openapi-generator filter --config path/to/openapi-generator-config.yaml path/to/openapi.yaml
 ```
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Manually-invoking-the-generator-CLI.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Manually-invoking-the-generator-CLI.md
@@ -48,8 +48,8 @@ As an alternative to invoking the CLI manually, you can also use the package com
 
 Set up the `openapi.yaml` and `openapi-generator-config.yaml` files the same way as you would for the build plugin, and then run:
 
-```
-swift package plugin generate-code-from-openapi --target GreetingServiceClient
+```zsh
+% swift package plugin generate-code-from-openapi --target GreetingServiceClient
 ```
 
 This will generate files into the `GreetingServiceClient` target's Sources directory, in a directory called GeneratedSources, which you can then check into your repository.

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Manually-invoking-the-generator-CLI.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Manually-invoking-the-generator-CLI.md
@@ -36,7 +36,7 @@ This will create the following files in the specified output directory:
 
 To see the usage documentation for the generator CLI, use the following command:
 
-```zsh
+```console
 % swift run swift-openapi-generator --help
 ```
 
@@ -48,7 +48,7 @@ As an alternative to invoking the CLI manually, you can also use the package com
 
 Set up the `openapi.yaml` and `openapi-generator-config.yaml` files the same way as you would for the build plugin, and then run:
 
-```zsh
+```console
 % swift package plugin generate-code-from-openapi --target GreetingServiceClient
 ```
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Useful-OpenAPI-patterns.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Useful-OpenAPI-patterns.md
@@ -63,7 +63,7 @@ The above is the most flexible, any JSON payload that doesn't match any of the c
 
 If you know the payload is, for example, always a JSON object, you can constrain the second schema further, like this:
 
-```
+```yaml
 MyOpenOneOf:
   anyOf:
     - oneOf:


### PR DESCRIPTION
### Motivation

As part of docs polish, ensure we're consistently using the percent sign as the prompt symbol.

### Modifications

Fix up.

### Result

Consistent docs.

### Test Plan

N/A
