### PR TITLE
[Examples] Stop linking transitive dependencies in tests

### DIFF
--- a/Examples/hello-world-hummingbird-server-example/Package.swift
+++ b/Examples/hello-world-hummingbird-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.9.2
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project
@@ -36,9 +36,7 @@ let package = Package(
         .testTarget(
             name: "HelloWorldHummingbirdServerTests",
             dependencies: [
-                "HelloWorldHummingbirdServer", .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-                .product(name: "OpenAPIHummingbird", package: "swift-openapi-hummingbird"),
-                .product(name: "Hummingbird", package: "hummingbird"),
+                "HelloWorldHummingbirdServer",
             ]
         ),
     ]

--- a/Examples/hello-world-hummingbird-server-example/Package.swift
+++ b/Examples/hello-world-hummingbird-server-example/Package.swift
@@ -32,12 +32,6 @@ let package = Package(
                 .product(name: "Hummingbird", package: "hummingbird"),
             ],
             plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
-        ),
-        .testTarget(
-            name: "HelloWorldHummingbirdServerTests",
-            dependencies: [
-                "HelloWorldHummingbirdServer",
-            ]
-        ),
+        ), .testTarget(name: "HelloWorldHummingbirdServerTests", dependencies: ["HelloWorldHummingbirdServer"]),
     ]
 )

--- a/Examples/hello-world-vapor-server-example/Package.swift
+++ b/Examples/hello-world-vapor-server-example/Package.swift
@@ -32,12 +32,6 @@ let package = Package(
                 .product(name: "Vapor", package: "vapor"),
             ],
             plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
-        ),
-        .testTarget(
-            name: "HelloWorldVaporServerTests",
-            dependencies: [
-                "HelloWorldVaporServer",
-            ]
-        ),
+        ), .testTarget(name: "HelloWorldVaporServerTests", dependencies: ["HelloWorldVaporServer"]),
     ]
 )

--- a/Examples/hello-world-vapor-server-example/Package.swift
+++ b/Examples/hello-world-vapor-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.9.2
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project
@@ -36,9 +36,7 @@ let package = Package(
         .testTarget(
             name: "HelloWorldVaporServerTests",
             dependencies: [
-                "HelloWorldVaporServer", .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-                .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
-                .product(name: "Vapor", package: "vapor"),
+                "HelloWorldVaporServer",
             ]
         ),
     ]

--- a/Examples/various-content-types-server-example/Package.swift
+++ b/Examples/various-content-types-server-example/Package.swift
@@ -32,12 +32,6 @@ let package = Package(
                 .product(name: "Vapor", package: "vapor"),
             ],
             plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
-        ),
-        .testTarget(
-            name: "ContentTypesServerTests",
-            dependencies: [
-                "ContentTypesServer",
-            ]
-        ),
+        ), .testTarget(name: "ContentTypesServerTests", dependencies: ["ContentTypesServer"]),
     ]
 )

--- a/Examples/various-content-types-server-example/Package.swift
+++ b/Examples/various-content-types-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.9.2
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project
@@ -36,9 +36,7 @@ let package = Package(
         .testTarget(
             name: "ContentTypesServerTests",
             dependencies: [
-                "ContentTypesServer", .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-                .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
-                .product(name: "Vapor", package: "vapor"),
+                "ContentTypesServer",
             ]
         ),
     ]


### PR DESCRIPTION
### Motivation

In Swift 5.9.2, a bug is fixed that forced us to previously explicitly link transitive dependencies in tests. So let's remove it, and also bump the swift-tools-version of the affected projects to 5.9.2 to make it explicit.

### Modifications

Removed the explicit linkage, bumped the swift-tools-version.

### Result

Examples show the best practices using the latest tools.

### Test Plan

Ran locally using:

```
docker run --rm -it -v $PWD/Examples/hello-world-hummingbird-server-example:/app swift:5.9 swift test --package-path /app
```

Failed with 5.9.1. Passed with 5.9.2 (and 5.9, which is now an alias for 5.9.2).
