### PR TITLE
Bidirectional stream events

### DIFF
--- a/Examples/bidirectional-event-streams-client-example/.gitignore
+++ b/Examples/bidirectional-event-streams-client-example/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.vscode
+/Package.resolved
+.ci/
+.docc-build/

--- a/Examples/bidirectional-event-streams-client-example/Package.swift
+++ b/Examples/bidirectional-event-streams-client-example/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.9
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import PackageDescription
+
+let package = Package(
+    name: "event-streams-client-example",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0"),
+//        .package(url: "https://github.com/swift-server/swift-openapi-async-http-client", from: "1.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "BidirectionalEventStreamsClient",
+            dependencies: [
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
+//                .product(name: "OpenAPIAsyncHTTPClient", package: "swift-openapi-async-http-client"),
+            ],
+            plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
+        )
+    ]
+)

--- a/Examples/bidirectional-event-streams-client-example/Package.swift
+++ b/Examples/bidirectional-event-streams-client-example/Package.swift
@@ -20,16 +20,14 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.2.0"),
-        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0"),
-//        .package(url: "https://github.com/swift-server/swift-openapi-async-http-client", from: "1.0.0"),
+        .package(url: "https://github.com/swift-server/swift-openapi-async-http-client", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(
             name: "BidirectionalEventStreamsClient",
             dependencies: [
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
-//                .product(name: "OpenAPIAsyncHTTPClient", package: "swift-openapi-async-http-client"),
+                .product(name: "OpenAPIAsyncHTTPClient", package: "swift-openapi-async-http-client"),
             ],
             plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
         )

--- a/Examples/bidirectional-event-streams-client-example/README.md
+++ b/Examples/bidirectional-event-streams-client-example/README.md
@@ -1,0 +1,21 @@
+# Client handling bidirectional event streams
+
+An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
+
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
+## Overview
+
+A command-line tool that uses a generated client to show how to work with bidirectional event streams.
+
+The tool uses the [URLSession](https://developer.apple.com/documentation/foundation/urlsession) API to perform the HTTP call, wrapped in the [Swift OpenAPI URLSession Transport](https://github.com/apple/swift-openapi-urlsession).
+
+The server can be started by running `bidirectional-event-streams-server-example` locally.
+
+## Usage
+
+Build and run the client CLI using:
+
+```console
+% swift run
+```

--- a/Examples/bidirectional-event-streams-client-example/README.md
+++ b/Examples/bidirectional-event-streams-client-example/README.md
@@ -8,7 +8,7 @@ An example project using [Swift OpenAPI Generator](https://github.com/apple/swif
 
 A command-line tool that uses a generated client to show how to work with bidirectional event streams.
 
-The tool uses the [URLSession](https://developer.apple.com/documentation/foundation/urlsession) API to perform the HTTP call, wrapped in the [Swift OpenAPI URLSession Transport](https://github.com/apple/swift-openapi-urlsession).
+Instead of [URLSession](https://developer.apple.com/documentation/foundation/urlsession), which will return stream only until at least “some” bytes of the body have also been received, tool uses the [AsyncHTTPClient](https://github.com/swift-server/async-http-client) API to perform the HTTP call, wrapped in the [AsyncHTTPClient Transport for Swift OpenAPI Generator](https://github.com/swift-server/swift-openapi-async-http-client). A workaround for URLSession could be sending an `empty` or hearbeat message from server first when initialising a stream.
 
 The server can be started by running `bidirectional-event-streams-server-example` locally.
 
@@ -18,4 +18,6 @@ Build and run the client CLI using:
 
 ```console
 % swift run
+Sending and fetching back greetings using JSON Lines
+...
 ```

--- a/Examples/bidirectional-event-streams-client-example/README.md
+++ b/Examples/bidirectional-event-streams-client-example/README.md
@@ -8,7 +8,7 @@ An example project using [Swift OpenAPI Generator](https://github.com/apple/swif
 
 A command-line tool that uses a generated client to show how to work with bidirectional event streams.
 
-Instead of [URLSession](https://developer.apple.com/documentation/foundation/urlsession), which will return stream only until at least “some” bytes of the body have also been received, tool uses the [AsyncHTTPClient](https://github.com/swift-server/async-http-client) API to perform the HTTP call, wrapped in the [AsyncHTTPClient Transport for Swift OpenAPI Generator](https://github.com/swift-server/swift-openapi-async-http-client). A workaround for URLSession could be sending an `empty` or hearbeat message from server first when initialising a stream.
+Instead of [URLSession](https://developer.apple.com/documentation/foundation/urlsession), which will return stream only until at least “some” bytes of the body have also been received (see [comment](https://github.com/apple/swift-openapi-urlsession/blob/main/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/URLSessionBidirectionalStreamingTests.swift#L193-L206)), tool uses the [AsyncHTTPClient](https://github.com/swift-server/async-http-client) API to perform the HTTP call, wrapped in the [AsyncHTTPClient Transport for Swift OpenAPI Generator](https://github.com/swift-server/swift-openapi-async-http-client). A workaround for URLSession could be sending an `empty` or hearbeat message from server first when initialising a stream.
 
 The server can be started by running `bidirectional-event-streams-server-example` locally.
 

--- a/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/BidirectionalEventStreamsClient.swift
+++ b/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/BidirectionalEventStreamsClient.swift
@@ -12,8 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import OpenAPIRuntime
-import OpenAPIURLSession
-//import OpenAPIAsyncHTTPClient
+import OpenAPIAsyncHTTPClient
 import Foundation
 
 @main
@@ -32,7 +31,7 @@ struct BidirectionalEventStreamsClient {
     static func main() async throws {
         let client = Client(
             serverURL: URL(string: "http://localhost:8080/api")!,
-            transport: URLSessionTransport()
+            transport: AsyncHTTPClientTransport()
         )
         do {
             print("Sending and fetching back greetings using JSON Lines")

--- a/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/BidirectionalEventStreamsClient.swift
+++ b/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/BidirectionalEventStreamsClient.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIRuntime
+import OpenAPIURLSession
+//import OpenAPIAsyncHTTPClient
+import Foundation
+
+@main
+struct BidirectionalEventStreamsClient {
+    
+    private static let templates: [String] = [
+        "Hello, %@!",
+        "Good morning, %@!",
+        "Hi, %@!",
+        "Greetings, %@!",
+        "Hey, %@!",
+        "Hi there, %@!",
+        "Good evening, %@!",
+    ]
+    
+    static func main() async throws {
+        let client = Client(
+            serverURL: URL(string: "http://localhost:8080/api")!,
+            transport: URLSessionTransport()
+        )
+        do {
+            print("Sending and fetching back greetings using JSON Lines")
+            let (stream, continuation) = AsyncStream<Components.Schemas.Greeting>.makeStream()
+            let requestBody: Operations.getGreetingsStream.Input.Body = .application_jsonl(
+              .init(
+                stream.asEncodedJSONLines(),
+                length: .unknown,
+                iterationBehavior: .single
+              )
+            )
+            let response = try await client.getGreetingsStream(
+                query: .init(name: "Example"),
+                body: requestBody
+            )
+            let greetingStream = try response.ok.body.application_jsonl.asDecodedJSONLines(
+                of: Components.Schemas.Greeting.self
+            )
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Listen for upcoming messages
+                group.addTask {
+                    for try await greeting in greetingStream {
+                        try Task.checkCancellation()
+                        print("Got greeting: \(greeting.message)")
+                    }
+                }
+                // Send messages
+                group.addTask {
+                    for template in Self.templates {
+                        try Task.checkCancellation()
+                        continuation.yield(.init(message: template))
+                        try await Task.sleep(nanoseconds: 1 * 1_000_000_000)
+                    }
+                    continuation.finish()
+                }
+                return try await group.waitForAll()
+            }
+        }
+    }
+}

--- a/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/BidirectionalEventStreamsClient.swift
+++ b/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/BidirectionalEventStreamsClient.swift
@@ -36,6 +36,8 @@ struct BidirectionalEventStreamsClient {
         do {
             print("Sending and fetching back greetings using JSON Lines")
             let (stream, continuation) = AsyncStream<Components.Schemas.Greeting>.makeStream()
+            /// To keep it simple, using JSON Lines, as it most straightforward and easy way to have streams.
+            /// For SSE and JSON Sequences cases please check `event-streams-client-example`.
             let requestBody: Operations.getGreetingsStream.Input.Body = .application_jsonl(
               .init(
                 stream.asEncodedJSONLines(),

--- a/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/openapi-generator-config.yaml
+++ b/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/openapi-generator-config.yaml
@@ -1,0 +1,4 @@
+generate:
+  - types
+  - client
+accessModifier: internal

--- a/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/openapi.yaml
+++ b/Examples/bidirectional-event-streams-client-example/Sources/BidirectionalEventStreamsClient/openapi.yaml
@@ -1,0 +1,39 @@
+openapi: '3.1.0'
+info:
+  title: EventStreamsService
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+    description: Example service deployment.
+paths:
+  /greetings:
+    post:
+      operationId: getGreetingsStream
+      parameters:
+        - name: name
+          required: false
+          in: query
+          description: The name used in the returned greeting.
+          schema:
+            type: string
+      requestBody:
+        description: A body with a greetings stream.
+        required: true
+        content:
+          application/jsonl: {}
+      responses:
+        '200':
+          description: A success response with a greetings stream.
+          content:
+            application/jsonl: {}
+components:
+  schemas:
+    Greeting:
+      type: object
+      description: A value with the greeting contents.
+      properties:
+        message:
+          type: string
+          description: The string representation of the greeting.
+      required:
+        - message

--- a/Examples/bidirectional-event-streams-server-example/.gitignore
+++ b/Examples/bidirectional-event-streams-server-example/.gitignore
@@ -1,0 +1,12 @@
+.DS_Store
+.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.vscode
+/Package.resolved
+.ci/
+.docc-build/
+

--- a/Examples/bidirectional-event-streams-server-example/Package.swift
+++ b/Examples/bidirectional-event-streams-server-example/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version:5.9
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import PackageDescription
+
+let package = Package(
+    name: "bidirectional-event-streams-server-example",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.2.0"),
+        // Hummingbird
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0-rc.1"),
+        .package(url: "https://github.com/swift-server/swift-openapi-hummingbird.git", from: "2.0.0-beta.4"),
+//        .package(url: "https://github.com/swift-server/swift-openapi-vapor", from: "1.0.0"),
+//        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "BidirectionalEventStreamsServer",
+            dependencies: [
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "OpenAPIHummingbird", package: "swift-openapi-hummingbird"),
+                .product(name: "Hummingbird", package: "hummingbird"),
+//                .product(name: "Vapor", package: "vapor"),
+            ],
+            plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
+        )
+    ]
+)

--- a/Examples/bidirectional-event-streams-server-example/README.md
+++ b/Examples/bidirectional-event-streams-server-example/README.md
@@ -1,0 +1,23 @@
+# Server supporting bidirectional event streams
+
+An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
+
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
+## Overview
+
+A server that uses generated server stubs to show how to work with bidirectional event streams.
+
+The tool uses the [Vapor](https://github.com/vapor/vapor) server framework to handle HTTP requests, wrapped in the [Swift OpenAPI Vapor Transport](https://github.com/swift-server/swift-openapi-vapor).
+
+The CLI starts the server on `http://localhost:8080` and can be invoked by running `bidirectional-event-streams-client-example`.
+
+## Usage
+
+Build and run the server CLI using:
+
+```console
+% swift run
+2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
+...
+```

--- a/Examples/bidirectional-event-streams-server-example/README.md
+++ b/Examples/bidirectional-event-streams-server-example/README.md
@@ -18,6 +18,6 @@ Build and run the server CLI using:
 
 ```console
 % swift run
-2023-12-01T14:14:35+0100 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
+2024-07-04T08:56:23+0200 info Hummingbird : [HummingbirdCore] Server started and listening on 127.0.0.1:8080
 ...
 ```

--- a/Examples/bidirectional-event-streams-server-example/README.md
+++ b/Examples/bidirectional-event-streams-server-example/README.md
@@ -8,7 +8,7 @@ An example project using [Swift OpenAPI Generator](https://github.com/apple/swif
 
 A server that uses generated server stubs to show how to work with bidirectional event streams.
 
-The tool uses the [Vapor](https://github.com/vapor/vapor) server framework to handle HTTP requests, wrapped in the [Swift OpenAPI Vapor Transport](https://github.com/swift-server/swift-openapi-vapor).
+The tool uses the [Hummingbird](https://github.com/hummingbird-project/hummingbird) server framework to handle HTTP requests, wrapped in the [Swift OpenAPI Hummingbird](https://github.com/swift-server/swift-openapi-hummingbird).
 
 The CLI starts the server on `http://localhost:8080` and can be invoked by running `bidirectional-event-streams-client-example`.
 

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/BidirectionalEventStreamsServer.swift
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/BidirectionalEventStreamsServer.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIRuntime
+import OpenAPIHummingbird
+import Hummingbird
+import Foundation
+
+struct Handler: APIProtocol {
+    
+    private let storage: StreamStorage = .init()
+    
+    func getGreetingsStream(_ input: Operations.getGreetingsStream.Input) async throws -> Operations.getGreetingsStream.Output {
+        let eventStream = await self.storage.makeStream(input: input)
+        let responseBody = Operations.getGreetingsStream.Output.Ok.Body.application_jsonl(
+            .init(eventStream.asEncodedJSONLines(), length: .unknown, iterationBehavior: .single)
+        )
+        return .ok(.init(body: responseBody))
+    }
+    
+}
+
+@main
+struct BidirectionalEventStreamsServer {
+    static func main() async throws {
+        let router = Router()
+        let handler = Handler()
+        try handler.registerHandlers(on: router, serverURL: URL(string: "/api")!)
+        let app = Application(router: router, configuration: .init())
+        try await app.run()
+    }
+}

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/BidirectionalEventStreamsServer.swift
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/BidirectionalEventStreamsServer.swift
@@ -22,6 +22,8 @@ struct Handler: APIProtocol {
     
     func getGreetingsStream(_ input: Operations.getGreetingsStream.Input) async throws -> Operations.getGreetingsStream.Output {
         let eventStream = await self.storage.makeStream(input: input)
+        /// To keep it simple, using JSON Lines, as it most straightforward and easy way to have streams.
+        /// For SSE and JSON Sequences cases please check `event-streams-server-example`.
         let responseBody = Operations.getGreetingsStream.Output.Ok.Body.application_jsonl(
             .init(eventStream.asEncodedJSONLines(), length: .unknown, iterationBehavior: .single)
         )

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+actor StreamStorage: Sendable {
+    
+    private typealias StreamType = AsyncStream<Components.Schemas.Greeting>
+    
+    private var streams: [String: Task<Void, any Error>] = [:]
+    
+    init() {}
+    
+    private func finishedStream(id: String) {
+        guard self.streams[id] != nil else { return }
+        self.streams.removeValue(forKey: id)
+    }
+    
+    private func cancelStream(id: String) {
+        guard let task = self.streams[id] else { return }
+        self.streams.removeValue(forKey: id)
+        task.cancel()
+        print("Canceled stream \(id)")
+    }
+    
+    func makeStream(
+        input: Operations.getGreetingsStream.Input
+    ) -> AsyncStream<Components.Schemas.Greeting> {
+        let name = input.query.name ?? "Stranger"
+        let id = UUID().uuidString
+        print("Creating stream \(id) for name: \(name)")
+        let (stream, continuation) = StreamType.makeStream()
+        continuation.onTermination = { termination in
+            Task { [weak self] in
+                switch termination {
+                case .cancelled: await self?.cancelStream(id: id)
+                case .finished: await self?.finishedStream(id: id)
+                @unknown default: await self?.finishedStream(id: id)
+                }
+            }
+        }
+        let inputStream = switch input.body {
+        case .application_jsonl(let body):
+            body.asDecodedJSONLines(
+                of: Components.Schemas.Greeting.self
+            )
+        }
+        let task = Task<Void, any Error> {
+            for try await message in inputStream {
+                try Task.checkCancellation()
+                print("Recieved a message \(message)")
+                print("Sending greeting back for \(id)")
+                let greetingText = String(format: message.message, name)
+                continuation.yield(.init(message: greetingText))
+            }
+            continuation.finish()
+        }
+        self.streams[id] = task
+        return stream
+    }
+}

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/openapi-generator-config.yaml
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/openapi-generator-config.yaml
@@ -1,0 +1,4 @@
+generate:
+  - types
+  - server
+accessModifier: internal

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/openapi.yaml
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/openapi.yaml
@@ -1,0 +1,39 @@
+openapi: '3.1.0'
+info:
+  title: EventStreamsService
+  version: 1.0.0
+servers:
+  - url: https://example.com/api
+    description: Example service deployment.
+paths:
+  /greetings:
+    post:
+      operationId: getGreetingsStream
+      parameters:
+        - name: name
+          required: false
+          in: query
+          description: The name used in the returned greeting.
+          schema:
+            type: string
+      requestBody:
+        description: A body with a greetings stream.
+        required: true
+        content:
+          application/jsonl: {}
+      responses:
+        '200':
+          description: A success response with a greetings stream.
+          content:
+            application/jsonl: {}
+components:
+  schemas:
+    Greeting:
+      type: object
+      description: A value with the greeting contents.
+      properties:
+        message:
+          type: string
+          description: The string representation of the greeting.
+      required:
+        - message


### PR DESCRIPTION
### Motivation

While working with my [swift distributed actors showcase](https://github.com/akbashev/swift-chat/) one of the points for me was to try openapi. As this is a chat client showcase, took me some time to realise that you can do bidirectional streaming. Think this is quite an important feature and not very discoverable, so to fill this gap—created two simple examples. Things to consider:
- Basically copied and updated `event-streams-_-example`
- For simplicity using just json lines
- Switched to AsyncHttpTransport, cause for URLSession you need a hack, see [comment](https://github.com/apple/swift-openapi-urlsession/blob/main/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/URLSessionBidirectionalStreamingTests.swift#L193-L206).
- While playing switched to Hummingbird, can switch back to Vapor though.

### Modifications

Working examples showing bidirectional streaming both for server and client.

### Test Plan

I've tested myself, it's working, don't think examples are covered with tests.
