### PR TITLE
[README] Add a CI badge for the main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Swift OpenAPI Generator
 
+[![Scheduled](https://github.com/apple/swift-openapi-generator/actions/workflows/scheduled.yml/badge.svg?branch=main)](https://github.com/apple/swift-openapi-generator/actions/workflows/scheduled.yml)
 [![](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://www.swift.org/sswg/)
 [![](https://img.shields.io/badge/docc-read_documentation-blue)](https://swiftpackageindex.com/apple/swift-openapi-generator/documentation)
 [![](https://img.shields.io/github/v/release/apple/swift-openapi-generator)](https://github.com/apple/swift-openapi-generator/releases)


### PR DESCRIPTION
### Motivation

Provide a glanceable way to see the CI status of the main branch.

### Modifications

Add the GHA-provided badge to the README, shows the status of the "Scheduled" workflow.

### Result

README now has a CI status badge.

### Test Plan

N/A
