### PR TITLE
Add CaseIterable conformance for string, int enums

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -146,7 +146,7 @@ enum Constants {
         static let baseConformanceInteger: String = "Int"
 
         /// The types that every enum conforms to.
-        static let conformances: [String] = ["Codable", "Hashable", "Sendable"]
+        static let conformances: [String] = ["Codable", "Hashable", "Sendable", "CaseIterable"]
     }
 
     /// Constants related to generated oneOf enums.

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -405,7 +405,7 @@ public enum Components {
         /// Kind of pet
         ///
         /// - Remark: Generated from `#/components/schemas/PetKind`.
-        @frozen public enum PetKind: String, Codable, Hashable, Sendable {
+        @frozen public enum PetKind: String, Codable, Hashable, Sendable, CaseIterable {
             case cat = "cat"
             case dog = "dog"
             case ELEPHANT = "ELEPHANT"
@@ -492,7 +492,7 @@ public enum Components {
         /// - Remark: Generated from `#/components/schemas/PetFeeding`.
         public struct PetFeeding: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/PetFeeding/schedule`.
-            @frozen public enum schedulePayload: String, Codable, Hashable, Sendable {
+            @frozen public enum schedulePayload: String, Codable, Hashable, Sendable, CaseIterable {
                 case hourly = "hourly"
                 case daily = "daily"
                 case weekly = "weekly"
@@ -1491,7 +1491,7 @@ public enum Components {
                     /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log/headers`.
                     public struct Headers: Sendable, Hashable {
                         /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log/headers/x-log-type`.
-                        @frozen public enum x_hyphen_log_hyphen_typePayload: String, Codable, Hashable, Sendable {
+                        @frozen public enum x_hyphen_log_hyphen_typePayload: String, Codable, Hashable, Sendable, CaseIterable {
                             case structured = "structured"
                             case unstructured = "unstructured"
                         }
@@ -1645,7 +1645,7 @@ public enum Components {
                         /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log/headers`.
                         public struct Headers: Sendable, Hashable {
                             /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log/headers/x-log-type`.
-                            @frozen public enum x_hyphen_log_hyphen_typePayload: String, Codable, Hashable, Sendable {
+                            @frozen public enum x_hyphen_log_hyphen_typePayload: String, Codable, Hashable, Sendable, CaseIterable {
                                 case structured = "structured"
                                 case unstructured = "unstructured"
                             }
@@ -1773,7 +1773,7 @@ public enum Operations {
                 /// - Remark: Generated from `#/paths/pets/GET/query/limit`.
                 public var limit: Swift.Int32?
                 /// - Remark: Generated from `#/paths/pets/GET/query/habitat`.
-                @frozen public enum habitatPayload: String, Codable, Hashable, Sendable {
+                @frozen public enum habitatPayload: String, Codable, Hashable, Sendable, CaseIterable {
                     case water = "water"
                     case land = "land"
                     case air = "air"
@@ -1782,7 +1782,7 @@ public enum Operations {
                 /// - Remark: Generated from `#/paths/pets/GET/query/habitat`.
                 public var habitat: Operations.listPets.Input.Query.habitatPayload?
                 /// - Remark: Generated from `#/paths/pets/GET/query/feedsPayload`.
-                @frozen public enum feedsPayloadPayload: String, Codable, Hashable, Sendable {
+                @frozen public enum feedsPayloadPayload: String, Codable, Hashable, Sendable, CaseIterable {
                     case omnivore = "omnivore"
                     case carnivore = "carnivore"
                     case herbivore = "herbivore"

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1189,7 +1189,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Schemas {
-                @frozen public enum MyEnum: String, Codable, Hashable, Sendable {
+                @frozen public enum MyEnum: String, Codable, Hashable, Sendable, CaseIterable {
                     case one = "one"
                     case _empty = ""
                     case _dollar_tart = "$tart"
@@ -1213,7 +1213,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """,
             """
             public enum Schemas {
-                @frozen public enum MyEnum: Int, Codable, Hashable, Sendable {
+                @frozen public enum MyEnum: Int, Codable, Hashable, Sendable, CaseIterable {
                     case _0 = 0
                     case _10 = 10
                     case _20 = 20
@@ -1238,7 +1238,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             """
             public enum Schemas {
                 public struct MyOpenEnum: Codable, Hashable, Sendable {
-                    @frozen public enum Value1Payload: String, Codable, Hashable, Sendable {
+                    @frozen public enum Value1Payload: String, Codable, Hashable, Sendable, CaseIterable {
                         case one = "one"
                         case two = "two"
                     }
@@ -1928,7 +1928,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
             public enum Responses {
                 public struct BadRequest: Sendable, Hashable {
                     public struct Headers: Sendable, Hashable {
-                        @frozen public enum X_hyphen_ReasonPayload: String, Codable, Hashable, Sendable {
+                        @frozen public enum X_hyphen_ReasonPayload: String, Codable, Hashable, Sendable, CaseIterable {
                             case badLuck = "badLuck"
                         }
                         public var X_hyphen_Reason: Components.Responses.BadRequest.Headers.X_hyphen_ReasonPayload?
@@ -2118,7 +2118,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     @frozen public enum multipartFormPayload: Sendable, Hashable {
                         public struct logPayload: Sendable, Hashable {
                             public struct Headers: Sendable, Hashable {
-                                @frozen public enum x_hyphen_log_hyphen_typePayload: String, Codable, Hashable, Sendable {
+                                @frozen public enum x_hyphen_log_hyphen_typePayload: String, Codable, Hashable, Sendable, CaseIterable {
                                     case structured = "structured"
                                     case unstructured = "unstructured"
                                 }


### PR DESCRIPTION
### Motivation

- Fixes - #548.

### Modifications

- Add another value in `conformances` array.

### Result

- `String` and `Int` generated enums will conform by default to `CaseIterable` protocol.

### Test Plan

- Adjust `OpenAPIGeneratorReferenceTests`.