### PR TITLE
[GHA] Call the Soundness workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
  
 jobs:
-  call-reusable-pull-request-workflow:
-    name: Checks
-    uses: apple/swift-nio/.github/workflows/reusable_pull_request.yml@main
-    with:
-      benchmarks_linux_enabled: false
+  call-pull-request-soundness-workflow:
+    name: Soundness
+    uses: apple/swift-nio/.github/workflows/pull_request_soundness.yml@main


### PR DESCRIPTION
### Motivation

Observed all the workflows failed.

- https://github.com/apple/swift-openapi-generator/actions

After examining the cause, the file name of the workflow used was changed. The PR where the file name has been changed is as follows.

- apple/swift-nio#2789

### Modifications

The file name has been changed to the correct one.

Also, `benchmarks_linux_enabled` was deleted in this PR. Therefore, `with.benchmarks_linux_enabled` was deleted.

### Result

The workflow will move normally.