### PR TITLE
Add Github issue template forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,110 @@
+name: 🐞 Report a bug
+description: >
+  Report a deviation from expected or documented behavior, but not a crash.
+labels: [kind/bug, status/triage]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        This repository hosts issues for the Swift OpenAPI generator, the Swift
+        OpenAPI runtime library, the Swift OpenAPI URLSession transport library,
+        and the AsyncHTTPClient transport library.
+        It does *not* track feedback on Xcode and other closed source Apple
+        developer software such as URLSession itself; please direct it to
+        [Feedback Assistant](https://developer.apple.com/bug-reporting) instead.
+
+        ___
+  - type: textarea
+    attributes:
+      label: Description
+      description: >
+        A concise description of what causes the problem, in human language.
+        Though not required, it may help us to more accurately triage the issue
+        as well as understand a non-trivial test case.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Reproduction
+      description: >
+        Please provide inputs to help us reproduce the issue.
+
+        If the issue relates to code generation, provide an example OpenAPI
+        document, a generator configuration file, and extract of the Swift
+        code you believe to contain the issue. If generation fails, please
+        provide the generator output.
+
+        If the issue is with using the generated code, or the runtime or
+        transport libraries, provide a test case, provide sample Swift code, and
+        explain how to build or run it to reproduce the problem.
+
+        If the problem is a poor or unexpected error, warning, or output, please
+        show them.
+
+        Consider reducing the test case to the smallest amount of code possible
+        — a smaller test case is easier to reason about and more appealing to
+        contributors.
+      placeholder: |
+        ```yaml
+        # openapi.yaml
+        openapi: '3.1.0'
+        ...
+        ```
+
+        ```yaml
+        # openapi-generator-config.yaml
+        mode:
+          - types
+          - client
+        ...
+        ```
+
+        ```swift
+        let message = try await client.getGreeting()
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Package version(s)
+      description: >
+        Provide the versions of the relevant Swift OpenAPI packages used when
+        encountering the issue.
+      placeholder: |
+        ```console
+        % swift package show-dependencies
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: >
+        Describe the behavior you expected.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Environment
+      description: >
+        Provide the Swift version, tag, or revision. If you suspect that the
+        problem might be specific to a particular development platform or
+        deployment target, please specify them as well.
+      placeholder: |
+        ```console
+        % swift -version
+
+        % sw_vers ||
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: >
+        Any complementary information that could help others to work around
+        the problem, and us to better understand the problem and its impact.
+        For example, a link to a discussion or post that motivated this
+        report.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,35 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 Learn about Swift OpenAPI Generator
+    url: https://swiftpackageindex.com/apple/swift-openapi-generator/documentation/
+    about: >
+      Read the rendered Swift OpenAPI Generator documentation on Swift Package Index.
+  - name: 🧑‍🏫 Example projects
+    url: https://github.com/apple/swift-openapi-generator/blob/main/Examples/README.md
+    about: >
+      Build, run, and experiment with sample projects that use Swift OpenAPI
+      Generator and integrate with other packages in the ecosystem.
+  - name: ✅ Take a look at the FAQ
+    url: https://swiftpackageindex.com/apple/swift-openapi-generator/documentation/swift-openapi-generator/useful-openapi-patterns
+    about: >
+      See solutions to commonly-asked questions and common workflows.
+  - name: 🧩 Check the list of supported OpenAPI features
+    url: https://swiftpackageindex.com/apple/swift-openapi-generator/documentation/swift-openapi-generator/supported-openapi-features
+    about: >
+      See which features of the OpenAPI Specification are currently supported by
+      the Swift OpenAPI Generator.
+  - name: 📄 Formally propose a change
+    url: https://swiftpackageindex.com/apple/swift-openapi-generator/documentation/swift-openapi-generator/proposals
+    about: >
+      Formally propose an addition, removal, or change to the features of the
+      Swift OpenAPI Generator using the proposal process.
+  - name: 💬 Join the \#openapi Slack channel
+    url: https://swift-open-source.slack.com/archives/C05AZ55J75K
+    about: >
+      Chat with other adopters and contributors on the Swift Open Source Slack
+      workspace.
+  - name: 🪲 Report an issue using Feedback Assistant
+    url: https://developer.apple.com/bug-reporting
+    about: >
+      Report an issue with Xcode or other closed source Apple developer
+      software such as URLSession.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,60 @@
+name: 🌟 Request a change
+description: >
+  Request a feature, improvement, or other change.
+labels: [kind/feature, status/triage]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        This repository hosts issues for the Swift OpenAPI generator, the Swift
+        OpenAPI runtime library, the Swift OpenAPI URLSession transport library,
+        and the AsyncHTTPClient transport library.
+        It does *not* track feedback on Xcode and other closed source Apple
+        developer software such as URLSession itself; please direct it to
+        [Feedback Assistant](https://developer.apple.com/bug-reporting) instead.
+
+        ___
+
+        For non-trivial changes that affect the public API, the Swift OpenAPI
+        Generator project adopts a ligthweight version of the [Swift
+        Evolution](https://github.com/apple/swift-evolution/blob/main/process.md)
+        process.
+
+        Writing a proposal first helps discuss multiple possible solutions
+        early, apply useful feedback from other contributors, and avoid
+        reimplementing the same feature multiple times.
+
+        Use this issue template to start discussion about your feature request.
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: >
+        Describe the problems that this proposal aims to address, and what
+        workarounds adopters have to employ currently, if any.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed solution
+      description: >
+        Describe your solution to the problem. Provide examples and describe how they
+        work. Show how your solution is better than current workarounds.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+      description: >
+        Any alternative approaches that were considered, and why the *proposed
+        solution* was chosen instead.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: >
+        Any complementary information that could be valuable to an author of a
+        formal proposal, an implementor, or future discussions. For example, a
+        link to a discussion or post that motivated this request.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/support-request.yml
+++ b/.github/ISSUE_TEMPLATE/support-request.yml
@@ -1,0 +1,30 @@
+name: 🙋 Ask a question
+description: >
+  Ask a question about or get help with Swift OpenAPI Generator. Beginner
+  questions welcome!
+labels: [kind/support, status/triage]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        This repository hosts issues for the Swift OpenAPI generator, the Swift
+        OpenAPI runtime library, the Swift OpenAPI URLSession transport library,
+        and the AsyncHTTPClient transport library.
+        It does *not* track feedback on Xcode and other closed source Apple
+        developer software such as URLSession itself; please direct it to
+        [Feedback Assistant](https://developer.apple.com/bug-reporting) instead.
+
+        ___
+
+        Please use this issue template to ask a question.
+
+        You may also like to check out our
+        [FAQ](https://swiftpackageindex.com/apple/swift-openapi-generator/documentation/swift-openapi-generator/useful-openapi-patterns)
+        for solutions to frequently asked questions and common workflows.
+  - type: textarea
+    attributes:
+      label: Question
+      description: >
+        What are you trying to achieve? What have you tried? What didn't work as expected?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,31 @@
+name: ⚙️ Track a task
+description: >
+  Tasks can be used to track internal work, extract individual subtasks from a
+  larger issue, and can serve as umbrella issues themselves.
+labels: [kind/enhancement, status/triage]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        This repository hosts issues for the Swift OpenAPI generator, the Swift
+        OpenAPI runtime library, the Swift OpenAPI URLSession transport library,
+        and the AsyncHTTPClient transport library.
+        It does *not* track feedback on Xcode and other closed source Apple
+        developer software such as URLSession itself; please direct it to
+        [Feedback Assistant](https://developer.apple.com/bug-reporting) instead.
+
+        ___
+  - type: textarea
+    attributes:
+      label: Description
+      description: >
+        A comprehensive description of the task, in human language.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: >
+        Any complementary information that could be valuable to an implementor.
+    validations:
+      required: false

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -35,6 +35,15 @@ This product contains derivations of various scripts and templates from SwiftNIO
 
 -------------------------------------------------------------------------------
 
+This product contains derivations of templates and proposal workflows from Swift.
+
+  * LICENSE (Apache License 2.0):
+    * https://swift.org/LICENSE.txt
+  * HOMEPAGE:
+    * https://github.com/apple/swift
+
+-------------------------------------------------------------------------------
+
 This product contains derivations of examples from the OpenAPI project.
 
   * LICENSE (Apache License 2.0):


### PR DESCRIPTION
### Motivation

Github recently added support for Issue forms, which can help guide the creation of issues for adopters and developers to provide the critical information needed to diagnose issues. These have recently been adopted by the Swift project too, from which our templates take much inspiration.

When using issue forms (and templates in general) it also provides the filer with a choice of what kind of issue it is, and can automatically add appropriate labels based on kind and apply the `status/triage` label.

Finally the page that displays the choice of issue templates can be further extended to provide links to other useful external resources.

Note that it is still possible to create an issue from a blank slate if none of the options suit the adopter.

Check out the "New issue" page on apple/swift to see all these features combined and in action[^1].

[^1]: https://github.com/apple/swift/issues/new/choose

### Modifications

- Add template for reporting a bug:
  - Disclaimer that this is not for Xcode issues. 
  - Required fields for versions, reproduction steps, expected behavior.
  - Optional fields for additional information.
  - Applies labels: `kind/bug`, `status/triage`.
- Add template for asking a question:
  - Disclaimer that this is not for Xcode support. 
  - Links to FAQ.
  - Applies labels: `kind/support`, `status/triage`.
- Add template for requesting a feature:
  - Explains the proposal process.
  - Required fields for cut-down proposal input.
  - Applies labels: `kind/feature`, `status/triage`.
- Add template for tracking a task:
  - Meant for maintainers and for breaking out issues from PRs or quotes from bugs.
  - Applies labels: `kind/enhancement`, `status/triage`.
- Added additional resources to chooser:
  - Documentation
  - Examples
  - FAQ
  - Supported OpenAPI features
  - Proposal process
  - Swift Open Source Slack channel
  - Feedback Assistant for Xcode and URLSession bugs
- Kept the blank issues enabled.

### Result

More guided process when filing issues and surfaces other relevant resources.

### Test Plan

None.