### PR TITLE
add support for visionOS

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -16,7 +16,7 @@
 // project.
 //
 // When compiling for MacCatalyst, the plugin is (erroneously?) compiled with os(iOS).
-#if !(os(macOS) || os(Linux) || (os(iOS) && targetEnvironment(macCatalyst)))
+#if !(os(macOS) || os(visionOS) || os(Linux) || (os(iOS) && targetEnvironment(macCatalyst)))
 #error(
     "_OpenAPIGeneratorCore is only to be used by swift-openapi-generator itself—your target should not link this library or the command line tool directly."
 )


### PR DESCRIPTION
### Motivation

When I use it in visionOS project, Xcode compiles and reports errors. When checking the platform, there is indeed little support for the latest visionOS.

### Modifications

add os(visionOS) when checking the platform 

### Result

Xcode has been compiled successfully and is used normally.

### Test Plan

Passed the test, does not affect other platforms
