### PR TITLE
[CI] Disable the API breakage check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
         name: Soundness
         uses: apple/swift-nio/.github/workflows/soundness.yml@main
         with:
-            api_breakage_check_enabled: true
+            api_breakage_check_enabled: false
             broken_symlink_check_enabled: true
             docs_check_enabled: true
             format_check_enabled: true


### PR DESCRIPTION
### Motivation

This package doesn't have any library products that would need to maintain API stability, so we don't need to run the CI.

We only have `_OpenAPIGeneratorCore`, which is underscored and not expected to be API stable (so it can only be used using an `exact: "..."` constraint). But we don't want to fail CI when we change that API (right now it's introducing noise in: https://github.com/apple/swift-openapi-generator/pull/627)

### Modifications

Disable API breakage check.

### Result

Disabled that CI step.

### Test Plan

N/A
