### PR TITLE
Generate arrays with an optional element type for arrays with nullable items

### DIFF
--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -399,6 +399,13 @@ components:
           type: string
       additionalProperties:
         type: integer
+    ObjectWithOptionalNullableArrayOfNullableItems:
+      type: object
+      properties:
+        foo:
+          type: [array, null]
+          items:
+            type: [string, null]
     CodeError:
       type: object
       properties:

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -619,6 +619,21 @@ public enum Components {
                 try encoder.encodeAdditionalProperties(additionalProperties)
             }
         }
+        /// - Remark: Generated from `#/components/schemas/ObjectWithOptionalNullableArrayOfNullableItems`.
+        public struct ObjectWithOptionalNullableArrayOfNullableItems: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/ObjectWithOptionalNullableArrayOfNullableItems/foo`.
+            public var foo: [Swift.String?]?
+            /// Creates a new `ObjectWithOptionalNullableArrayOfNullableItems`.
+            ///
+            /// - Parameters:
+            ///   - foo:
+            public init(foo: [Swift.String?]? = nil) {
+                self.foo = foo
+            }
+            public enum CodingKeys: String, CodingKey {
+                case foo
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/CodeError`.
         public struct CodeError: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/CodeError/code`.


### PR DESCRIPTION
### Motivation

Array items can be nullable. When this is the case, the element type of the generated array should be optional. Today it is not. For example, consider the following OpenAPI snippet:

```yaml
  StringArrayNullableItems:
    type: array
    items:
      type: [string, null]
```

This currently generates a type alias for `[String]` but it should be `[String?]`

### Modifications

Update the translator to take into account `arrayContext.items.nullable` when generating the types for array values.

### Result

Arrays with nullable items 

### Test Plan

- Snippet test for standalone schema.
- Snippet test for use within an object.
- A test that shows lossless conversion to JSON with Foundation.

### Related issues

- Fixes #444.
