### PR TITLE
[Docs] Explain how to enable plugins in Xcode and Xcode Cloud

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
@@ -71,3 +71,23 @@ For Xcode projects, make sure the target that uses the Swift OpenAPI Generator b
 Alternatively, change the access modifier of the generated code to either `internal` (if no code outside of that module needs to use it) or `public` (if the generated code is exported to other modules and packages.) You can do so by setting `accessModifier: internal` in the generator configuration file, or by providing `--access-modifier internal` to the `swift-openapi-generator` CLI.
 
 For details, check out <doc:Configuring-the-generator>.
+
+### How do I enable the build plugin in Xcode and Xcode Cloud?
+
+By default, build plugins must be explicitly enabled by the adopter.
+
+In Xcode, the first time you add a build plugin as a dependency of your project or package, the build fails and requires you to enable the plugin.
+
+In Xcode Cloud, you might encounter the error _"OpenAPIGenerator" is disabled_, caused by the fact that build plugins must also be enabled explicitly when run in automation.
+
+One way to enable build plugins in Xcode Cloud is by adding the script `ci_scripts/ci_post_clone.sh` next to your Xcode project or workspace, containing:
+
+```bash
+#!/usr/bin/env bash
+
+set -e
+
+defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
+```
+
+Learn more about Xcode Cloud custom scripts in the [documentation](https://developer.apple.com/documentation/xcode/writing-custom-build-scripts).

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
@@ -76,7 +76,7 @@ For details, check out <doc:Configuring-the-generator>.
 
 By default, you must explicitly enable build plugins before they are allowed to run.
 
-Before a plugin is enabled, you might encounter a build error with the message _"OpenAPIGenerator" is disabled_.
+Before a plugin is enabled, you will encounter a build error with the message `"OpenAPIGenerator" is disabled`.
 
 In Xcode, enable the plugin by clicking the "Enable Plugin" button next to the build error and confirm the dialog by clicking "Trust & Enable".
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
@@ -74,13 +74,13 @@ For details, check out <doc:Configuring-the-generator>.
 
 ### How do I enable the build plugin in Xcode and Xcode Cloud?
 
-By default, build plugins must be explicitly enabled by the adopter.
+By default, you must explicitly enable build plugins before they are allowed to run.
 
-In Xcode, the first time you add a build plugin as a dependency of your project or package, the build fails and requires you to enable the plugin.
+Before a plugin is enabled, you might encounter a build error with the message _"OpenAPIGenerator" is disabled_.
 
-In Xcode Cloud, you might encounter the error _"OpenAPIGenerator" is disabled_, caused by the fact that build plugins must also be enabled explicitly when run in automation.
+In Xcode, enable the plugin by clicking the "Enable Plugin" button next to the build error and confirm the dialog by clicking "Trust & Enable".
 
-One way to enable build plugins in Xcode Cloud is by adding the script `ci_scripts/ci_post_clone.sh` next to your Xcode project or workspace, containing:
+In Xcode Cloud, add the script `ci_scripts/ci_post_clone.sh` next to your Xcode project or workspace, containing:
 
 ```bash
 #!/usr/bin/env bash


### PR DESCRIPTION
### Motivation

By default, adopters hit this error both in Xcode and Xcode Cloud and might not be familiar with how to resolve it.

### Modifications

Expand the FAQ to cover how to enable plugins in Xcode and Xcode Cloud.

### Result

Better docs, adopters can find a solution easier.

### Test Plan

N/A
