### PR TITLE
Disable use of auxiliary file to prevent permission error on XcodeCloud

### DIFF
--- a/Sources/swift-openapi-generator/YamlFileDiagnosticsCollector.swift
+++ b/Sources/swift-openapi-generator/YamlFileDiagnosticsCollector.swift
@@ -51,6 +51,6 @@ final class _YamlFileDiagnosticsCollector: DiagnosticCollector, @unchecked Senda
         let encoder = YAMLEncoder()
         encoder.options.sortKeys = true
         let container = _DiagnosticsYamlFileContent(uniqueMessages: uniqueMessages, diagnostics: sortedDiagnostics)
-        try encoder.encode(container).write(to: url, atomically: true, encoding: .utf8)
+        try encoder.encode(container).write(to: url, atomically: false, encoding: .utf8)
     }
 }


### PR DESCRIPTION
### Motivation

- RELATED #246

### Modifications

The implementation of swift-openapi-generator is [try encoder.encode(container).write(to: url, atomically: true, encoding: .utf8)](https://github.com/apple/swift-openapi-generator/blob/6a98026199720b3e23b238248d4444bc065061b2/Sources/swift-openapi-generator/YamlFileDiagnosticsCollector.swift#L54C54-L54C64). if atomically is true, the content is written to an intermediate file and then moved to the outputURL. However, XocdeCloud does not seem to allow writing outside of the pluginWorkDirectory, even for temporary files created by the Foundation framework.

- https://developer.apple.com/documentation/foundation/nsdata/1408033-write

The easiest way to get Build to succeed on Xcode Cloud seems to be to change "atomically" to false.

What do you think about this change?

### Result

Swift Package Manager's Build Tools plug-in works on XcodeCloud

### Test Plan

N/A
