### PR TITLE
ci: Add missing environment variable to integration-test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
         uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
             name: "Integration test"
-            matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
+            matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
             matrix_linux_5_8_enabled: false
             matrix_linux_nightly_main_enabled: false
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,7 +20,7 @@ jobs:
         uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
         with:
             name: "Integration test"
-            matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && ./scripts/run-integration-test.sh"
+            matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
             matrix_linux_5_8_enabled: false
 
     example-packages:


### PR DESCRIPTION
### Motivation

When we migrated the CI to Github Actions we lost an important configuration for the integration test that makes sure we're using the copy of this repo from the PR, rather than cloning from upstream. This can be seen in the logs of recent PR jobs:

```
** Cloning https://github.com/apple/swift-openapi-generator to /tmp/run-integration-test.sh.SUVBe45RMQ/swift-openapi-generator
Cloning into '/tmp/run-integration-test.sh.SUVBe45RMQ/swift-openapi-generator'...
** Extracting name for Swift package: /__w/swift-openapi-generator/swift-openapi-generator
** Overriding dependency in /tmp/run-integration-test.sh.SUVBe45RMQ/swift-openapi-generator/IntegrationTest on swift-openapi-generator to use /__w/swift-openapi-generator/swift-openapi-generator
```

This used to be specified in the Docker Compose file as an environment variable but dropped off during migration.

### Modifications

Add the environment variable back to use `file://${GITHUB_WORKSPACE}` for the clone.

Note that one cannot use the `env:` map when making use of a reusable GitHub workflow with `uses:` so it's been added in the command passed to the matrix job, itself.

### Result

The integration test CI will use this repo for the test itself so we can make sure we're testing the right thing.

### Test Plan

The logs on _this_ PR job show that we're now cloning from the GitHub workspace:

```
** Cloning file:///__w/swift-openapi-generator/swift-openapi-generator to /tmp/run-integration-test.sh.OWgemDungm/swift-openapi-generator
Cloning into '/tmp/run-integration-test.sh.OWgemDungm/swift-openapi-generator'...
Note: switching to '9664e9cb2170a5fa8a1bad3266891d4b4248e6ba'.
...
** Extracting name for Swift package: /__w/swift-openapi-generator/swift-openapi-generator
** Overriding dependency in /tmp/run-integration-test.sh.OWgemDungm/swift-openapi-generator/IntegrationTest on swift-openapi-generator to use /__w/swift-openapi-generator/swift-openapi-generator
```