### PR TITLE
Additional api protocol conformances

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Config.swift
+++ b/Sources/_OpenAPIGeneratorCore/Config.swift
@@ -32,6 +32,9 @@ public struct Config: Sendable {
     /// Additional imports to add to each generated file.
     public var additionalImports: [String]
 
+    /// Additional protocol conformances to add to the APIProtocol type
+    public var additionalAPIProtocols: [String]
+
     /// Filter to apply to the OpenAPI document before generation.
     public var filter: DocumentFilter?
 
@@ -49,12 +52,14 @@ public struct Config: Sendable {
         mode: GeneratorMode,
         access: AccessModifier,
         additionalImports: [String] = [],
+        additionalAPIProtocols: [String] = [],
         filter: DocumentFilter? = nil,
         featureFlags: FeatureFlags = []
     ) {
         self.mode = mode
         self.access = access
         self.additionalImports = additionalImports
+        self.additionalAPIProtocols = additionalAPIProtocols
         self.filter = filter
         self.featureFlags = featureFlags
     }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
@@ -28,7 +28,7 @@ extension TypesFileTranslator {
         let protocolDescription = ProtocolDescription(
             accessModifier: config.access,
             name: Constants.APIProtocol.typeName,
-            conformances: Constants.APIProtocol.conformances,
+            conformances: Constants.APIProtocol.conformances + config.additionalAPIProtocols,
             members: functionDecls
         )
         let protocolComment: Comment = .doc("A type that performs HTTP operations defined by the OpenAPI document.")

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -35,6 +35,7 @@ The configuration file has the following keys:
     - `package`: Generated API is accessible from other modules within the same package or project.
     - `internal` (default): Generated API is accessible from the containing module only.
 - `additionalImports` (optional): array of strings. Each string value is a Swift module name. An import statement will be added to the generated source files for each module.
+- `additionalAPIProtocols` (optional): array of strings. Each string value is the name of a protocol the resulting API should conform to. These protocols must be available in the scope that the API is generated.
 - `filter`: (optional): Filters to apply to the OpenAPI document before generation.
     - `operations`: Operations with these operation IDs will be included in the filter.
     - `tags`: Operations tagged with these tags will be included in the filter.
@@ -84,6 +85,17 @@ generate:
 additionalImports:
   - APITypes
 accessModifier: public
+```
+
+To use together with a mocking library, it is possible to add conformance to a custom protocol:
+
+```yaml
+generate:
+  - client
+additionalImports:
+  - APITypes
+additionalAPIProtocols:
+  - AutoMockable
 ```
 
 ### Document filtering

--- a/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
@@ -32,12 +32,14 @@ extension _GenerateOptions {
         let sortedModes = try resolvedModes(config)
         let resolvedAccessModifier = resolvedAccessModifier(config) ?? Config.defaultAccessModifier
         let resolvedAdditionalImports = resolvedAdditionalImports(config)
+        let resolvedAdditionalAPIProtocols = resolvedAdditionalAPIProtocols(config)
         let resolvedFeatureFlags = resolvedFeatureFlags(config)
         let configs: [Config] = sortedModes.map {
             .init(
                 mode: $0,
                 access: resolvedAccessModifier,
                 additionalImports: resolvedAdditionalImports,
+                additionalAPIProtocols: resolvedAdditionalAPIProtocols,
                 filter: config?.filter,
                 featureFlags: resolvedFeatureFlags
             )

--- a/Sources/swift-openapi-generator/GenerateOptions.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions.swift
@@ -35,6 +35,8 @@ struct _GenerateOptions: ParsableArguments {
 
     @Option(help: "Additional import to add to all generated files.") var additionalImport: [String] = []
 
+    @Option(help: "Additional protocol conformances to add to the APIProtocol type") var additionalAPIProtocols: [String] = []
+
     @Option(help: "Pre-release feature to enable. Options: \(FeatureFlag.prettyListing).") var featureFlag:
         [FeatureFlag] = []
 
@@ -80,6 +82,14 @@ extension _GenerateOptions {
     func resolvedAdditionalImports(_ config: _UserConfig?) -> [String] {
         if !additionalImport.isEmpty { return additionalImport }
         if let additionalImports = config?.additionalImports, !additionalImports.isEmpty { return additionalImports }
+        return []
+    }
+
+    func resolvedAdditionalAPIProtocols(_ config: _UserConfig?) -> [String] {
+        if !additionalAPIProtocols.isEmpty { return additionalAPIProtocols }
+        if let additionalAPIProcotols = config?.additionalAPIProtocols, !additionalAPIProcotols.isEmpty {
+            return additionalAPIProcotols
+        }
         return []
     }
 

--- a/Sources/swift-openapi-generator/UserConfig.swift
+++ b/Sources/swift-openapi-generator/UserConfig.swift
@@ -30,6 +30,10 @@ struct _UserConfig: Codable {
     /// generated Swift file.
     var additionalImports: [String]?
 
+    /// A list of additional protocol conformances to add to the APIProtocol
+    /// that is generated.
+    var additionalAPIProtocols: [String]?
+
     /// Filter to apply to the OpenAPI document before generation.
     var filter: DocumentFilter?
 

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
@@ -138,9 +138,12 @@ final class Test_YamsParser: Test_Core {
 
             additionalImports:
               - Foundation
+            
+            additionalAPIProtocols:
+              - ExampleProtocol
             """
         let keys = try? YamsParser.extractTopLevelKeys(fromYAMLString: yaml)
-        XCTAssertEqual(keys, ["generate", "featureFlags", "additionalImports"])
+        XCTAssertEqual(keys, ["generate", "featureFlags", "additionalImports", "additionalAPIProtocols"])
     }
 
     func testExtractTopLevelKeysWithInvalidYAML() {

--- a/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
@@ -20,13 +20,20 @@ struct TestConfig: Encodable {
     var docFilePath: String
     var mode: GeneratorMode
     var additionalImports: [String]?
+    var additionalAPIProtocols: [String]?
     var featureFlags: FeatureFlags?
     var referenceOutputDirectory: String
 }
 
 extension TestConfig {
     var asConfig: Config {
-        .init(mode: mode, access: .public, additionalImports: additionalImports ?? [], featureFlags: featureFlags ?? [])
+        .init(
+            mode: mode,
+            access: .public,
+            additionalImports: additionalImports ?? [],
+            additionalAPIProtocols: additionalAPIProtocols ?? [],
+            featureFlags: featureFlags ?? []
+        )
     }
 }
 
@@ -126,6 +133,7 @@ final class FileBasedReferenceTests: XCTestCase {
                     docFilePath: "Docs/\(project.openAPIDocFileName)",
                     mode: mode,
                     additionalImports: [],
+                    additionalAPIProtocols: [],
                     featureFlags: featureFlags,
                     referenceOutputDirectory: "ReferenceSources/\(project.fixtureCodeDirectoryName)"
                 ),


### PR DESCRIPTION
### Motivation

The generated code from this tool offers a very good starting point for integrating an API into a larger project. One challenge that I've run into when using this tool is testability and mocking. While it is possible to write mocks by hand I have found it very useful to use code generation tools (e.g. Sourcery) to do most of the heavy lifting. To enable behavior like this it is often necessary to annotate the client/server source in some way. This change offers a way to let the `APIProtocol` declaration have a conformance to one or more user-defined protocols to achieve this.

### Modifications

- Added an option to the generate command to list protocols that the user wishes the API to conform to
- Added entry to the config-file to list protocols that the user wishes the API to conform to
- Added protocol conformance of user-defined protocols to the `APIProtocol`
- Added test to verify correct behavior

### Result

The generate command and config file will get an extra option (`additionalAPIProtocols`) for the user to list additional protocols they wish that the `APIProtocol` type conforms to.

### Test Plan

- Added a reference test that generates an empty API with conformance to an additional example protocol
- Modified existing config file test to include this change
