### PR TITLE
[Generator] Add support of deepObject style in query params

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -319,7 +319,6 @@ enum Constants {
 
                 /// The form style.
                 static let form = "form"
-                
                 /// The deepObject style.
                 static let deepObject = "deepObject"
             }

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -319,6 +319,9 @@ enum Constants {
 
                 /// The form style.
                 static let form = "form"
+                
+                /// The deepObject style.
+                static let deepObject = "deepObject"
             }
         }
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/Parameters/TypedParameter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Parameters/TypedParameter.swift
@@ -131,7 +131,9 @@ extension FileTranslator {
             switch location {
             case .query:
                 switch style {
-                case .form, .deepObject:
+                case .form:
+                    break
+                case .deepObject where explode:
                     break
                 default:
                     try diagnostics.emitUnsupported(

--- a/Sources/_OpenAPIGeneratorCore/Translator/Parameters/TypedParameter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Parameters/TypedParameter.swift
@@ -131,10 +131,8 @@ extension FileTranslator {
             switch location {
             case .query:
                 switch style {
-                case .form:
-                    break
-                case .deepObject where explode:
-                    break
+                case .form: break
+                case .deepObject where explode: break
                 default:
                     try diagnostics.emitUnsupported(
                         "Query params of style \(style.rawValue), explode: \(explode)",

--- a/Sources/_OpenAPIGeneratorCore/Translator/Parameters/TypedParameter.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Parameters/TypedParameter.swift
@@ -130,7 +130,10 @@ extension FileTranslator {
             let location = parameter.location
             switch location {
             case .query:
-                guard case .form = style else {
+                switch style {
+                case .form, .deepObject:
+                    break
+                default:
                     try diagnostics.emitUnsupported(
                         "Query params of style \(style.rawValue), explode: \(explode)",
                         foundIn: foundIn
@@ -243,6 +246,7 @@ extension OpenAPI.Parameter.SchemaContext.Style {
     var runtimeName: String {
         switch self {
         case .form: return Constants.Components.Parameters.Style.form
+        case .deepObject: return Constants.Components.Parameters.Style.deepObject
         default: preconditionFailure("Unsupported style")
         }
     }

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -69,6 +69,18 @@ paths:
           schema:
             format: uuid
             type: string
+        - name: sort
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
         - $ref: '#/components/parameters/query.born-since'
       responses:
         '200':

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -76,10 +76,26 @@ paths:
           explode: true
           schema:
             type: object
+            required:
+            - id
             properties:
               id:
                 type: string
               name:
+                type: string
+        - name: filter
+          in: query
+          required: true
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            required:
+            - name
+            properties:
+              name:
+                type: string
+              state:
                 type: string
         - $ref: '#/components/parameters/query.born-since'
       responses:

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -96,6 +96,13 @@ public struct Client: APIProtocol {
                 )
                 try converter.setQueryItemAsURI(
                     in: &request,
+                    style: .deepObject,
+                    explode: true,
+                    name: "filter",
+                    value: input.query.filter
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
                     style: .form,
                     explode: true,
                     name: "since",

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Client.swift
@@ -89,6 +89,13 @@ public struct Client: APIProtocol {
                 )
                 try converter.setQueryItemAsURI(
                     in: &request,
+                    style: .deepObject,
+                    explode: true,
+                    name: "sort",
+                    value: input.query.sort
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
                     style: .form,
                     explode: true,
                     name: "since",

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -192,7 +192,14 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                         style: .deepObject,
                         explode: true,
                         name: "sort",
-                        as: Operations.listPets.Input.Query.sortPayload.self
+                        as: Operations.ListPets.Input.Query.SortPayload.self
+                    ),
+                    filter: try converter.getRequiredQueryItemAsURI(
+                        in: request.soar_query,
+                        style: .deepObject,
+                        explode: true,
+                        name: "filter",
+                        as: Operations.ListPets.Input.Query.FilterPayload.self
                     ),
                     since: try converter.getOptionalQueryItemAsURI(
                         in: request.soar_query,

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Server.swift
@@ -187,6 +187,13 @@ fileprivate extension UniversalServer where APIHandler: APIProtocol {
                         name: "feeds",
                         as: Operations.ListPets.Input.Query.FeedsPayload.self
                     ),
+                    sort: try converter.getOptionalQueryItemAsURI(
+                        in: request.soar_query,
+                        style: .deepObject,
+                        explode: true,
+                        name: "sort",
+                        as: Operations.listPets.Input.Query.sortPayload.self
+                    ),
                     since: try converter.getOptionalQueryItemAsURI(
                         in: request.soar_query,
                         style: .form,

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -1895,6 +1895,31 @@ public enum Operations {
                 public typealias FeedsPayload = [Operations.ListPets.Input.Query.FeedsPayloadPayload]
                 /// - Remark: Generated from `#/paths/pets/GET/query/feeds`.
                 public var feeds: Operations.ListPets.Input.Query.FeedsPayload?
+                /// - Remark: Generated from `#/paths/pets/GET/query/sort`.
+                public struct SortPayload: Codable, Hashable, Sendable {
+                    /// - Remark: Generated from `#/paths/pets/GET/query/sort/id`.
+                    public var id: Swift.String?
+                    /// - Remark: Generated from `#/paths/pets/GET/query/sort/name`.
+                    public var name: Swift.String?
+                    /// Creates a new `sortPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - id:
+                    ///   - name:
+                    public init(
+                        id: Swift.String? = nil,
+                        name: Swift.String? = nil
+                    ) {
+                        self.id = id
+                        self.name = name
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case id
+                        case name
+                    }
+                }
+                /// - Remark: Generated from `#/paths/pets/GET/query/sort`.
+                public var sort: Operations.listPets.Input.Query.SortPayload?
                 /// Supply this parameter to filter pets born since the provided date.
                 ///
                 /// - Remark: Generated from `#/paths/pets/GET/query/since`.
@@ -1905,16 +1930,19 @@ public enum Operations {
                 ///   - limit: How many items to return at one time (max 100)
                 ///   - habitat:
                 ///   - feeds:
+                ///   - sort:
                 ///   - since: Supply this parameter to filter pets born since the provided date.
                 public init(
                     limit: Swift.Int32? = nil,
                     habitat: Operations.ListPets.Input.Query.HabitatPayload? = nil,
                     feeds: Operations.ListPets.Input.Query.FeedsPayload? = nil,
+                    sort: Operations.listPets.Input.Query.SortPayload? = nil,
                     since: Components.Parameters.Query_bornSince? = nil
                 ) {
                     self.limit = limit
                     self.habitat = habitat
                     self.feeds = feeds
+                    self.sort = sort
                     self.since = since
                 }
             }

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -66,7 +66,7 @@ extension APIProtocol {
     /// - Remark: HTTP `GET /pets`.
     /// - Remark: Generated from `#/paths//pets/get(listPets)`.
     public func listPets(
-        query: Operations.ListPets.Input.Query = .init(),
+        query: Operations.ListPets.Input.Query,
         headers: Operations.ListPets.Input.Headers = .init()
     ) async throws -> Operations.ListPets.Output {
         try await listPets(Operations.ListPets.Input(
@@ -1898,16 +1898,16 @@ public enum Operations {
                 /// - Remark: Generated from `#/paths/pets/GET/query/sort`.
                 public struct SortPayload: Codable, Hashable, Sendable {
                     /// - Remark: Generated from `#/paths/pets/GET/query/sort/id`.
-                    public var id: Swift.String?
+                    public var id: Swift.String
                     /// - Remark: Generated from `#/paths/pets/GET/query/sort/name`.
                     public var name: Swift.String?
-                    /// Creates a new `sortPayload`.
+                    /// Creates a new `SortPayload`.
                     ///
                     /// - Parameters:
                     ///   - id:
                     ///   - name:
                     public init(
-                        id: Swift.String? = nil,
+                        id: Swift.String,
                         name: Swift.String? = nil
                     ) {
                         self.id = id
@@ -1919,7 +1919,32 @@ public enum Operations {
                     }
                 }
                 /// - Remark: Generated from `#/paths/pets/GET/query/sort`.
-                public var sort: Operations.listPets.Input.Query.SortPayload?
+                public var sort: Operations.ListPets.Input.Query.SortPayload?
+                /// - Remark: Generated from `#/paths/pets/GET/query/filter`.
+                public struct FilterPayload: Codable, Hashable, Sendable {
+                    /// - Remark: Generated from `#/paths/pets/GET/query/filter/name`.
+                    public var name: Swift.String
+                    /// - Remark: Generated from `#/paths/pets/GET/query/filter/state`.
+                    public var state: Swift.String?
+                    /// Creates a new `FilterPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - name:
+                    ///   - state:
+                    public init(
+                        name: Swift.String,
+                        state: Swift.String? = nil
+                    ) {
+                        self.name = name
+                        self.state = state
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case name
+                        case state
+                    }
+                }
+                /// - Remark: Generated from `#/paths/pets/GET/query/filter`.
+                public var filter: Operations.ListPets.Input.Query.FilterPayload
                 /// Supply this parameter to filter pets born since the provided date.
                 ///
                 /// - Remark: Generated from `#/paths/pets/GET/query/since`.
@@ -1931,18 +1956,21 @@ public enum Operations {
                 ///   - habitat:
                 ///   - feeds:
                 ///   - sort:
+                ///   - filter:
                 ///   - since: Supply this parameter to filter pets born since the provided date.
                 public init(
                     limit: Swift.Int32? = nil,
                     habitat: Operations.ListPets.Input.Query.HabitatPayload? = nil,
                     feeds: Operations.ListPets.Input.Query.FeedsPayload? = nil,
-                    sort: Operations.listPets.Input.Query.SortPayload? = nil,
+                    sort: Operations.ListPets.Input.Query.SortPayload? = nil,
+                    filter: Operations.ListPets.Input.Query.FilterPayload,
                     since: Components.Parameters.Query_bornSince? = nil
                 ) {
                     self.limit = limit
                     self.habitat = habitat
                     self.feeds = feeds
                     self.sort = sort
+                    self.filter = filter
                     self.since = since
                 }
             }
@@ -1974,7 +2002,7 @@ public enum Operations {
             ///   - query:
             ///   - headers:
             public init(
-                query: Operations.ListPets.Input.Query = .init(),
+                query: Operations.ListPets.Input.Query,
                 headers: Operations.ListPets.Input.Headers = .init()
             ) {
                 self.query = query

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -2600,6 +2600,18 @@ final class SnippetBasedReferenceTests: XCTestCase {
                       type: array
                       items:
                         type: string
+                  - name: sort
+                    in: query
+                    required: true
+                    style: deepObject
+                    explode: true
+                    schema:
+                      type: object
+                      properties:
+                        option1:
+                          type: string
+                        option2:
+                          type: string
                 responses:
                   default:
                     description: Response
@@ -2610,18 +2622,36 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         public var single: Swift.String?
                         public var manyExploded: [Swift.String]?
                         public var manyUnexploded: [Swift.String]?
+                        public struct sortPayload: Codable, Hashable, Sendable {
+                            public var option1: Swift.String?
+                            public var option2: Swift.String?
+                            public init(
+                                option1: Swift.String? = nil,
+                                option2: Swift.String? = nil
+                            ) {
+                                self.option1 = option1
+                                self.option2 = option2
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case option1
+                                case option2
+                            }
+                        }
+                        public var sort: Operations.get_sol_foo.Input.Query.sortPayload
                         public init(
                             single: Swift.String? = nil,
                             manyExploded: [Swift.String]? = nil,
-                            manyUnexploded: [Swift.String]? = nil
+                            manyUnexploded: [Swift.String]? = nil,
+                            sort: Operations.get_sol_foo.Input.Query.sortPayload
                         ) {
                             self.single = single
                             self.manyExploded = manyExploded
                             self.manyUnexploded = manyUnexploded
+                            self.sort = sort
                         }
                     }
                     public var query: Operations.get_sol_foo.Input.Query
-                    public init(query: Operations.get_sol_foo.Input.Query = .init()) {
+                    public init(query: Operations.get_sol_foo.Input.Query) {
                         self.query = query
                     }
                 }
@@ -2658,6 +2688,13 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         name: "manyUnexploded",
                         value: input.query.manyUnexploded
                     )
+                    try converter.setQueryItemAsURI(
+                        in: &request,
+                        style: .deepObject,
+                        explode: true,
+                        name: "sort",
+                        value: input.query.sort
+                    )
                     return (request, nil)
                 }
                 """,
@@ -2684,6 +2721,13 @@ final class SnippetBasedReferenceTests: XCTestCase {
                             explode: false,
                             name: "manyUnexploded",
                             as: [Swift.String].self
+                        ),
+                        sort: try converter.getRequiredQueryItemAsURI(
+                            in: request.soar_query,
+                            style: .deepObject,
+                            explode: true,
+                            name: "sort",
+                            as: Operations.get_sol_foo.Input.Query.sortPayload.self
                         )
                     )
                     return Operations.get_sol_foo.Input(query: query)

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -2612,6 +2612,20 @@ final class SnippetBasedReferenceTests: XCTestCase {
                           type: string
                         option2:
                           type: string
+                  - name: filter
+                    in: query
+                    required: true
+                    style: deepObject
+                    explode: true
+                    schema:
+                      type: object
+                      required:
+                        - option3
+                      properties:
+                        option3:
+                          type: string
+                        option4:
+                          type: string
                 responses:
                   default:
                     description: Response
@@ -2637,17 +2651,35 @@ final class SnippetBasedReferenceTests: XCTestCase {
                                 case option2
                             }
                         }
-                        public var sort: Operations.get_sol_foo.Input.Query.sortPayload
+                        public var sort: Operations.get_sol_foo.Input.Query.sortPayload?
+                        public struct filterPayload: Codable, Hashable, Sendable {
+                            public var option3: Swift.String
+                            public var option4: Swift.String?
+                            public init(
+                                option3: Swift.String,
+                                option4: Swift.String? = nil
+                            ) {
+                                self.option3 = option3
+                                self.option4 = option4
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case option3
+                                case option4
+                            }
+                        }
+                        public var filter: Operations.get_sol_foo.Input.Query.filterPayload
                         public init(
                             single: Swift.String? = nil,
                             manyExploded: [Swift.String]? = nil,
                             manyUnexploded: [Swift.String]? = nil,
-                            sort: Operations.get_sol_foo.Input.Query.sortPayload
+                            sort: Operations.get_sol_foo.Input.Query.sortPayload? = nil,
+                            filter: Operations.get_sol_foo.Input.Query.filterPayload
                         ) {
                             self.single = single
                             self.manyExploded = manyExploded
                             self.manyUnexploded = manyUnexploded
                             self.sort = sort
+                            self.filter = filter
                         }
                     }
                     public var query: Operations.get_sol_foo.Input.Query
@@ -2695,6 +2727,13 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         name: "sort",
                         value: input.query.sort
                     )
+                    try converter.setQueryItemAsURI(
+                        in: &request,
+                        style: .deepObject,
+                        explode: true,
+                        name: "filter",
+                        value: input.query.filter
+                    )
                     return (request, nil)
                 }
                 """,
@@ -2722,12 +2761,19 @@ final class SnippetBasedReferenceTests: XCTestCase {
                             name: "manyUnexploded",
                             as: [Swift.String].self
                         ),
-                        sort: try converter.getRequiredQueryItemAsURI(
+                        sort: try converter.getOptionalQueryItemAsURI(
                             in: request.soar_query,
                             style: .deepObject,
                             explode: true,
                             name: "sort",
                             as: Operations.get_sol_foo.Input.Query.sortPayload.self
+                        ),
+                        filter: try converter.getRequiredQueryItemAsURI(
+                            in: request.soar_query,
+                            style: .deepObject,
+                            explode: true,
+                            name: "filter",
+                            as: Operations.get_sol_foo.Input.Query.filterPayload.self
                         )
                     )
                     return Operations.get_sol_foo.Input(query: query)

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -2602,7 +2602,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         type: string
                   - name: sort
                     in: query
-                    required: true
+                    required: false
                     style: deepObject
                     explode: true
                     schema:

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -66,7 +66,13 @@ final class Test_Client: XCTestCase {
         }
         let response = try await client.listPets(
             .init(
-                query: .init(limit: 24, habitat: .water, feeds: [.herbivore, .carnivore], sort: .init(id: "ascending", name: "descending"), since: .test),
+                query: .init(
+                    limit: 24,
+                    habitat: .water,
+                    feeds: [.herbivore, .carnivore],
+                    sort: .init(id: "ascending", name: "descending"),
+                    since: .test
+                ),
                 headers: .init(myRequestUUID: "abcd-1234")
             )
         )

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -40,7 +40,7 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(operationID, "listPets")
             XCTAssertEqual(
                 request.path,
-                "/pets?limit=24&habitat=water&feeds=herbivore&feeds=carnivore&sort%5Bid%5D=ascending&sort%5Bname%5D=descending&since=2023-01-18T10%3A04%3A11Z"
+                "/pets?limit=24&habitat=water&feeds=herbivore&feeds=carnivore&sort%5Bid%5D=ascending&sort%5Bname%5D=descending&filter%5Bname%5D=whale&since=2023-01-18T10%3A04%3A11Z"
             )
             XCTAssertEqual(baseURL.absoluteString, "/api")
             XCTAssertEqual(request.method, .get)
@@ -71,6 +71,7 @@ final class Test_Client: XCTestCase {
                     habitat: .water,
                     feeds: [.herbivore, .carnivore],
                     sort: .init(id: "ascending", name: "descending"),
+                    filter: .init(name: "whale"),
                     since: .test
                 ),
                 headers: .init(myRequestUUID: "abcd-1234")
@@ -90,7 +91,7 @@ final class Test_Client: XCTestCase {
     func testListPets_default() async throws {
         transport = .init { request, body, baseURL, operationID in
             XCTAssertEqual(operationID, "listPets")
-            XCTAssertEqual(request.path, "/pets?limit=24")
+            XCTAssertEqual(request.path, "/pets?limit=24&filter%5Bname%5D=whale")
             XCTAssertEqual(baseURL.absoluteString, "/api")
             XCTAssertEqual(request.method, .get)
             XCTAssertEqual(request.headerFields, [.accept: "application/json"])
@@ -106,7 +107,7 @@ final class Test_Client: XCTestCase {
                     """#
                 )
         }
-        let response = try await client.listPets(.init(query: .init(limit: 24)))
+        let response = try await client.listPets(.init(query: .init(limit: 24, filter: .init(name: "whale"))))
         guard case let .default(statusCode, value) = response else {
             XCTFail("Unexpected response: \(response)")
             return

--- a/Tests/PetstoreConsumerTests/Test_Client.swift
+++ b/Tests/PetstoreConsumerTests/Test_Client.swift
@@ -40,7 +40,7 @@ final class Test_Client: XCTestCase {
             XCTAssertEqual(operationID, "listPets")
             XCTAssertEqual(
                 request.path,
-                "/pets?limit=24&habitat=water&feeds=herbivore&feeds=carnivore&since=2023-01-18T10%3A04%3A11Z"
+                "/pets?limit=24&habitat=water&feeds=herbivore&feeds=carnivore&sort%5Bid%5D=ascending&sort%5Bname%5D=descending&since=2023-01-18T10%3A04%3A11Z"
             )
             XCTAssertEqual(baseURL.absoluteString, "/api")
             XCTAssertEqual(request.method, .get)
@@ -66,7 +66,7 @@ final class Test_Client: XCTestCase {
         }
         let response = try await client.listPets(
             .init(
-                query: .init(limit: 24, habitat: .water, feeds: [.herbivore, .carnivore], since: .test),
+                query: .init(limit: 24, habitat: .water, feeds: [.herbivore, .carnivore], sort: .init(id: "ascending", name: "descending"), since: .test),
                 headers: .init(myRequestUUID: "abcd-1234")
             )
         )

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -44,7 +44,8 @@ final class Test_Server: XCTestCase {
         })
         let (response, responseBody) = try await server.listPets(
             .init(
-                soar_path: "/api/pets?limit=24&habitat=water&feeds=carnivore&feeds=herbivore&sort%5Bid%5D=ascending&sort%5Bname%5D=descending&since=\(Date.testString)",
+                soar_path:
+                    "/api/pets?limit=24&habitat=water&feeds=carnivore&feeds=herbivore&sort%5Bid%5D=ascending&sort%5Bname%5D=descending&since=\(Date.testString)",
                 method: .get,
                 headerFields: [.init("My-Request-UUID")!: "abcd-1234"]
             ),

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -33,6 +33,7 @@ final class Test_Server: XCTestCase {
             XCTAssertEqual(input.query.habitat, .water)
             XCTAssertEqual(input.query.since, .test)
             XCTAssertEqual(input.query.feeds, [.carnivore, .herbivore])
+            XCTAssertEqual(input.query.sort, .init(id: "ascending", name: "descending"))
             XCTAssertEqual(input.headers.myRequestUUID, "abcd-1234")
             return .ok(
                 .init(
@@ -43,7 +44,7 @@ final class Test_Server: XCTestCase {
         })
         let (response, responseBody) = try await server.listPets(
             .init(
-                soar_path: "/api/pets?limit=24&habitat=water&feeds=carnivore&feeds=herbivore&since=\(Date.testString)",
+                soar_path: "/api/pets?sort%5Bid%5D=ascending&sort%5Bname%5D=descending",
                 method: .get,
                 headerFields: [.init("My-Request-UUID")!: "abcd-1234"]
             ),

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -44,7 +44,7 @@ final class Test_Server: XCTestCase {
         })
         let (response, responseBody) = try await server.listPets(
             .init(
-                soar_path: "/api/pets?sort%5Bid%5D=ascending&sort%5Bname%5D=descending",
+                soar_path: "/api/pets?limit=24&habitat=water&feeds=carnivore&feeds=herbivore&sort%5Bid%5D=ascending&sort%5Bname%5D=descending&since=\(Date.testString)",
                 method: .get,
                 headerFields: [.init("My-Request-UUID")!: "abcd-1234"]
             ),

--- a/Tests/PetstoreConsumerTests/Test_Server.swift
+++ b/Tests/PetstoreConsumerTests/Test_Server.swift
@@ -45,7 +45,7 @@ final class Test_Server: XCTestCase {
         let (response, responseBody) = try await server.listPets(
             .init(
                 soar_path:
-                    "/api/pets?limit=24&habitat=water&feeds=carnivore&feeds=herbivore&sort%5Bid%5D=ascending&sort%5Bname%5D=descending&since=\(Date.testString)",
+                    "/api/pets?limit=24&habitat=water&feeds=carnivore&feeds=herbivore&sort%5Bid%5D=ascending&sort%5Bname%5D=descending&filter%5Bname%5D=whale&since=\(Date.testString)",
                 method: .get,
                 headerFields: [.init("My-Request-UUID")!: "abcd-1234"]
             ),
@@ -84,7 +84,7 @@ final class Test_Server: XCTestCase {
             .default(statusCode: 400, .init(body: .json(.init(code: 1, me_dollar_sage: "Oh no!"))))
         })
         let (response, responseBody) = try await server.listPets(
-            .init(soar_path: "/api/pets", method: .get),
+            .init(soar_path: "/api/pets?filter%5Bname%5D=whale", method: .get),
             nil,
             .init()
         )


### PR DESCRIPTION
### Motivation

The generator changes for: 
[apple/swift-openapi-generator](https://github.com/apple/swift-openapi-generator/issues/259)

Depends on https://github.com/apple/swift-openapi-runtime/pull/100 
landing first and getting released, and the version dependency being bumped here.

### Modifications

Added `deepObject` style to serializer & parser in order to support nested keys on query parameters.

### Result

Support nested keys on query parameters.

### Test Plan

Adapted snippet tests (SnippetBasedReferenceTests)