### PR TITLE
Enable strict concurrency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
         with:
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_main_enabled: false
 

--- a/Package.swift
+++ b/Package.swift
@@ -19,15 +19,8 @@ import PackageDescription
 var swiftSettings: [SwiftSetting] = [
     // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
     // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny")
+    .enableUpcomingFeature("ExistentialAny"), .enableExperimentalFeature("StrictConcurrency=complete"),
 ]
-
-// Strict concurrency is enabled in CI; use this environment variable to enable it locally.
-if ProcessInfo.processInfo.environment["SWIFT_OPENAPI_STRICT_CONCURRENCY"].flatMap(Bool.init) ?? false {
-    swiftSettings.append(contentsOf: [
-        .define("SWIFT_OPENAPI_STRICT_CONCURRENCY"), .enableExperimentalFeature("StrictConcurrency"),
-    ])
-}
 
 let package = Package(
     name: "swift-openapi-generator",

--- a/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
+++ b/Sources/_OpenAPIGeneratorCore/Diagnostics.swift
@@ -174,15 +174,17 @@ public protocol DiagnosticCollector {
 /// It receives diagnostics and forwards them to an upstream `DiagnosticCollector`.
 ///
 /// If a diagnostic with a severity of `.error` is emitted, this collector will throw the diagnostic as an error.
-public struct ErrorThrowingDiagnosticCollector: DiagnosticCollector {
-    let upstream: any DiagnosticCollector
+public struct ErrorThrowingDiagnosticCollector: DiagnosticCollector, Sendable {
+
+    /// The `DiagnosticCollector` to which this collector will forward diagnostics.
+    internal let upstream: any DiagnosticCollector & Sendable
 
     /// Initializes a new `ErrorThrowingDiagnosticCollector` with an upstream `DiagnosticCollector`.
     ///
     /// The upstream collector is where this collector will forward all received diagnostics.
     ///
     /// - Parameter upstream: The `DiagnosticCollector` to which this collector will forward diagnostics.
-    public init(upstream: any DiagnosticCollector) { self.upstream = upstream }
+    public init(upstream: any DiagnosticCollector & Sendable) { self.upstream = upstream }
 
     /// Emits a diagnostic to the collector.
     ///

--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -21,7 +21,3 @@
     "_OpenAPIGeneratorCore is only to be used by swift-openapi-generator itself—your target should not link this library or the command line tool directly."
 )
 #endif
-
-#if SWIFT_OPENAPI_STRICT_CONCURRENCY
-#warning("Compiling with Strict Concurrency")
-#endif

--- a/Sources/_OpenAPIGeneratorCore/Translator/Multipart/MultipartAdditionalProperties.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Multipart/MultipartAdditionalProperties.swift
@@ -11,10 +11,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import OpenAPIKit
+@preconcurrency import OpenAPIKit
 
 /// The strategy for handling the additional properties key in a multipart schema.
-enum MultipartAdditionalPropertiesStrategy: Equatable {
+enum MultipartAdditionalPropertiesStrategy: Equatable, Sendable {
 
     /// A strategy where additional properties are explicitly disallowed.
     case disallowed

--- a/Sources/_OpenAPIGeneratorCore/Translator/Multipart/MultipartContentInspector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Multipart/MultipartContentInspector.swift
@@ -305,7 +305,7 @@ extension FileTranslator {
             return nil
         }
         let finalContentTypeSource: MultipartPartInfo.ContentTypeSource
-        if let encoding, let contentType = encoding.contentType {
+        if let encoding, let contentType = encoding.contentTypes.first, encoding.contentTypes.count == 1 {
             finalContentTypeSource = try .explicit(contentType.asGeneratorContentType)
         } else {
             finalContentTypeSource = candidateSource

--- a/Sources/swift-openapi-generator/Extensions.swift
+++ b/Sources/swift-openapi-generator/Extensions.swift
@@ -18,13 +18,11 @@ import Yams
 
 #if $RetroactiveAttribute
 extension URL: @retroactive ExpressibleByArgument {}
-extension GeneratorMode: @retroactive ExpressibleByArgument {}
-extension FeatureFlag: @retroactive ExpressibleByArgument {}
 #else
 extension URL: ExpressibleByArgument {}
+#endif
 extension GeneratorMode: ExpressibleByArgument {}
 extension FeatureFlag: ExpressibleByArgument {}
-#endif
 
 extension URL {
 

--- a/Sources/swift-openapi-generator/FilterCommand.swift
+++ b/Sources/swift-openapi-generator/FilterCommand.swift
@@ -18,7 +18,7 @@ import Yams
 import OpenAPIKit
 
 struct _FilterCommand: AsyncParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
         commandName: "filter",
         abstract: "Filter an OpenAPI document",
         discussion: """

--- a/Sources/swift-openapi-generator/GenerateCommand.swift
+++ b/Sources/swift-openapi-generator/GenerateCommand.swift
@@ -16,7 +16,7 @@ import Foundation
 import _OpenAPIGeneratorCore
 
 struct _GenerateCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration = .init(
+    static let configuration: CommandConfiguration = .init(
         commandName: "generate",
         abstract: "Generate Swift files from an OpenAPI document",
         discussion: """

--- a/Sources/swift-openapi-generator/Tool.swift
+++ b/Sources/swift-openapi-generator/Tool.swift
@@ -14,7 +14,7 @@
 import ArgumentParser
 
 @main struct _Tool: AsyncParsableCommand {
-    static var configuration: CommandConfiguration = .init(
+    static let configuration: CommandConfiguration = .init(
         commandName: "swift-openapi-generator",
         abstract: "Generate Swift client and server code from an OpenAPI document",
         subcommands: [_FilterCommand.self, _GenerateCommand.self]

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/Multipart/Test_MultipartAdditionalProperties.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/Multipart/Test_MultipartAdditionalProperties.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit
+@preconcurrency import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 class Test_MultipartAdditionalProperties: XCTestCase {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit
+@preconcurrency import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 final class Test_TypeMatcher: Test_Core {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import OpenAPIKit
+@preconcurrency import OpenAPIKit
 @testable import _OpenAPIGeneratorCore
 
 class Test_isSchemaSupported: XCTestCase {


### PR DESCRIPTION
### Motivation:

Catch potential data races at build time.

### Modifications:

- Enabled unconditional strict concurrency complete checking.
- Enabled warnings-as-errors on Swift 6 Linux pipelines.
- Made a few fixes to be strict concurrency-clean.

### Result:

Fewer potential data races can sneak in.

### Test Plan

Ran tests locally, did not see any more warnings or errors.
