### PR TITLE
[Docs] Add a link to the Lambda transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The Swift OpenAPI Generator project is split across multiple repositories to ena
 | [swift-server/swift-openapi-async-http-client][repo-ahc]   | `ClientTransport` using [AsyncHTTPClient][ahc]     |
 | [swift-server/swift-openapi-vapor][repo-vapor]             | `ServerTransport` using [Vapor][vapor]             |
 | [swift-server/swift-openapi-hummingbird][repo-hummingbird] | `ServerTransport` using [Hummingbird][hummingbird] |
-
+| [swift-server/swift-openapi-lambda][repo-lambda]           | `ServerTransport` using [AWS Lambda][lambda]       |
 
 ## Requirements and supported features
 
@@ -135,6 +135,8 @@ Generator](https://developer.apple.com/wwdc23/10171) from WWDC23.
 [vapor]: https://github.com/vapor/vapor
 [repo-hummingbird]: https://github.com/swift-server/swift-openapi-hummingbird
 [hummingbird]: https://github.com/hummingbird-project/hummingbird
+[repo-lambda]: https://github.com/swift-server/swift-openapi-lambda
+[lambda]: https://docs.aws.amazon.com/lambda/latest/dg/welcome.html
 [^example-openapi-yaml]: <details><summary>Example OpenAPI document (click to expand)</summary>
 
     ```yaml

--- a/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
@@ -86,6 +86,7 @@ The Swift OpenAPI Generator project is split across multiple repositories to ena
 | [swift-server/swift-openapi-async-http-client][repo-ahc]   | `ClientTransport` using [AsyncHTTPClient][ahc]     |
 | [swift-server/swift-openapi-vapor][repo-vapor]             | `ServerTransport` using [Vapor][vapor]             |
 | [swift-server/swift-openapi-hummingbird][repo-hummingbird] | `ServerTransport` using [Hummingbird][hummingbird] |
+| [swift-server/swift-openapi-lambda][repo-lambda]           | `ServerTransport` using [AWS Lambda][lambda]       |
 
 ### Requirements and supported features
 
@@ -198,3 +199,5 @@ components:
 [vapor]: https://github.com/vapor/vapor
 [repo-hummingbird]: https://github.com/swift-server/swift-openapi-hummingbird
 [hummingbird]: https://github.com/hummingbird-project/hummingbird
+[repo-lambda]: https://github.com/swift-server/swift-openapi-lambda
+[lambda]: https://docs.aws.amazon.com/lambda/latest/dg/welcome.html


### PR DESCRIPTION
### Motivation

Showcase the new Lambda transport.

### Modifications

Link to the swift-server/swift-openapi-lambda transport repo.

### Result

Easier to find that transport.

### Test Plan

Previewed locally.
