### PR TITLE
Correctly handle path params with a hyphen in the name

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -248,7 +248,7 @@ extension OperationDescription {
     /// The regular expression for parsing subcomponents of path components.
     ///
     /// Either a parameter `{foo}` or a constant value `foo`.
-    private static let pathParameterRegex = try! NSRegularExpression(pattern: #"(\{[a-zA-Z0-9_-]+\})|([^{}]+)"#)
+    private static let pathParameterRegex = try! NSRegularExpression(pattern: #"(\{[a-zA-Z0-9_\-\.]+\})|([^{}]+)"#)
 
     /// Returns a string that contains the template to be generated for
     /// the client that fills in path parameters, and an array expression

--- a/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Operations/OperationDescription.swift
@@ -248,7 +248,7 @@ extension OperationDescription {
     /// The regular expression for parsing subcomponents of path components.
     ///
     /// Either a parameter `{foo}` or a constant value `foo`.
-    private static let pathParameterRegex = try! NSRegularExpression(pattern: #"(\{[a-zA-Z0-9_]+\})|([^{}]+)"#)
+    private static let pathParameterRegex = try! NSRegularExpression(pattern: #"(\{[a-zA-Z0-9_-]+\})|([^{}]+)"#)
 
     /// Returns a string that contains the template to be generated for
     /// the client that fills in path parameters, and an array expression

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -2697,13 +2697,13 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
-    func testRequestWithPathParamWithHyphen() throws {
+    func testRequestWithPathParamWithHyphenAndPeriod() throws {
         try self.assertRequestInTypesClientServerTranslation(
             """
-            /foo/{a-b}:
+            /foo/{p.a-b}:
               get:
                 parameters:
-                  - name: a-b
+                  - name: p.a-b
                     in: path
                     required: true
                     schema:
@@ -2716,9 +2716,9 @@ final class SnippetBasedReferenceTests: XCTestCase {
             types: """
                 public struct Input: Sendable, Hashable {
                     public struct Path: Sendable, Hashable {
-                        public var a_hyphen_b: Swift.String
-                        public init(a_hyphen_b: Swift.String) {
-                            self.a_hyphen_b = a_hyphen_b
+                        public var p_period_a_hyphen_b: Swift.String
+                        public init(p_period_a_hyphen_b: Swift.String) {
+                            self.p_period_a_hyphen_b = p_period_a_hyphen_b
                         }
                     }
                     public var path: Operations.getFoo.Input.Path
@@ -2732,7 +2732,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     let path = try converter.renderedPath(
                         template: "/foo/{}",
                         parameters: [
-                            input.path.a_hyphen_b
+                            input.path.p_period_a_hyphen_b
                         ]
                     )
                     var request: HTTPTypes.HTTPRequest = .init(
@@ -2745,9 +2745,9 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 """,
             server: """
                 { request, requestBody, metadata in
-                    let path: Operations.getFoo.Input.Path = .init(a_hyphen_b: try converter.getPathParameterAsURI(
+                    let path: Operations.getFoo.Input.Path = .init(p_period_a_hyphen_b: try converter.getPathParameterAsURI(
                         in: metadata.pathParameters,
-                        name: "a-b",
+                        name: "p.a-b",
                         as: Swift.String.self
                     ))
                     return Operations.getFoo.Input(path: path)

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -2605,6 +2605,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 """
         )
     }
+
     func testRequestWithPathParams() throws {
         try self.assertRequestInTypesClientServerTranslation(
             """
@@ -2690,6 +2691,65 @@ final class SnippetBasedReferenceTests: XCTestCase {
                             as: Swift.Int.self
                         )
                     )
+                    return Operations.getFoo.Input(path: path)
+                }
+                """
+        )
+    }
+
+    func testRequestWithPathParamWithHyphen() throws {
+        try self.assertRequestInTypesClientServerTranslation(
+            """
+            /foo/{a-b}:
+              get:
+                parameters:
+                  - name: a-b
+                    in: path
+                    required: true
+                    schema:
+                      type: string
+                operationId: getFoo
+                responses:
+                  default:
+                    description: Response
+            """,
+            types: """
+                public struct Input: Sendable, Hashable {
+                    public struct Path: Sendable, Hashable {
+                        public var a_hyphen_b: Swift.String
+                        public init(a_hyphen_b: Swift.String) {
+                            self.a_hyphen_b = a_hyphen_b
+                        }
+                    }
+                    public var path: Operations.getFoo.Input.Path
+                    public init(path: Operations.getFoo.Input.Path) {
+                        self.path = path
+                    }
+                }
+                """,
+            client: """
+                { input in
+                    let path = try converter.renderedPath(
+                        template: "/foo/{}",
+                        parameters: [
+                            input.path.a_hyphen_b
+                        ]
+                    )
+                    var request: HTTPTypes.HTTPRequest = .init(
+                        soar_path: path,
+                        method: .get
+                    )
+                    suppressMutabilityWarning(&request)
+                    return (request, nil)
+                }
+                """,
+            server: """
+                { request, requestBody, metadata in
+                    let path: Operations.getFoo.Input.Path = .init(a_hyphen_b: try converter.getPathParameterAsURI(
+                        in: metadata.pathParameters,
+                        name: "a-b",
+                        as: Swift.String.self
+                    ))
                     return Operations.getFoo.Input(path: path)
                 }
                 """


### PR DESCRIPTION
### Motivation

Fixes #601, check out the issue for details.

### Modifications

Adds hyphen to the regular expression that parses out params from the URL template.

### Result

Correctly handle path params with hyphens in the name.

### Test Plan

Added a unit test.
