### PR TITLE
Update FAQ script to include note on correctness of spelling mistake

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
@@ -16,13 +16,13 @@ This article includes some commonly asked questions and answers.
 
 Check out <doc:Project-scope-and-goals>.
 
-### What OpenAPI featues does the generator support?
+### What OpenAPI features does the generator support?
 
 Check out <doc:Supported-OpenAPI-features>.
 
 ### Which underlying HTTP library does the generated code use?
 
-Swift OpenAPI Generator is not tied to any particular HTTP library. Instead, the generated code utilizies a general protocol called [`ClientTransport`](https://swiftpackageindex.com/apple/swift-openapi-runtime/documentation/openapiruntime/clienttransport) for client code, and [`ServerTransport`](https://swiftpackageindex.com/apple/swift-openapi-runtime/documentation/openapiruntime/servertransport) for server code.
+Swift OpenAPI Generator is not tied to any particular HTTP library. Instead, the generated code utilizes a general protocol called [`ClientTransport`](https://swiftpackageindex.com/apple/swift-openapi-runtime/documentation/openapiruntime/clienttransport) for client code, and [`ServerTransport`](https://swiftpackageindex.com/apple/swift-openapi-runtime/documentation/openapiruntime/servertransport) for server code.
 
 The user of the generated code provides one of the concrete transport implementations, based on what's appropriate for their use case.
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Frequently-asked-questions.md
@@ -87,6 +87,7 @@ In Xcode Cloud, add the script `ci_scripts/ci_post_clone.sh` next to your Xcode 
 
 set -e
 
+# NOTE: the misspelling of validation as "validatation" is intentional and the spelling Xcode expects.
 defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
 ```
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Practicing-spec-driven-API-development.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Practicing-spec-driven-API-development.md
@@ -113,7 +113,7 @@ Publishing the source of truth is preferable to relying on transcoding from code
 
 By inferring the specification from existing code, the resulting OpenAPI spec is often lossy and incomplete. And even with annotated code, it can be difficult to predict the OpenAPI output.
 
-Additionally, any feature unsupported by the transcoder cannot be represented in the generated OpenAPI document, further limiting the creativity and expressivness of the API.
+Additionally, any feature unsupported by the transcoder cannot be represented in the generated OpenAPI document, further limiting the creativity and expressiveness of the API.
 
 > Tip: Publish the source of truth, not a representation transcoded from the source of truth.
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/Adding-openapi-and-swagger-ui-endpoints.tutorial
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/Adding-openapi-and-swagger-ui-endpoints.tutorial
@@ -2,7 +2,7 @@
     @Intro(title: "Adding OpenAPI and Swagger UI endpoints") {
         One of the most popular ways to share your OpenAPI document with your users is to host it alongside your API server itself.
         
-        Typically this is at `/openapi.yaml` or similar, which serves a plain-text OpenAPI document for consumpion by clients.
+        Typically this is at `/openapi.yaml` or similar, which serves a plain-text OpenAPI document for consumption by clients.
         
         Additionally, you can host an HTML page that renders the OpenAPI document as interactive documentation that you can use from the browser, for example using [swagger-ui](https://github.com/swagger-api/swagger-ui).
         
@@ -37,7 +37,7 @@
                 This step is necessary because the Vapor middleware serves files relative to the current working directory for the running server process.
             }
             @Step {
-                Test this enpoint in your browser, or using curl.
+                Test this endpoint in your browser, or using curl.
                 
                 @Code(name: "console", file: server-openapi-endpoints.console.2.txt, previousFile: server-openapi-endpoints.console.1.txt)
             }

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.0.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.0.swift
@@ -21,7 +21,7 @@ let app = Vapor.Application()
 let transport = VaporTransport(routesBuilder: app)
 
 // Create an instance of your handler type that conforms the generated protocol
-// defininig your service API.
+// defining your service API.
 let handler = GreetingServiceAPIImpl()
 
 // Call the generated function on your implementation to add its request

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.1.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.1.swift
@@ -21,7 +21,7 @@ let app = Vapor.Application()
 let transport = VaporTransport(routesBuilder: app)
 
 // Create an instance of your handler type that conforms the generated protocol
-// defininig your service API.
+// defining your service API.
 let handler = GreetingServiceAPIImpl()
 
 // Call the generated function on your implementation to add its request

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.2.swift
@@ -21,7 +21,7 @@ let app = Vapor.Application()
 let transport = VaporTransport(routesBuilder: app)
 
 // Create an instance of your handler type that conforms the generated protocol
-// defininig your service API.
+// defining your service API.
 let handler = GreetingServiceAPIImpl()
 
 // Call the generated function on your implementation to add its request

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.1.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.1.2.swift
@@ -21,7 +21,7 @@ let app = Vapor.Application()
 let transport = VaporTransport(routesBuilder: app)
 
 // Create an instance of your handler type that conforms the generated protocol
-// defininig your service API.
+// defining your service API.
 let handler = GreetingServiceAPIImpl()
 
 // Call the generated function on your implementation to add its request

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.2.swift
@@ -29,7 +29,7 @@ let app = Vapor.Application()
 let transport = VaporTransport(routesBuilder: app)
 
 // Create an instance of your handler type that conforms the generated protocol
-// defininig your service API.
+// defining your service API.
 let handler = GreetingServiceAPIImpl()
 
 // Call the generated function on your implementation to add its request


### PR DESCRIPTION
### Motivation

Addressing https://github.com/apple/swift-openapi-generator/pull/653#issuecomment-2419247718

### Modifications

I added a comment to the bash script provided in the FAQ to note the correctness of the spelling mistake of validation.

I also quickly went through all the documentation and fixed the few spelling mistakes I found.

### Result

Better documentation for adopters, and their own review processes.

### Test Plan

N/A
