### PR TITLE
Add support for OpenAPI 3.0.4 and 3.1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0"),
 
         // Read OpenAPI documents
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "3.1.2"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "3.3.0"),
         .package(url: "https://github.com/jpsim/Yams", "4.0.0"..<"6.0.0"),
 
         // CLI Tool

--- a/Sources/_OpenAPIGeneratorCore/Parser/YamsParser.swift
+++ b/Sources/_OpenAPIGeneratorCore/Parser/YamsParser.swift
@@ -70,10 +70,10 @@ public struct YamsParser: ParserProtocol {
         do {
             let document: OpenAPIKit.OpenAPI.Document
             switch openAPIVersion {
-            case "3.0.0", "3.0.1", "3.0.2", "3.0.3":
+            case "3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4":
                 let openAPI30Document = try decoder.decode(OpenAPIKit30.OpenAPI.Document.self, from: input.contents)
                 document = openAPI30Document.convert(to: .v3_1_0)
-            case "3.1.0": document = try decoder.decode(OpenAPIKit.OpenAPI.Document.self, from: input.contents)
+            case "3.1.0", "3.1.1": document = try decoder.decode(OpenAPIKit.OpenAPI.Document.self, from: input.contents)
             default:
                 throw Diagnostic.openAPIVersionError(
                     versionString: "openapi: \(openAPIVersion)",

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
@@ -21,7 +21,9 @@ final class Test_YamsParser: Test_Core {
         XCTAssertNoThrow(try _test(openAPIVersionString: "3.0.1"))
         XCTAssertNoThrow(try _test(openAPIVersionString: "3.0.2"))
         XCTAssertNoThrow(try _test(openAPIVersionString: "3.0.3"))
+        XCTAssertNoThrow(try _test(openAPIVersionString: "3.0.4"))
         XCTAssertNoThrow(try _test(openAPIVersionString: "3.1.0"))
+        XCTAssertNoThrow(try _test(openAPIVersionString: "3.1.1"))
 
         let expected1 =
             "/foo.yaml: error: Unsupported document version: openapi: 3.2.0. Please provide a document with OpenAPI versions in the 3.0.x or 3.1.x sets."


### PR DESCRIPTION
### Motivation

OpenAPI 3.0.4 and 3.1.1 dropped, mostly containing clarifications: https://www.openapis.org/blog/2024/10/25/announcing-openapi-specification-patch-releases

### Modifications

- Bumped the OpenAPIKit dependency to get the new versions parsed.
- Added the two new versions to our enum.
- Added unit tests.

### Result

We can parse the new versions.

### Test Plan

Added unit tests.

