### PR TITLE
Add macCatalyst to the PlatformChecks

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -14,7 +14,7 @@
 
 // Emit a compiler error if this library is linked with a target in an adopter
 // project.
-#if !(os(macOS) || os(Linux))
+#if !(os(macOS) || targetEnvironment(macCatalyst) || os(Linux))
 #error(
     "_OpenAPIGeneratorCore is only to be used by swift-openapi-generator itself—your target should not link this library or the command line tool directly."
 )

--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -14,7 +14,9 @@
 
 // Emit a compiler error if this library is linked with a target in an adopter
 // project.
-#if !(os(macOS) || targetEnvironment(macCatalyst) || os(Linux))
+//
+// When compiling for MacCatalyst, the plugin is (erroneously?) compiled with os(iOS).
+#if !(os(macOS) || os(Linux) || (os(iOS) && targetEnvironment(macCatalyst)))
 #error(
     "_OpenAPIGeneratorCore is only to be used by swift-openapi-generator itself—your target should not link this library or the command line tool directly."
 )


### PR DESCRIPTION
### Motivation

When attempting to compile the Swift OpenAPI Generator on MacCatalyst, code that compiles on iOS will _not_ compile as it will fail on the `PlatformChecks`. 

### Modifications

Added an extra condition in `PlatformChecks` to allow running on MacCatalyst.

### Result

fixes #523

### Test Plan

I've tried to familiarize myself with the project, but could not come up with a good way to add a test for running the tool on MacCatalyst. In my manual testing giving the instructions in the issue, it now works as expected.
