### PR TITLE
[GHA] Call the reusable package workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,13 @@
+name: Pull Request
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+ 
+jobs:
+  call-reusable-pull-request-workflow:
+    name: Checks
+    uses: apple/swift-nio/.github/workflows/reusable_pull_request.yml
+    with:
+      benchmarks_linux_enabled: false
+      license_header_check_project_name: "SwiftOpenAPIGenerator"


### PR DESCRIPTION
# Motivation

We are migrating our CI over to GH actions. We have created a reusable workflow inside the NIO repository that we want to move into a separate repo in the future. For testing purposes let's try out calling the reusable workflow from the this repo as well.

# Modification

Add a GH actions workflow that calls the reusable package workflow.
