### PR TITLE
Include path item parameters in filter

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -313,6 +313,7 @@ private extension FilteredDocumentBuilder {
                 guard predicate(endpoint) else { continue }
                 if requiredEndpoints[path] == nil { requiredEndpoints[path] = Set() }
                 if requiredEndpoints[path]!.insert(endpoint.method).inserted {
+                    for parameter in originalPathItem.parameters { try includeParameter(parameter) }
                     try includeComponentsReferencedBy(endpoint.operation)
                 }
             }

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_FilteredDocument.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_FilteredDocument.swift
@@ -28,6 +28,8 @@ final class Test_FilteredDocument: XCTestCase {
             - name: t
             paths:
               /things/a:
+                parameters:
+                  - $ref: '#/components/parameters/A'
                 get:
                   operationId: getA
                   tags:
@@ -52,6 +54,12 @@ final class Test_FilteredDocument: XCTestCase {
                   type: string
                 B:
                   $ref: '#/components/schemas/A'
+              parameters:
+                A:
+                  in: query
+                  schema:
+                    type: string
+                  name: A
               responses:
                 A:
                   description: success
@@ -75,14 +83,16 @@ final class Test_FilteredDocument: XCTestCase {
             filter: DocumentFilter(tags: ["t"]),
             hasPaths: ["/things/a"],
             hasOperations: ["getA"],
-            hasSchemas: ["A"]
+            hasSchemas: ["A"],
+            hasParameters: ["A"]
         )
         assert(
             filtering: document,
             filter: DocumentFilter(paths: ["/things/a"]),
             hasPaths: ["/things/a"],
             hasOperations: ["getA", "deleteA"],
-            hasSchemas: ["A"]
+            hasSchemas: ["A"],
+            hasParameters: ["A"]
         )
         assert(
             filtering: document,
@@ -96,7 +106,8 @@ final class Test_FilteredDocument: XCTestCase {
             filter: DocumentFilter(paths: ["/things/a", "/things/b"]),
             hasPaths: ["/things/a", "/things/b"],
             hasOperations: ["getA", "deleteA", "getB"],
-            hasSchemas: ["A", "B"]
+            hasSchemas: ["A", "B"],
+            hasParameters: ["A"]
         )
         assert(
             filtering: document,
@@ -117,21 +128,24 @@ final class Test_FilteredDocument: XCTestCase {
             filter: DocumentFilter(paths: ["/things/a"], schemas: ["B"]),
             hasPaths: ["/things/a"],
             hasOperations: ["getA", "deleteA"],
-            hasSchemas: ["A", "B"]
+            hasSchemas: ["A", "B"],
+            hasParameters: ["A"]
         )
         assert(
             filtering: document,
             filter: DocumentFilter(tags: ["t"], schemas: ["B"]),
             hasPaths: ["/things/a"],
             hasOperations: ["getA"],
-            hasSchemas: ["A", "B"]
+            hasSchemas: ["A", "B"],
+            hasParameters: ["A"]
         )
         assert(
             filtering: document,
             filter: DocumentFilter(operations: ["deleteA"]),
             hasPaths: ["/things/a"],
             hasOperations: ["deleteA"],
-            hasSchemas: []
+            hasSchemas: [],
+            hasParameters: ["A"]
         )
     }
 
@@ -141,6 +155,7 @@ final class Test_FilteredDocument: XCTestCase {
         hasPaths paths: [OpenAPI.Path.RawValue],
         hasOperations operationIDs: [String],
         hasSchemas schemas: [String],
+        hasParameters parameters: [String] = [],
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
@@ -149,11 +164,31 @@ final class Test_FilteredDocument: XCTestCase {
             XCTFail("Filter threw error: \(error)", file: file, line: line)
             return
         }
-        XCTAssertUnsortedEqual(filteredDocument.paths.keys.map(\.rawValue), paths, file: file, line: line)
-        XCTAssertUnsortedEqual(filteredDocument.allOperationIds, operationIDs, file: file, line: line)
+        XCTAssertUnsortedEqual(
+            filteredDocument.paths.keys.map(\.rawValue),
+            paths,
+            "Paths don't match",
+            file: file,
+            line: line
+        )
+        XCTAssertUnsortedEqual(
+            filteredDocument.allOperationIds,
+            operationIDs,
+            "Operations don't match",
+            file: file,
+            line: line
+        )
         XCTAssertUnsortedEqual(
             filteredDocument.components.schemas.keys.map(\.rawValue),
             schemas,
+            "Schemas don't match",
+            file: file,
+            line: line
+        )
+        XCTAssertUnsortedEqual(
+            filteredDocument.components.parameters.keys.map(\.rawValue),
+            parameters,
+            "Parameters don't match",
             file: file,
             line: line
         )


### PR DESCRIPTION
### Motivation

When filtering by a specific operationId, any path item-level parameters were not included (only operation-level parameters).

### Modifications

Include path item level parameters.

### Result

No errors for missing references when filtering for operations that have a path item-level parameter with a reference.

### Test Plan

Adapted unit tests to cover this.
