### PR TITLE
examples: Flesh out Makefile-based example

### DIFF
--- a/Examples/manual-generation-generator-cli-example/.gitignore
+++ b/Examples/manual-generation-generator-cli-example/.gitignore
@@ -9,3 +9,4 @@ DerivedData/
 /Package.resolved
 .ci/
 .docc-build/
+.swift-openapi-generator/

--- a/Examples/manual-generation-generator-cli-example/Makefile
+++ b/Examples/manual-generation-generator-cli-example/Makefile
@@ -1,21 +1,86 @@
-REPO_URL = https://github.com/apple/swift-openapi-generator
-VERSION = 1.0.0
-TMP_DIR = /tmp
-REPO_DIR = $(TMP_DIR)/swift-openapi-generator
-CLI_EXECUTABLE = $(REPO_DIR)/.build/release/swift-openapi-generator
+# To see how to drive this makefile use:
+#
+#   % make help
 
-$(REPO_DIR):
-	git clone --branch $(VERSION) --depth 1 $(REPO_URL) $(REPO_DIR)
+# The following values can be changed here, or passed on the command line.
+SWIFT_OPENAPI_GENERATOR_GIT_URL ?= https://github.com/apple/swift-openapi-generator
+SWIFT_OPENAPI_GENERATOR_GIT_TAG ?= 1.0.0
+SWIFT_OPENAPI_GENERATOR_CLONE_DIR ?= $(CURRENT_MAKEFILE_DIR)/.swift-openapi-generator
+SWIFT_OPENAPI_GENERATOR_BUILD_CONFIGURATION ?= debug
+OPENAPI_YAML_PATH ?= $(CURRENT_MAKEFILE_DIR)/openapi.yaml
+OPENAPI_GENERATOR_CONFIG_PATH ?= $(CURRENT_MAKEFILE_DIR)/openapi-generator-config.yaml
+OUTPUT_DIRECTORY ?= $(CURRENT_MAKEFILE_DIR)/Sources/ManualGeneratorInvocationClient/Generated
 
-$(CLI_EXECUTABLE): $(REPO_DIR)
-	cd $(REPO_DIR) && swift build -c release --package-path $(REPO_DIR)
+# Derived values (don't change these).
+CURRENT_MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_MAKEFILE_DIR := $(patsubst %/,%,$(dir $(CURRENT_MAKEFILE_PATH)))
+SWIFT_OPENAPI_GENERATOR_BIN := $(SWIFT_OPENAPI_GENERATOR_CLONE_DIR)/.build/$(SWIFT_OPENAPI_GENERATOR_BUILD_CONFIGURATION)/swift-openapi-generator
 
-all: $(CLI_EXECUTABLE)
+# If no target is specified, display help
+.DEFAULT_GOAL := help
 
-generate: $(CLI_EXECUTABLE)
-	$(CLI_EXECUTABLE) generate ./openapi.yaml \
-		--output-directory ./Sources/ManualGeneratorInvocationClient/Generated \
-		--config ./openapi-generator-config.yaml
+help:  # Display this help.
+	@-+echo "Run make with one of the following targets:"
+	@-+echo
+	@-+grep -Eh "^[a-z-]+:.*#" $(CURRENT_MAKEFILE_PATH) | sed -E 's/^(.*:)(.*#+)(.*)/  \1 @@@ \3 /' | column -t -s "@@@"
+	@-+echo
+	@-+echo "The following options can be overriden on the command line:"
+	@-+echo
+	@-+echo "  SWIFT_OPENAPI_GENERATOR_GIT_URL (e.g. https://github.com/apple/swift-openapi-generator)"
+	@-+echo "  SWIFT_OPENAPI_GENERATOR_GIT_TAG (e.g. 1.0.0)"
+	@-+echo "  SWIFT_OPENAPI_GENERATOR_CLONE_DIR (e.g. .swift-openapi-generator)"
+	@-+echo "  SWIFT_OPENAPI_GENERATOR_BUILD_CONFIGURATION (e.g. release)"
+	@-+echo "  OPENAPI_YAML_PATH (e.g. openapi.yaml)"
+	@-+echo "  OPENAPI_GENERATOR_CONFIG_PATH (e.g. openapi-generator-config.yaml)"
+	@-+echo "  OUTPUT_DIRECTORY (e.g. Sources/ManualGeneratorInvocationClient/Generated)"
 
-clean-generator:
-	rm -rf $(REPO_DIR)
+generate: $(SWIFT_OPENAPI_GENERATOR_BIN) $(OPENAPI_YAML_PATH) $(OPENAPI_GENERATOR_CONFIG_PATH) $(OUTPUT_DIRECTORY)  # Generate the sources using swift-openapi-generator.
+	$< generate \
+		--config "$(OPENAPI_GENERATOR_CONFIG_PATH)" \
+		--output-directory "$(OUTPUT_DIRECTORY)" \
+		"$(OPENAPI_YAML_PATH)"
+
+build:  # Runs swift build.
+	swift build
+
+clean:  # Delete the output directory used for generated sources.
+	@echo 'Delete entire directory: $(OUTPUT_DIRECTORY)? [y/N] ' && read ans && [ $${ans:-N} = y ] || (echo "Aborted"; exit 1)
+	rm -rf "$(OUTPUT_DIRECTORY)"
+
+clean-all: clean  # Clean everything, including the checkout of swift-openapi-generator.
+	@echo 'Delete checkout of swift-openapi-generator $(SWIFT_OPENAPI_GENERATOR_CLONE_DIR)? [y/N] ' && read ans && [ $${ans:-N} = y ] || (echo "Aborted"; exit 1)
+	rm -rf "$(SWIFT_OPENAPI_GENERATOR_CLONE_DIR)"
+
+
+dump:  # Dump all derived values used by the Makefile.
+	@echo "CURRENT_MAKEFILE_PATH = $(CURRENT_MAKEFILE_PATH)"
+	@echo "CURRENT_MAKEFILE_DIR = $(CURRENT_MAKEFILE_DIR)"
+	@echo "SWIFT_OPENAPI_GENERATOR_GIT_URL = $(SWIFT_OPENAPI_GENERATOR_GIT_URL)"
+	@echo "SWIFT_OPENAPI_GENERATOR_GIT_TAG = $(SWIFT_OPENAPI_GENERATOR_GIT_TAG)"
+	@echo "SWIFT_OPENAPI_GENERATOR_CLONE_DIR = $(SWIFT_OPENAPI_GENERATOR_CLONE_DIR)"
+	@echo "SWIFT_OPENAPI_GENERATOR_BUILD_CONFIGURATION = $(SWIFT_OPENAPI_GENERATOR_BUILD_CONFIGURATION)"
+	@echo "SWIFT_OPENAPI_GENERATOR_BIN = $(SWIFT_OPENAPI_GENERATOR_BIN)"
+	@echo "OPENAPI_YAML_PATH = $(OPENAPI_YAML_PATH)"
+	@echo "OPENAPI_GENERATOR_CONFIG_PATH = $(OPENAPI_GENERATOR_CONFIG_PATH)"
+	@echo "OUTPUT_DIRECTORY = $(OUTPUT_DIRECTORY)"
+
+$(SWIFT_OPENAPI_GENERATOR_CLONE_DIR):
+	git \
+		-c advice.detachedHead=false \
+		clone \
+		--branch "$(SWIFT_OPENAPI_GENERATOR_GIT_TAG)" \
+		--depth 1 \
+		"$(SWIFT_OPENAPI_GENERATOR_GIT_URL)" \
+		$@
+
+$(SWIFT_OPENAPI_GENERATOR_BIN): $(SWIFT_OPENAPI_GENERATOR_CLONE_DIR)
+	swift \
+		build \
+		--package-path "$(SWIFT_OPENAPI_GENERATOR_CLONE_DIR)" \
+		--configuration "$(SWIFT_OPENAPI_GENERATOR_BUILD_CONFIGURATION)" \
+		--product swift-openapi-generator
+
+$(OUTPUT_DIRECTORY):
+	mkdir -p "$@"
+
+.PHONY: help generate build clean clean-all dump

--- a/Examples/manual-generation-generator-cli-example/Sources/ManualGeneratorInvocationClient/Generated/Client.swift
+++ b/Examples/manual-generation-generator-cli-example/Sources/ManualGeneratorInvocationClient/Generated/Client.swift
@@ -10,7 +10,7 @@ import struct Foundation.Data
 import struct Foundation.Date
 #endif
 import HTTPTypes
-package struct Client: APIProtocol {
+internal struct Client: APIProtocol {
     /// The underlying HTTP client.
     private let client: UniversalClient
     /// Creates a new client.
@@ -21,7 +21,7 @@ package struct Client: APIProtocol {
     ///   - configuration: A set of configuration values for the client.
     ///   - transport: A transport that performs HTTP operations.
     ///   - middlewares: A list of middlewares to call before the transport.
-    package init(
+    internal init(
         serverURL: Foundation.URL,
         configuration: Configuration = .init(),
         transport: any ClientTransport,
@@ -39,7 +39,7 @@ package struct Client: APIProtocol {
     }
     /// - Remark: HTTP `GET /greet`.
     /// - Remark: Generated from `#/paths//greet/get(getGreeting)`.
-    package func getGreeting(_ input: Operations.getGreeting.Input) async throws -> Operations.getGreeting.Output {
+    internal func getGreeting(_ input: Operations.getGreeting.Input) async throws -> Operations.getGreeting.Output {
         try await client.send(
             input: input,
             forOperation: Operations.getGreeting.id,

--- a/Examples/manual-generation-generator-cli-example/Sources/ManualGeneratorInvocationClient/Generated/Types.swift
+++ b/Examples/manual-generation-generator-cli-example/Sources/ManualGeneratorInvocationClient/Generated/Types.swift
@@ -10,7 +10,7 @@ import struct Foundation.Data
 import struct Foundation.Date
 #endif
 /// A type that performs HTTP operations defined by the OpenAPI document.
-package protocol APIProtocol: Sendable {
+internal protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /greet`.
     /// - Remark: Generated from `#/paths//greet/get(getGreeting)`.
     func getGreeting(_ input: Operations.getGreeting.Input) async throws -> Operations.getGreeting.Output
@@ -20,7 +20,7 @@ package protocol APIProtocol: Sendable {
 extension APIProtocol {
     /// - Remark: HTTP `GET /greet`.
     /// - Remark: Generated from `#/paths//greet/get(getGreeting)`.
-    package func getGreeting(
+    internal func getGreeting(
         query: Operations.getGreeting.Input.Query = .init(),
         headers: Operations.getGreeting.Input.Headers = .init()
     ) async throws -> Operations.getGreeting.Output {
@@ -32,9 +32,9 @@ extension APIProtocol {
 }
 
 /// Server URLs defined in the OpenAPI document.
-package enum Servers {
+internal enum Servers {
     /// Example service deployment.
-    package static func server1() throws -> Foundation.URL {
+    internal static func server1() throws -> Foundation.URL {
         try Foundation.URL(
             validatingOpenAPIServerURL: "https://example.com/api",
             variables: []
@@ -43,79 +43,79 @@ package enum Servers {
 }
 
 /// Types generated from the components section of the OpenAPI document.
-package enum Components {
+internal enum Components {
     /// Types generated from the `#/components/schemas` section of the OpenAPI document.
-    package enum Schemas {
+    internal enum Schemas {
         /// A value with the greeting contents.
         ///
         /// - Remark: Generated from `#/components/schemas/Greeting`.
-        package struct Greeting: Codable, Hashable, Sendable {
+        internal struct Greeting: Codable, Hashable, Sendable {
             /// The string representation of the greeting.
             ///
             /// - Remark: Generated from `#/components/schemas/Greeting/message`.
-            package var message: Swift.String
+            internal var message: Swift.String
             /// Creates a new `Greeting`.
             ///
             /// - Parameters:
             ///   - message: The string representation of the greeting.
-            package init(message: Swift.String) {
+            internal init(message: Swift.String) {
                 self.message = message
             }
-            package enum CodingKeys: String, CodingKey {
+            internal enum CodingKeys: String, CodingKey {
                 case message
             }
         }
     }
     /// Types generated from the `#/components/parameters` section of the OpenAPI document.
-    package enum Parameters {}
+    internal enum Parameters {}
     /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
-    package enum RequestBodies {}
+    internal enum RequestBodies {}
     /// Types generated from the `#/components/responses` section of the OpenAPI document.
-    package enum Responses {}
+    internal enum Responses {}
     /// Types generated from the `#/components/headers` section of the OpenAPI document.
-    package enum Headers {}
+    internal enum Headers {}
 }
 
 /// API operations, with input and output types, generated from `#/paths` in the OpenAPI document.
-package enum Operations {
+internal enum Operations {
     /// - Remark: HTTP `GET /greet`.
     /// - Remark: Generated from `#/paths//greet/get(getGreeting)`.
-    package enum getGreeting {
-        package static let id: Swift.String = "getGreeting"
-        package struct Input: Sendable, Hashable {
+    internal enum getGreeting {
+        internal static let id: Swift.String = "getGreeting"
+        internal struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/greet/GET/query`.
-            package struct Query: Sendable, Hashable {
+            internal struct Query: Sendable, Hashable {
                 /// The name used in the returned greeting.
                 ///
                 /// - Remark: Generated from `#/paths/greet/GET/query/name`.
-                package var name: Swift.String?
+                internal var name: Swift.String?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
                 ///   - name: The name used in the returned greeting.
-                package init(name: Swift.String? = nil) {
+                internal init(name: Swift.String? = nil) {
                     self.name = name
                 }
             }
-            package var query: Operations.getGreeting.Input.Query
+            internal var query: Operations.getGreeting.Input.Query
             /// - Remark: Generated from `#/paths/greet/GET/header`.
-            package struct Headers: Sendable, Hashable {
-                package var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getGreeting.AcceptableContentType>]
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getGreeting.AcceptableContentType>]
                 /// Creates a new `Headers`.
                 ///
                 /// - Parameters:
                 ///   - accept:
-                package init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getGreeting.AcceptableContentType>] = .defaultValues()) {
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getGreeting.AcceptableContentType>] = .defaultValues()) {
                     self.accept = accept
                 }
             }
-            package var headers: Operations.getGreeting.Input.Headers
+            internal var headers: Operations.getGreeting.Input.Headers
             /// Creates a new `Input`.
             ///
             /// - Parameters:
             ///   - query:
             ///   - headers:
-            package init(
+            internal init(
                 query: Operations.getGreeting.Input.Query = .init(),
                 headers: Operations.getGreeting.Input.Headers = .init()
             ) {
@@ -123,17 +123,17 @@ package enum Operations {
                 self.headers = headers
             }
         }
-        @frozen package enum Output: Sendable, Hashable {
-            package struct Ok: Sendable, Hashable {
+        @frozen internal enum Output: Sendable, Hashable {
+            internal struct Ok: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/greet/GET/responses/200/content`.
-                @frozen package enum Body: Sendable, Hashable {
+                @frozen internal enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/greet/GET/responses/200/content/application\/json`.
                     case json(Components.Schemas.Greeting)
                     /// The associated value of the enum case if `self` is `.json`.
                     ///
                     /// - Throws: An error if `self` is not `.json`.
                     /// - SeeAlso: `.json`.
-                    package var json: Components.Schemas.Greeting {
+                    internal var json: Components.Schemas.Greeting {
                         get throws {
                             switch self {
                             case let .json(body):
@@ -143,12 +143,12 @@ package enum Operations {
                     }
                 }
                 /// Received HTTP response body
-                package var body: Operations.getGreeting.Output.Ok.Body
+                internal var body: Operations.getGreeting.Output.Ok.Body
                 /// Creates a new `Ok`.
                 ///
                 /// - Parameters:
                 ///   - body: Received HTTP response body
-                package init(body: Operations.getGreeting.Output.Ok.Body) {
+                internal init(body: Operations.getGreeting.Output.Ok.Body) {
                     self.body = body
                 }
             }
@@ -162,7 +162,7 @@ package enum Operations {
             ///
             /// - Throws: An error if `self` is not `.ok`.
             /// - SeeAlso: `.ok`.
-            package var ok: Operations.getGreeting.Output.Ok {
+            internal var ok: Operations.getGreeting.Output.Ok {
                 get throws {
                     switch self {
                     case let .ok(response):
@@ -180,10 +180,10 @@ package enum Operations {
             /// A response with a code that is not documented in the OpenAPI document.
             case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
-        @frozen package enum AcceptableContentType: AcceptableProtocol {
+        @frozen internal enum AcceptableContentType: AcceptableProtocol {
             case json
             case other(Swift.String)
-            package init?(rawValue: Swift.String) {
+            internal init?(rawValue: Swift.String) {
                 switch rawValue.lowercased() {
                 case "application/json":
                     self = .json
@@ -191,7 +191,7 @@ package enum Operations {
                     self = .other(rawValue)
                 }
             }
-            package var rawValue: Swift.String {
+            internal var rawValue: Swift.String {
                 switch self {
                 case let .other(string):
                     return string
@@ -199,7 +199,7 @@ package enum Operations {
                     return "application/json"
                 }
             }
-            package static var allCases: [Self] {
+            internal static var allCases: [Self] {
                 [
                     .json
                 ]


### PR DESCRIPTION
### Motivation

We have an example project showing ahead-of-time generation using the `swift-openapi-generator` CLI directly, driven by a Makefile. This PR polishes it up a bit and makes it more flexible. Additionally, the generated code had not been updated since we switched the default access modifier from package to internal.


### Modifications

- Allow overriding a bunch of things when calling `make`.
- Prompt for confirmation before blowing away the output directory.
- Regenerate sources to pick up the new access modifier.
- Add a `help` target.

### Result

More extensive example.

E.g. running the following command:

```console
% make help
Run make with one of the following targets:

  help:          Display this help.
  generate:      Generate the sources using swift-openapi-generator.
  build:         Runs swift build.
  clean:         Delete the output directory used for generated sources.
  clean-all:     Clean everything, including the checkout of swift-openapi-generator.
  dump:          Dump all derived values used by the Makefile.

The following options can be overriden on the command line:

  SWIFT_OPENAPI_GENERATOR_GIT_URL (e.g. https://github.com/apple/swift-openapi-generator)
  SWIFT_OPENAPI_GENERATOR_GIT_TAG (e.g. 1.0.0)
  SWIFT_OPENAPI_GENERATOR_CLONE_DIR (e.g. .swift-openapi-generator)
  SWIFT_OPENAPI_GENERATOR_BUILD_CONFIGURATION (e.g. release)
  OPENAPI_YAML_PATH (e.g. openapi.yaml)
  OPENAPI_GENERATOR_CONFIG_PATH (e.g. openapi-generator-config.yaml)
  OUTPUT_DIRECTORY (e.g. Sources/ManualGeneratorInvocationClient/Generated)
``` 

### Test Plan

CI should still build the package.