### PR TITLE
Fix compiler warnings in example projects

### DIFF
--- a/Examples/event-streams-server-example/Sources/EventStreamsServer/GreetingStream.swift
+++ b/Examples/event-streams-server-example/Sources/EventStreamsServer/GreetingStream.swift
@@ -25,7 +25,7 @@ final class StreamStorage: @unchecked Sendable {
     private func finishedStream(id: String) {
         lock.lock()
         defer { lock.unlock() }
-        guard let task = locked_streams[id] else { return }
+        guard locked_streams[id] != nil else { return }
         locked_streams.removeValue(forKey: id)
         print("Finished stream \(id)")
     }

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -68,6 +68,7 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
 
     log "Building example package: ${EXAMPLE_PACKAGE_NAME}"
     "${SWIFT_BIN}" build --build-tests \
+        -Xswiftc -warnings-as-errors \
         --package-path "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" \
         --cache-path "${SHARED_PACKAGE_CACHE_PATH}" \
         --skip-update \


### PR DESCRIPTION
### Motivation

A recent example project was added that had a compiler warning which wasn't caught by CI. We can have our example code free of warnings and ensure they remain so by compiling them with `-warnings-as-errors` in CI.

### Modifications

- Fix compiler warnings in example.
- Build with `-warnings-as-errors` in examples CI pipeline.

### Result

Example projects compile without warnings.

### Test Plan

CI updated.