### PR TITLE
Make error message for missing "openapi" key clearer.

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Parser/YamsParser.swift
+++ b/Sources/_OpenAPIGeneratorCore/Parser/YamsParser.swift
@@ -139,7 +139,7 @@ extension Diagnostic {
     static func openAPIMissingVersionError(location: Location) -> Diagnostic {
         error(
             message:
-                "No openapi key found, please provide a valid OpenAPI document with OpenAPI versions in the 3.0.x or 3.1.x sets.",
+                "No key named openapi found. Please provide a valid OpenAPI document with OpenAPI versions in the 3.0.x or 3.1.x sets.",
             location: location
         )
     }

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
@@ -56,7 +56,7 @@ final class Test_YamsParser: Test_Core {
             """
 
         let expected =
-            "/foo.yaml: error: No openapi key found, please provide a valid OpenAPI document with OpenAPI versions in the 3.0.x or 3.1.x sets."
+            "/foo.yaml: error: No key named openapi found. Please provide a valid OpenAPI document with OpenAPI versions in the 3.0.x or 3.1.x sets."
         assertThrownError(try _test(yaml), expectedDiagnostic: expected)
     }
 


### PR DESCRIPTION
Accidentally hit this error message due to a copy/paste oops and found the resulting error message confusing.

### Motivation

Initially when I saw the message, I thought of key as in public/private keys, not key as in key/value pair.

### Modifications

Slight change in wording to make it clearer that a key with the name openapi is what's missing.

### Result

Error message will be updated.

### Test Plan

Updated test results also and verified tests pass.
