### PR TITLE
[Docs] Update supported parameter styles

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
@@ -212,8 +212,8 @@ For any other formats, the payload is provided as raw bytes (using the `HTTPBody
 - [x] required
 - [x] deprecated
 - [ ] allowEmptyValue
-- [x] style (only defaults)
-- [x] explode (non default only for query items)
+- [x] style
+- [x] explode
 - [ ] allowReserved
 - [x] schema
 - [ ] example
@@ -230,7 +230,7 @@ For any other formats, the payload is provided as raw bytes (using the `HTTPBody
 - [x] simple (in header)
 - [ ] spaceDelimited (in query)
 - [ ] pipeDelimited (in query)
-- [ ] deepObject (in query)
+- [x] deepObject (in query)
 
 #### Supported combinations
 
@@ -239,6 +239,7 @@ For any other formats, the payload is provided as raw bytes (using the `HTTPBody
 | path | `simple` | `false` |
 | query | `form` | `true` |
 | query | `form` | `false` |
+| query | `deepObject` | `true` |
 | header | `simple` | `false` |
 
 #### Reference Object


### PR DESCRIPTION
### Motivation

Have our docs accurately represent the feautures we support.

### Modifications

Updated the supported OpenAPI features doc to reflect that we will support deepObject as of https://github.com/apple/swift-openapi-generator/pull/538 (wait for that to land first).

### Result

Accurate docs.

### Test Plan

N/A
