### PR TITLE
Support `type: 'null'` as OpenAPIValueContainer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
 
         // Read OpenAPI documents
         .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "3.1.2"),
-        .package(url: "https://github.com/jpsim/Yams", "4.0.0"..<"6.0.0"),
+        .package(url: "https://github.com/jpsim/Yams", "5.1.0"..<"6.0.0"),
 
         // CLI Tool
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeMatcher.swift
@@ -289,6 +289,7 @@ struct TypeMatcher {
     private static func _tryMatchBuiltinNonRecursive(for schema: JSONSchema.Schema) -> TypeUsage? {
         let typeName: TypeName
         switch schema {
+        case .null(_): typeName = TypeName.valueContainer
         case .boolean(_): typeName = .swift("Bool")
         case .number(let core, _):
             switch core.format {
@@ -331,7 +332,7 @@ struct TypeMatcher {
             // arrays are already recursed-into by _tryMatchTypeRecursive
             // so just return nil here
             return nil
-        case .reference, .not, .all, .any, .one, .null:
+        case .reference, .not, .all, .any, .one:
             // never built-in
             return nil
         }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
@@ -132,7 +132,7 @@ extension FileTranslator {
     func isSchemaSupported(_ schema: JSONSchema, referenceStack: inout ReferenceStack) throws -> IsSchemaSupportedResult
     {
         switch schema.value {
-        case .string, .integer, .number, .boolean,
+        case .null, .string, .integer, .number, .boolean,
             // We mark any object as supported, even if it
             // has unsupported properties.
             // The code responsible for emitting an object is
@@ -173,7 +173,7 @@ extension FileTranslator {
                 schemas.filter(\.isReference),
                 referenceStack: &referenceStack
             )
-        case .not, .null: return .unsupported(reason: .schemaType, schema: schema)
+        case .not: return .unsupported(reason: .schemaType, schema: schema)
         }
     }
 

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -224,6 +224,25 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testComponentsSchemasNull() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              Null:
+                type: "null"
+              NullArray:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Null"
+            """,
+            """
+            public enum Schemas {
+                public typealias Null = OpenAPIRuntime.OpenAPIValueContainer
+                public typealias NullArray = [Components.Schemas.Null]
+            }
+            """)
+    }
+
     func testComponentsSchemasNullableStringProperty() throws {
         try self.assertSchemasTranslation(
             """


### PR DESCRIPTION
### Motivation

OpenAPIKit's handling of `type: 'null'` was problematic with older Yams versions. See https://github.com/mattpolzin/OpenAPIKit/pull/366/files for a test demonstrating that & dependency version bump.

Similarly, swift-openapi-generator explicitly does not "support" `type: 'null'`. As part of searching for something to address https://github.com/apple/swift-openapi-generator/issues/513 I have added such support for explicit nulls. This gives one more sort of input schema where swift-openapi-generator produces some useful output instead of skipping a schema.

### Modifications

- Bumped minimum supported Yams version.
- Return`true` from `isSchemaSupported` for `type: 'null'` schemas.
- Defined `.null` to have a builtint ype of `OpenAPIValueContainer`

### Result

Nothing should change for existing users because `type: null` schemas were previously unsupported. Going forward, usages of these schemas is supported.

### Test Plan

New test included.