### PR TITLE
Initial message fix

### DIFF
--- a/Examples/bidirectional-event-streams-client-example/Package.swift
+++ b/Examples/bidirectional-event-streams-client-example/Package.swift
@@ -20,14 +20,14 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.2.0"),
-        .package(url: "https://github.com/swift-server/swift-openapi-async-http-client", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(
             name: "BidirectionalEventStreamsClient",
             dependencies: [
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-                .product(name: "OpenAPIAsyncHTTPClient", package: "swift-openapi-async-http-client"),
+                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
             ],
             plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
         )

--- a/Examples/bidirectional-event-streams-server-example/Package.swift
+++ b/Examples/bidirectional-event-streams-server-example/Package.swift
@@ -20,16 +20,16 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.2.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0-rc.1"),
-        .package(url: "https://github.com/swift-server/swift-openapi-hummingbird.git", from: "2.0.0-beta.4"),
+        .package(url: "https://github.com/swift-server/swift-openapi-vapor", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
     ],
     targets: [
         .executableTarget(
             name: "BidirectionalEventStreamsServer",
             dependencies: [
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-                .product(name: "OpenAPIHummingbird", package: "swift-openapi-hummingbird"),
-                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
+                .product(name: "Vapor", package: "vapor"),
             ],
             plugins: [.plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")]
         )

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/BidirectionalEventStreamsServer.swift
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/BidirectionalEventStreamsServer.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 import OpenAPIRuntime
-import OpenAPIHummingbird
-import Hummingbird
+import OpenAPIVapor
+import Vapor
 import Foundation
 
 struct Handler: APIProtocol {
@@ -33,10 +33,10 @@ struct Handler: APIProtocol {
 
 @main struct BidirectionalEventStreamsServer {
     static func main() async throws {
-        let router = Router()
+        let app = try await Vapor.Application.make()
+        let transport = VaporTransport(routesBuilder: app)
         let handler = Handler()
-        try handler.registerHandlers(on: router, serverURL: URL(string: "/api")!)
-        let app = Application(router: router, configuration: .init())
-        try await app.run()
+        try handler.registerHandlers(on: transport, serverURL: URL(string: "/api")!)
+        try await app.execute()
     }
 }

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
@@ -51,12 +51,12 @@ actor StreamStorage: Sendable {
                 try Task.checkCancellation()
                 print("Recieved a message \(message)")
                 print("Sending greeting back for \(id)")
-                switch message.message {
-                case "connecting": continuation.yield(.init(message: "\(name) connected"))
-                default:
-                    let greetingText = String(format: message.message, name)
-                    continuation.yield(.init(message: greetingText))
-                }
+                let responseText: String =
+                    switch message.message {
+                    case "connecting": "\(name) connected"
+                    default: String(format: message.message, name)
+                    }
+                continuation.yield(.init(message: responseText))
             }
             continuation.finish()
         }

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
@@ -51,8 +51,13 @@ actor StreamStorage: Sendable {
                 try Task.checkCancellation()
                 print("Recieved a message \(message)")
                 print("Sending greeting back for \(id)")
-                let greetingText = String(format: message.message, name)
-                continuation.yield(.init(message: greetingText))
+                switch message.message {
+                case "connecting":
+                    continuation.yield(.init(message: "\(name) connected"))
+                default:
+                    let greetingText = String(format: message.message, name)
+                    continuation.yield(.init(message: greetingText))
+                }
             }
             continuation.finish()
         }

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
@@ -52,8 +52,7 @@ actor StreamStorage: Sendable {
                 print("Recieved a message \(message)")
                 print("Sending greeting back for \(id)")
                 switch message.message {
-                case "connecting":
-                    continuation.yield(.init(message: "\(name) connected"))
+                case "connecting": continuation.yield(.init(message: "\(name) connected"))
                 default:
                     let greetingText = String(format: message.message, name)
                     continuation.yield(.init(message: greetingText))


### PR DESCRIPTION
Last week I've been checking bidirectional examples with latest Xcode 16 beta 3 and realised it uses HBv2, which is supported only by macOS 14+, and it's not perfect. After downgrading to HBv1—same problem with returning stream until some bytes are sent appeared. So, this PR fixes two things:

- Moved to Vapor for two reasons: 1) anyway can't use HBv2 now and 2) it could be more familiar to others;
- Moved back to URLSession and added `initial message` hack.

It's working for now. I'll be checking from time to time status of Swift Server tools, maybe we can improve it in the future.