### PR TITLE
Add test for OperationDescription.responseOutcomes

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -312,7 +312,7 @@ extension OperationDescription {
         var outcomes = operation.responseOutcomes
         // if .default is present and not already last
         if let index = outcomes.firstIndex(where: { $0.status == .default }), index != (outcomes.count - 1) {
-            //then we move it to be last
+            // then we move it to be last
             let defaultResp = outcomes.remove(at: index)
             outcomes.append(defaultResp)
         }


### PR DESCRIPTION
### Motivation

I couldn't reproduce the issue #530 on my end.
However, I noticed that there were no tests, so I would like to add them.

### Modifications

Adding tests.

### Result

Only adding tests, no change in the behavior of the library.

### Test Plan

Added tests are passing.
