### PR TITLE
[CI] Update to Swift 6 CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,22 +10,16 @@ jobs:
         uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
         with:
             api_breakage_check_enabled: false
-            broken_symlink_check_enabled: true
-            docs_check_enabled: true
-            format_check_enabled: true
-            license_header_check_enabled: true
             license_header_check_project_name: "SwiftOpenAPIGenerator"
-            shell_check_enabled: true
-            unacceptable_language_check_enabled: true
             yamllint_check_enabled: false
 
     unit-tests:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_8_enabled: false
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_main_enabled: false
 
@@ -35,7 +29,6 @@ jobs:
         with:
             name: "Integration test"
             matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
-            matrix_linux_5_8_enabled: false
             matrix_linux_nightly_main_enabled: false
 
     compatibility-test:
@@ -63,7 +56,6 @@ jobs:
         with:
             name: "Example packages"
             matrix_linux_command: "./scripts/test-examples.sh"
-            matrix_linux_5_8_enabled: false
             matrix_linux_nightly_main_enabled: false
 
     swift-6-language-mode:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -9,9 +9,9 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_8_enabled: false
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
@@ -21,7 +21,6 @@ jobs:
         with:
             name: "Integration test"
             matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
-            matrix_linux_5_8_enabled: false
 
     example-packages:
         name: Example packages
@@ -29,4 +28,3 @@ jobs:
         with:
             name: "Example packages"
             matrix_linux_command: "./scripts/test-examples.sh"
-            matrix_linux_5_8_enabled: false


### PR DESCRIPTION
# Motivation

We just updated our CI matrix in NIO to only support 5.9, 5.10 and 6.

# Modification

This PR updates the trigger files in this repo. Since this repo was always 5.9+ this is easy.

# Result

Up to date CI
