### PR TITLE
Only write `@frozen` on public interfaces

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -645,7 +645,9 @@ struct TextBasedRenderer: RendererProtocol {
 
     /// Renders the specified enum declaration.
     func renderEnum(_ enumDesc: EnumDescription) {
-        if enumDesc.isFrozen {
+        if enumDesc.isFrozen,
+           let accessModifier = enumDesc.accessModifier,
+           accessModifier == .public {
             writer.writeLine("@frozen ")
             writer.nextLineAppendsToLastLine()
         }


### PR DESCRIPTION
### Motivation

Fixes a new warning in Xcode 16: `@frozen has no effect on non-public enums`

### Modifications

When rendering enums, first check if the frozen modifier is required, then check if the access modifier is explicitly public. If both conditions are satisfied, render the `@frozen` modifier

### Result

Frozen modifier will be in tact for public enums, but omitted for all other access levels 

### Test Plan

Integrated into my app, checked the warnings and they were fixed. 

| Before | After |
| --- | --- | 
| <img width="524" alt="Screenshot 2024-07-10 at 9 37 18 AM" src="https://github.com/apple/swift-openapi-generator/assets/967712/64740e30-fd93-4f97-9d2b-db082dd170fe"> | <img width="526" alt="Screenshot 2024-07-10 at 9 39 50 AM" src="https://github.com/apple/swift-openapi-generator/assets/967712/9264f3dc-a5e2-4a36-8dcd-16631cfd6d3b"> | 