### PR TITLE
Fix tests to include content-length header, now included by runtime library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ let package = Package(
         // Tests-only: Runtime library linked by generated code, and also
         // helps keep the runtime library new enough to work with the generated
         // code.
-        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.3.2"),
         .package(url: "https://github.com/apple/swift-http-types", from: "1.0.2"),
 
         // Build and preview docs

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -124,7 +124,7 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(
                 request.headerFields,
                 [
-                    .accept: "application/json", .contentType: "application/json; charset=utf-8",
+                    .accept: "application/json", .contentType: "application/json; charset=utf-8", .contentLength: "23",
                     .init("X-Extra-Arguments")!: #"{"code":1}"#,
                 ]
             )
@@ -198,7 +198,10 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(request.path, "/pets/create")
             XCTAssertEqual(baseURL.absoluteString, "/api")
             XCTAssertEqual(request.method, .post)
-            XCTAssertEqual(request.headerFields, [.contentType: "application/x-www-form-urlencoded"])
+            XCTAssertEqual(
+                request.headerFields,
+                [.contentType: "application/x-www-form-urlencoded", .contentLength: "11"]
+            )
             let bodyString: String
             if let body { bodyString = try await String(collecting: body, upTo: .max) } else { bodyString = "" }
             XCTAssertEqual(bodyString, "name=Fluffz")
@@ -220,7 +223,7 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(request.method, .patch)
             XCTAssertEqual(
                 request.headerFields,
-                [.accept: "application/json", .contentType: "application/json; charset=utf-8"]
+                [.accept: "application/json", .contentType: "application/json; charset=utf-8", .contentLength: "23"]
             )
             try await XCTAssertEqualStringifiedData(
                 requestBody,
@@ -265,7 +268,7 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(
                 request.headerFields,
                 [
-                    .accept: "application/json", .contentType: "application/json; charset=utf-8",
+                    .accept: "application/json", .contentType: "application/json; charset=utf-8", .contentLength: "112",
                     .init("X-Extra-Arguments")!: #"{"code":1}"#,
                 ]
             )
@@ -533,7 +536,10 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(request.path, "/pets/stats")
             XCTAssertEqual(baseURL.absoluteString, "/api")
             XCTAssertEqual(request.method, .post)
-            XCTAssertEqual(request.headerFields, [.contentType: "application/json; charset=utf-8"])
+            XCTAssertEqual(
+                request.headerFields,
+                [.contentType: "application/json; charset=utf-8", .contentLength: "17"]
+            )
             try await XCTAssertEqualStringifiedData(
                 requestBody,
                 #"""
@@ -557,7 +563,7 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(request.path, "/pets/stats")
             XCTAssertEqual(baseURL.absoluteString, "/api")
             XCTAssertEqual(request.method, .post)
-            XCTAssertEqual(request.headerFields, [.contentType: "text/plain"])
+            XCTAssertEqual(request.headerFields, [.contentType: "text/plain", .contentLength: "10"])
             try await XCTAssertEqualStringifiedData(
                 requestBody,
                 #"""
@@ -579,7 +585,7 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(request.path, "/pets/stats")
             XCTAssertEqual(baseURL.absoluteString, "/api")
             XCTAssertEqual(request.method, .post)
-            XCTAssertEqual(request.headerFields, [.contentType: "application/octet-stream"])
+            XCTAssertEqual(request.headerFields, [.contentType: "application/octet-stream", .contentLength: "10"])
             try await XCTAssertEqualStringifiedData(
                 requestBody,
                 #"""
@@ -635,7 +641,7 @@ final class Test_Client: XCTestCase {
                 request.headerFields,
                 [
                     .accept: "application/octet-stream, application/json, text/plain",
-                    .contentType: "application/octet-stream",
+                    .contentType: "application/octet-stream", .contentLength: "4",
                 ]
             )
             try await XCTAssertEqualStringifiedData(requestBody, Data.abcdString)
@@ -662,7 +668,7 @@ final class Test_Client: XCTestCase {
                 request.headerFields,
                 [
                     .accept: "application/octet-stream, application/json, text/plain",
-                    .contentType: "application/octet-stream",
+                    .contentType: "application/octet-stream", .contentLength: "4",
                 ]
             )
             try await XCTAssertEqualStringifiedData(requestBody, Data.abcdString)

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -55,7 +55,7 @@ final class Test_Server: XCTestCase {
             response.headerFields,
             [
                 .init("My-Response-UUID")!: "abcd", .init("My-Tracing-Header")!: "1234",
-                .contentType: "application/json; charset=utf-8",
+                .contentType: "application/json; charset=utf-8", .contentLength: "47",
             ]
         )
         let bodyString: String
@@ -87,7 +87,7 @@ final class Test_Server: XCTestCase {
             .init()
         )
         XCTAssertEqual(response.status.code, 400)
-        XCTAssertEqual(response.headerFields, [.contentType: "application/json; charset=utf-8"])
+        XCTAssertEqual(response.headerFields, [.contentType: "application/json; charset=utf-8", .contentLength: "40"])
         try await XCTAssertEqualStringifiedData(
             responseBody,
             #"""
@@ -131,7 +131,10 @@ final class Test_Server: XCTestCase {
         XCTAssertEqual(response.status.code, 201)
         XCTAssertEqual(
             response.headerFields,
-            [.init("X-Extra-Arguments")!: #"{"code":1}"#, .contentType: "application/json; charset=utf-8"]
+            [
+                .init("X-Extra-Arguments")!: #"{"code":1}"#, .contentType: "application/json; charset=utf-8",
+                .contentLength: "35",
+            ]
         )
         try await XCTAssertEqualStringifiedData(
             responseBody,
@@ -169,7 +172,7 @@ final class Test_Server: XCTestCase {
         XCTAssertEqual(response.status.code, 400)
         XCTAssertEqual(
             response.headerFields,
-            [.init("X-Reason")!: "bad%20luck", .contentType: "application/json; charset=utf-8"]
+            [.init("X-Reason")!: "bad%20luck", .contentType: "application/json; charset=utf-8", .contentLength: "16"]
         )
         try await XCTAssertEqualStringifiedData(
             responseBody,
@@ -270,7 +273,10 @@ final class Test_Server: XCTestCase {
         XCTAssertEqual(response.status.code, 201)
         XCTAssertEqual(
             response.headerFields,
-            [.init("X-Extra-Arguments")!: #"{"code":1}"#, .contentType: "application/json; charset=utf-8"]
+            [
+                .init("X-Extra-Arguments")!: #"{"code":1}"#, .contentType: "application/json; charset=utf-8",
+                .contentLength: "35",
+            ]
         )
         try await XCTAssertEqualStringifiedData(
             responseBody,
@@ -363,7 +369,7 @@ final class Test_Server: XCTestCase {
             .init(pathParameters: ["petId": "1"])
         )
         XCTAssertEqual(response.status.code, 400)
-        XCTAssertEqual(response.headerFields, [.contentType: "application/json; charset=utf-8"])
+        XCTAssertEqual(response.headerFields, [.contentType: "application/json; charset=utf-8", .contentLength: "26"])
         try await XCTAssertEqualStringifiedData(
             responseBody,
             #"""
@@ -386,7 +392,7 @@ final class Test_Server: XCTestCase {
             .init()
         )
         XCTAssertEqual(response.status.code, 200)
-        XCTAssertEqual(response.headerFields, [.contentType: "application/json; charset=utf-8"])
+        XCTAssertEqual(response.headerFields, [.contentType: "application/json; charset=utf-8", .contentLength: "17"])
         try await XCTAssertEqualStringifiedData(
             responseBody,
             #"""
@@ -421,7 +427,7 @@ final class Test_Server: XCTestCase {
             .init()
         )
         XCTAssertEqual(response.status.code, 200)
-        XCTAssertEqual(response.headerFields, [.contentType: "text/plain"])
+        XCTAssertEqual(response.headerFields, [.contentType: "text/plain", .contentLength: "10"])
         try await XCTAssertEqualStringifiedData(
             responseBody,
             #"""
@@ -482,7 +488,7 @@ final class Test_Server: XCTestCase {
             .init()
         )
         XCTAssertEqual(response.status.code, 200)
-        XCTAssertEqual(response.headerFields, [.contentType: "text/plain"])
+        XCTAssertEqual(response.headerFields, [.contentType: "text/plain", .contentLength: "10"])
         try await XCTAssertEqualStringifiedData(
             responseBody,
             #"""
@@ -509,7 +515,7 @@ final class Test_Server: XCTestCase {
             .init()
         )
         XCTAssertEqual(response.status.code, 200)
-        XCTAssertEqual(response.headerFields, [.contentType: "text/plain"])
+        XCTAssertEqual(response.headerFields, [.contentType: "text/plain", .contentLength: "10"])
         try await XCTAssertEqualStringifiedData(
             responseBody,
             #"""
@@ -530,7 +536,7 @@ final class Test_Server: XCTestCase {
             .init()
         )
         XCTAssertEqual(response.status.code, 200)
-        XCTAssertEqual(response.headerFields, [.contentType: "application/octet-stream"])
+        XCTAssertEqual(response.headerFields, [.contentType: "application/octet-stream", .contentLength: "10"])
         try await XCTAssertEqualStringifiedData(
             responseBody,
             #"""
@@ -674,7 +680,7 @@ final class Test_Server: XCTestCase {
             .init(pathParameters: ["petId": "1"])
         )
         XCTAssertEqual(response.status.code, 200)
-        XCTAssertEqual(response.headerFields, [.contentType: "application/octet-stream"])
+        XCTAssertEqual(response.headerFields, [.contentType: "application/octet-stream", .contentLength: "4"])
         try await XCTAssertEqualStringifiedData(responseBody, Data.efghString)
     }
 
@@ -711,7 +717,7 @@ final class Test_Server: XCTestCase {
             .init(pathParameters: ["petId": "1"])
         )
         XCTAssertEqual(response.status.code, 200)
-        XCTAssertEqual(response.headerFields, [.contentType: "application/octet-stream"])
+        XCTAssertEqual(response.headerFields, [.contentType: "application/octet-stream", .contentLength: "4"])
         try await XCTAssertEqualStringifiedData(responseBody, Data.abcdString)
         let sizes = await chunkSizeCollector.sizes
         XCTAssertEqual(sizes, [4])
@@ -736,7 +742,7 @@ final class Test_Server: XCTestCase {
             .init(pathParameters: ["petId": "1"])
         )
         XCTAssertEqual(response.status.code, 412)
-        XCTAssertEqual(response.headerFields, [.contentType: "application/json; charset=utf-8"])
+        XCTAssertEqual(response.headerFields, [.contentType: "application/json; charset=utf-8", .contentLength: "6"])
         try await XCTAssertEqualStringifiedData(responseBody, Data.quotedEfghString)
     }
 
@@ -759,7 +765,7 @@ final class Test_Server: XCTestCase {
             .init(pathParameters: ["petId": "1"])
         )
         XCTAssertEqual(response.status.code, 500)
-        XCTAssertEqual(response.headerFields, [.contentType: "text/plain"])
+        XCTAssertEqual(response.headerFields, [.contentType: "text/plain", .contentLength: "4"])
         try await XCTAssertEqualStringifiedData(responseBody, Data.efghString)
     }
 

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -10,7 +10,8 @@ services:
   test:
     image: *image
     environment:
-      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      # Disable warnings as errors on nightlies as they are still in-development.
+      # - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
   shell:


### PR DESCRIPTION
### Motivation

The runtime library now always includes content-length with bodies, and our tests verified the exact set of header fields present.

### Modifications

Update the expectations to include the content-length header.

### Result

Passing tests again.

### Test Plan

Tests are passing again.
