### PR TITLE
Fix CI - renamed upstream GHA workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
             license_header_check_project_name: "SwiftOpenAPIGenerator"
             shell_check_enabled: true
             unacceptable_language_check_enabled: true
-            yamllint_enabled: false
+            yamllint_check_enabled: false
 
     unit-tests:
         name: Unit tests


### PR DESCRIPTION
### Motivation

The parameter got renamed: https://github.com/swiftlang/github-workflows/pull/18

### Modifications

Update our workflow file.

### Result

Hopefully working CI.

### Test Plan

Will see once this is merged.
