### PR TITLE
[Generator] Add headerFields and body to UndocumentedPayload

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/ClientTranslator/translateClientMethod.swift
@@ -112,7 +112,17 @@ extension ClientFileTranslator {
                         .init(
                             label: "statusCode",
                             expression: .identifierPattern("response").dot("status").dot("code")
-                        ), .init(label: nil, expression: .dot("init").call([])),
+                        ),
+                        .init(
+                            label: nil,
+                            expression: .dot("init")
+                                .call([
+                                    .init(
+                                        label: "headerFields",
+                                        expression: .identifierPattern("response").dot("headerFields")
+                                    ), .init(label: "body", expression: .identifierPattern("responseBody")),
+                                ])
+                        ),
                     ])
             )
             cases.append(.init(kind: .default, body: [.expression(undocumentedExpr)]))

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -274,7 +274,10 @@ public struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }
@@ -316,7 +319,10 @@ public struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }
@@ -389,7 +395,10 @@ public struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }
@@ -441,7 +450,10 @@ public struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }
@@ -472,7 +484,10 @@ public struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }
@@ -544,7 +559,10 @@ public struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }
@@ -656,7 +674,10 @@ public struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }
@@ -787,7 +808,10 @@ public struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }
@@ -891,7 +915,10 @@ public struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -4478,7 +4478,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     default:
                         return .undocumented(
                             statusCode: response.status.code,
-                            .init()
+                            .init(
+                                headerFields: response.headerFields,
+                                body: responseBody
+                            )
                         )
                     }
                 }
@@ -4661,7 +4664,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     default:
                         return .undocumented(
                             statusCode: response.status.code,
-                            .init()
+                            .init(
+                                headerFields: response.headerFields,
+                                body: responseBody
+                            )
                         )
                     }
                 }

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -613,13 +613,16 @@ final class Test_Client: XCTestCase {
     }
 
     func testProbe_undocumented() async throws {
-        transport = .init { request, requestBody, baseURL, operationID in (.init(status: .serviceUnavailable), nil) }
+        transport = .init { request, requestBody, baseURL, operationID in (.init(status: .serviceUnavailable), "oh no")
+        }
         let response = try await client.probe(.init())
-        guard case let .undocumented(statusCode, _) = response else {
+        guard case let .undocumented(statusCode, payload) = response else {
             XCTFail("Unexpected response: \(response)")
             return
         }
         XCTAssertEqual(statusCode, 503)
+        XCTAssertEqual(payload.headerFields, [:])
+        try await XCTAssertEqualStringifiedData(payload.body, "oh no")
     }
 
     func testUploadAvatarForPet_200() async throws {


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/299.

Depends on https://github.com/apple/swift-openapi-runtime/pull/90 landing first and getting released, and the version dependency being bumped here.

### Modifications

Adapted to the runtime changes, added `headerFields` and `body` properties to `UndocumentedPayload`.

Now, the generated code actually also forwards the values to it.

### Result

Easier access to the raw response data if an undocumented response is returned.

### Test Plan

Adapted snippet and file-based reference tests, and also the unit tests of the generated code (PetstoreConsumerTests).
