### PR TITLE
Fix printing to stderr - add a missing newline

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
+++ b/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
@@ -322,7 +322,9 @@ public struct StdErrPrintingDiagnosticCollector: DiagnosticCollector, Sendable {
     /// Emits a diagnostic message to standard error.
     ///
     /// - Parameter diagnostic: The diagnostic message to emit.
-    public func emit(_ diagnostic: Diagnostic) { stdErrHandle.write(diagnostic.description) }
+    public func emit(_ diagnostic: Diagnostic) {
+        stdErrHandle.write(diagnostic.description + "\n")
+    }
 }
 
 /// A no-op collector, silently ignores all diagnostics.

--- a/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
+++ b/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
@@ -322,9 +322,7 @@ public struct StdErrPrintingDiagnosticCollector: DiagnosticCollector, Sendable {
     /// Emits a diagnostic message to standard error.
     ///
     /// - Parameter diagnostic: The diagnostic message to emit.
-    public func emit(_ diagnostic: Diagnostic) {
-        stdErrHandle.write(diagnostic.description + "\n")
-    }
+    public func emit(_ diagnostic: Diagnostic) { stdErrHandle.write(diagnostic.description + "\n") }
 }
 
 /// A no-op collector, silently ignores all diagnostics.


### PR DESCRIPTION
### Motivation

At some point, we switched to printing informative output to stderr and that diagnostic collector did not insert newlines between messages, printing it all on a long line.

### Modifications

Insert a newline after every message, similar to `print(...)`.

### Result

More readable output from the CLI.

### Test Plan

Tested manually, all tests still pass.
