### PR TITLE
Avoid repeating dependency names in code

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -17,6 +17,16 @@ import OpenAPIKit
 /// in the Runtime library, so they need to be kept in sync.
 enum Constants {
 
+    /// Constants related to the library dependencies.
+    enum Dependency {
+
+        /// The module name of the OpenAPI runtime library.
+        static let runtime: String = "OpenAPIRuntime"
+
+        /// The module name of the HTTP types library.
+        static let httpTypes: String = "HTTPTypes"
+    }
+
     /// Constants related to the generated Swift files.
     enum File {
 
@@ -25,7 +35,7 @@ enum Constants {
 
         /// The descriptions of modules imported by every generated file.
         static let imports: [ImportDescription] = [
-            ImportDescription(moduleName: "OpenAPIRuntime", spi: "Generated"),
+            ImportDescription(moduleName: Constants.Dependency.runtime, spi: "Generated"),
             ImportDescription(
                 moduleName: "Foundation",
                 moduleTypes: ["struct Foundation.URL", "struct Foundation.Data", "struct Foundation.Date"],
@@ -34,7 +44,8 @@ enum Constants {
         ]
 
         /// The descriptions of modules imported by client and server files.
-        static let clientServerImports: [ImportDescription] = imports + [ImportDescription(moduleName: "HTTPTypes")]
+        static let clientServerImports: [ImportDescription] =
+            imports + [ImportDescription(moduleName: Constants.Dependency.httpTypes)]
     }
 
     /// Constants related to the OpenAPI server object.

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -18,7 +18,7 @@ import OpenAPIKit
 enum Constants {
 
     /// Constants related to the library dependencies.
-    enum Dependency {
+    enum Import {
 
         /// The module name of the OpenAPI runtime library.
         static let runtime: String = "OpenAPIRuntime"
@@ -35,7 +35,7 @@ enum Constants {
 
         /// The descriptions of modules imported by every generated file.
         static let imports: [ImportDescription] = [
-            ImportDescription(moduleName: Constants.Dependency.runtime, spi: "Generated"),
+            ImportDescription(moduleName: Constants.Import.runtime, spi: "Generated"),
             ImportDescription(
                 moduleName: "Foundation",
                 moduleTypes: ["struct Foundation.URL", "struct Foundation.Data", "struct Foundation.Date"],
@@ -45,7 +45,7 @@ enum Constants {
 
         /// The descriptions of modules imported by client and server files.
         static let clientServerImports: [ImportDescription] =
-            imports + [ImportDescription(moduleName: Constants.Dependency.httpTypes)]
+            imports + [ImportDescription(moduleName: Constants.Import.httpTypes)]
     }
 
     /// Constants related to the OpenAPI server object.

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
@@ -42,9 +42,7 @@ extension TypeName {
     /// HTTPTypes module.
     /// - Parameter name: The name of the type.
     /// - Returns: A TypeName representing the type with the given name in the HTTPTypes module.
-    static func httpTypes(_ name: String) -> TypeName {
-        TypeName(swiftKeyPath: [Constants.Import.httpTypes, name])
-    }
+    static func httpTypes(_ name: String) -> TypeName { TypeName(swiftKeyPath: [Constants.Import.httpTypes, name]) }
 
     /// Returns the type name for the Date type.
     static var date: Self { .foundation("Date") }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
@@ -36,14 +36,14 @@ extension TypeName {
     /// OpenAPIRuntime module.
     /// - Parameter name: The name of the type.
     /// - Returns: A TypeName representing the specified type within the OpenAPIRuntime module.
-    static func runtime(_ name: String) -> TypeName { TypeName(swiftKeyPath: [Constants.Dependency.runtime, name]) }
+    static func runtime(_ name: String) -> TypeName { TypeName(swiftKeyPath: [Constants.Import.runtime, name]) }
 
     /// Returns a type name for a type with the specified name in the
     /// HTTPTypes module.
     /// - Parameter name: The name of the type.
     /// - Returns: A TypeName representing the type with the given name in the HTTPTypes module.
     static func httpTypes(_ name: String) -> TypeName {
-        TypeName(swiftKeyPath: [Constants.Dependency.httpTypes, name])
+        TypeName(swiftKeyPath: [Constants.Import.httpTypes, name])
     }
 
     /// Returns the type name for the Date type.

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
@@ -36,13 +36,15 @@ extension TypeName {
     /// OpenAPIRuntime module.
     /// - Parameter name: The name of the type.
     /// - Returns: A TypeName representing the specified type within the OpenAPIRuntime module.
-    static func runtime(_ name: String) -> TypeName { TypeName(swiftKeyPath: ["OpenAPIRuntime", name]) }
+    static func runtime(_ name: String) -> TypeName { TypeName(swiftKeyPath: [Constants.Dependency.runtime, name]) }
 
     /// Returns a type name for a type with the specified name in the
     /// HTTPTypes module.
     /// - Parameter name: The name of the type.
     /// - Returns: A TypeName representing the type with the given name in the HTTPTypes module.
-    static func httpTypes(_ name: String) -> TypeName { TypeName(swiftKeyPath: ["HTTPTypes", name]) }
+    static func httpTypes(_ name: String) -> TypeName {
+        TypeName(swiftKeyPath: [Constants.Dependency.httpTypes, name])
+    }
 
     /// Returns the type name for the Date type.
     static var date: Self { .foundation("Date") }


### PR DESCRIPTION
### Motivation

A small refactor - avoid repeating the dependency names in code.

### Modifications

Factor out the dependency names into a single place.

### Result

Less duplication that needs to be kept in sync manually.

### Test Plan

All tests still pass.
