### PR TITLE
Updated examples and integration test with the new servers syntax

### DIFF
--- a/Examples/manual-generation-generator-cli-example/Makefile
+++ b/Examples/manual-generation-generator-cli-example/Makefile
@@ -4,7 +4,7 @@
 
 # The following values can be changed here, or passed on the command line.
 SWIFT_OPENAPI_GENERATOR_GIT_URL ?= https://github.com/apple/swift-openapi-generator
-SWIFT_OPENAPI_GENERATOR_GIT_TAG ?= 1.0.0
+SWIFT_OPENAPI_GENERATOR_GIT_TAG ?= 1.5.0
 SWIFT_OPENAPI_GENERATOR_CLONE_DIR ?= $(CURRENT_MAKEFILE_DIR)/.swift-openapi-generator
 SWIFT_OPENAPI_GENERATOR_BUILD_CONFIGURATION ?= debug
 OPENAPI_YAML_PATH ?= $(CURRENT_MAKEFILE_DIR)/openapi.yaml

--- a/Examples/manual-generation-generator-cli-example/Sources/ManualGeneratorInvocationClient/Generated/Client.swift
+++ b/Examples/manual-generation-generator-cli-example/Sources/ManualGeneratorInvocationClient/Generated/Client.swift
@@ -93,7 +93,10 @@ internal struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }

--- a/Examples/manual-generation-generator-cli-example/Sources/ManualGeneratorInvocationClient/Generated/Types.swift
+++ b/Examples/manual-generation-generator-cli-example/Sources/ManualGeneratorInvocationClient/Generated/Types.swift
@@ -34,6 +34,17 @@ extension APIProtocol {
 /// Server URLs defined in the OpenAPI document.
 internal enum Servers {
     /// Example service deployment.
+    internal enum Server1 {
+        /// Example service deployment.
+        internal static func url() throws -> Foundation.URL {
+            try Foundation.URL(
+                validatingOpenAPIServerURL: "https://example.com/api",
+                variables: []
+            )
+        }
+    }
+    /// Example service deployment.
+    @available(*, deprecated, renamed: "Servers.Server1.url")
     internal static func server1() throws -> Foundation.URL {
         try Foundation.URL(
             validatingOpenAPIServerURL: "https://example.com/api",
@@ -123,10 +134,10 @@ internal enum Operations {
                 self.headers = headers
             }
         }
-        @frozen internal enum Output: Sendable, Hashable {
+        internal enum Output: Sendable, Hashable {
             internal struct Ok: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/greet/GET/responses/200/content`.
-                @frozen internal enum Body: Sendable, Hashable {
+                internal enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/greet/GET/responses/200/content/application\/json`.
                     case json(Components.Schemas.Greeting)
                     /// The associated value of the enum case if `self` is `.json`.
@@ -180,7 +191,7 @@ internal enum Operations {
             /// A response with a code that is not documented in the OpenAPI document.
             case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
-        @frozen internal enum AcceptableContentType: AcceptableProtocol {
+        internal enum AcceptableContentType: AcceptableProtocol {
             case json
             case other(Swift.String)
             internal init?(rawValue: Swift.String) {

--- a/Examples/manual-generation-package-plugin-example/Sources/CommandPluginInvocationClient/GeneratedSources/Client.swift
+++ b/Examples/manual-generation-package-plugin-example/Sources/CommandPluginInvocationClient/GeneratedSources/Client.swift
@@ -10,7 +10,7 @@ import struct Foundation.Data
 import struct Foundation.Date
 #endif
 import HTTPTypes
-package struct Client: APIProtocol {
+internal struct Client: APIProtocol {
     /// The underlying HTTP client.
     private let client: UniversalClient
     /// Creates a new client.
@@ -21,7 +21,7 @@ package struct Client: APIProtocol {
     ///   - configuration: A set of configuration values for the client.
     ///   - transport: A transport that performs HTTP operations.
     ///   - middlewares: A list of middlewares to call before the transport.
-    package init(
+    internal init(
         serverURL: Foundation.URL,
         configuration: Configuration = .init(),
         transport: any ClientTransport,
@@ -39,7 +39,7 @@ package struct Client: APIProtocol {
     }
     /// - Remark: HTTP `GET /greet`.
     /// - Remark: Generated from `#/paths//greet/get(getGreeting)`.
-    package func getGreeting(_ input: Operations.getGreeting.Input) async throws -> Operations.getGreeting.Output {
+    internal func getGreeting(_ input: Operations.getGreeting.Input) async throws -> Operations.getGreeting.Output {
         try await client.send(
             input: input,
             forOperation: Operations.getGreeting.id,
@@ -93,7 +93,10 @@ package struct Client: APIProtocol {
                 default:
                     return .undocumented(
                         statusCode: response.status.code,
-                        .init()
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
                     )
                 }
             }

--- a/Examples/manual-generation-package-plugin-example/Sources/CommandPluginInvocationClient/GeneratedSources/Types.swift
+++ b/Examples/manual-generation-package-plugin-example/Sources/CommandPluginInvocationClient/GeneratedSources/Types.swift
@@ -10,7 +10,7 @@ import struct Foundation.Data
 import struct Foundation.Date
 #endif
 /// A type that performs HTTP operations defined by the OpenAPI document.
-package protocol APIProtocol: Sendable {
+internal protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /greet`.
     /// - Remark: Generated from `#/paths//greet/get(getGreeting)`.
     func getGreeting(_ input: Operations.getGreeting.Input) async throws -> Operations.getGreeting.Output
@@ -20,7 +20,7 @@ package protocol APIProtocol: Sendable {
 extension APIProtocol {
     /// - Remark: HTTP `GET /greet`.
     /// - Remark: Generated from `#/paths//greet/get(getGreeting)`.
-    package func getGreeting(
+    internal func getGreeting(
         query: Operations.getGreeting.Input.Query = .init(),
         headers: Operations.getGreeting.Input.Headers = .init()
     ) async throws -> Operations.getGreeting.Output {
@@ -32,9 +32,20 @@ extension APIProtocol {
 }
 
 /// Server URLs defined in the OpenAPI document.
-package enum Servers {
+internal enum Servers {
     /// Example service deployment.
-    package static func server1() throws -> Foundation.URL {
+    internal enum Server1 {
+        /// Example service deployment.
+        internal static func url() throws -> Foundation.URL {
+            try Foundation.URL(
+                validatingOpenAPIServerURL: "https://example.com/api",
+                variables: []
+            )
+        }
+    }
+    /// Example service deployment.
+    @available(*, deprecated, renamed: "Servers.Server1.url")
+    internal static func server1() throws -> Foundation.URL {
         try Foundation.URL(
             validatingOpenAPIServerURL: "https://example.com/api",
             variables: []
@@ -43,79 +54,79 @@ package enum Servers {
 }
 
 /// Types generated from the components section of the OpenAPI document.
-package enum Components {
+internal enum Components {
     /// Types generated from the `#/components/schemas` section of the OpenAPI document.
-    package enum Schemas {
+    internal enum Schemas {
         /// A value with the greeting contents.
         ///
         /// - Remark: Generated from `#/components/schemas/Greeting`.
-        package struct Greeting: Codable, Hashable, Sendable {
+        internal struct Greeting: Codable, Hashable, Sendable {
             /// The string representation of the greeting.
             ///
             /// - Remark: Generated from `#/components/schemas/Greeting/message`.
-            package var message: Swift.String
+            internal var message: Swift.String
             /// Creates a new `Greeting`.
             ///
             /// - Parameters:
             ///   - message: The string representation of the greeting.
-            package init(message: Swift.String) {
+            internal init(message: Swift.String) {
                 self.message = message
             }
-            package enum CodingKeys: String, CodingKey {
+            internal enum CodingKeys: String, CodingKey {
                 case message
             }
         }
     }
     /// Types generated from the `#/components/parameters` section of the OpenAPI document.
-    package enum Parameters {}
+    internal enum Parameters {}
     /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
-    package enum RequestBodies {}
+    internal enum RequestBodies {}
     /// Types generated from the `#/components/responses` section of the OpenAPI document.
-    package enum Responses {}
+    internal enum Responses {}
     /// Types generated from the `#/components/headers` section of the OpenAPI document.
-    package enum Headers {}
+    internal enum Headers {}
 }
 
 /// API operations, with input and output types, generated from `#/paths` in the OpenAPI document.
-package enum Operations {
+internal enum Operations {
     /// - Remark: HTTP `GET /greet`.
     /// - Remark: Generated from `#/paths//greet/get(getGreeting)`.
-    package enum getGreeting {
-        package static let id: Swift.String = "getGreeting"
-        package struct Input: Sendable, Hashable {
+    internal enum getGreeting {
+        internal static let id: Swift.String = "getGreeting"
+        internal struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/greet/GET/query`.
-            package struct Query: Sendable, Hashable {
+            internal struct Query: Sendable, Hashable {
                 /// The name used in the returned greeting.
                 ///
                 /// - Remark: Generated from `#/paths/greet/GET/query/name`.
-                package var name: Swift.String?
+                internal var name: Swift.String?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
                 ///   - name: The name used in the returned greeting.
-                package init(name: Swift.String? = nil) {
+                internal init(name: Swift.String? = nil) {
                     self.name = name
                 }
             }
-            package var query: Operations.getGreeting.Input.Query
+            internal var query: Operations.getGreeting.Input.Query
             /// - Remark: Generated from `#/paths/greet/GET/header`.
-            package struct Headers: Sendable, Hashable {
-                package var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getGreeting.AcceptableContentType>]
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getGreeting.AcceptableContentType>]
                 /// Creates a new `Headers`.
                 ///
                 /// - Parameters:
                 ///   - accept:
-                package init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getGreeting.AcceptableContentType>] = .defaultValues()) {
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.getGreeting.AcceptableContentType>] = .defaultValues()) {
                     self.accept = accept
                 }
             }
-            package var headers: Operations.getGreeting.Input.Headers
+            internal var headers: Operations.getGreeting.Input.Headers
             /// Creates a new `Input`.
             ///
             /// - Parameters:
             ///   - query:
             ///   - headers:
-            package init(
+            internal init(
                 query: Operations.getGreeting.Input.Query = .init(),
                 headers: Operations.getGreeting.Input.Headers = .init()
             ) {
@@ -123,17 +134,17 @@ package enum Operations {
                 self.headers = headers
             }
         }
-        @frozen package enum Output: Sendable, Hashable {
-            package struct Ok: Sendable, Hashable {
+        internal enum Output: Sendable, Hashable {
+            internal struct Ok: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/greet/GET/responses/200/content`.
-                @frozen package enum Body: Sendable, Hashable {
+                internal enum Body: Sendable, Hashable {
                     /// - Remark: Generated from `#/paths/greet/GET/responses/200/content/application\/json`.
                     case json(Components.Schemas.Greeting)
                     /// The associated value of the enum case if `self` is `.json`.
                     ///
                     /// - Throws: An error if `self` is not `.json`.
                     /// - SeeAlso: `.json`.
-                    package var json: Components.Schemas.Greeting {
+                    internal var json: Components.Schemas.Greeting {
                         get throws {
                             switch self {
                             case let .json(body):
@@ -143,12 +154,12 @@ package enum Operations {
                     }
                 }
                 /// Received HTTP response body
-                package var body: Operations.getGreeting.Output.Ok.Body
+                internal var body: Operations.getGreeting.Output.Ok.Body
                 /// Creates a new `Ok`.
                 ///
                 /// - Parameters:
                 ///   - body: Received HTTP response body
-                package init(body: Operations.getGreeting.Output.Ok.Body) {
+                internal init(body: Operations.getGreeting.Output.Ok.Body) {
                     self.body = body
                 }
             }
@@ -162,7 +173,7 @@ package enum Operations {
             ///
             /// - Throws: An error if `self` is not `.ok`.
             /// - SeeAlso: `.ok`.
-            package var ok: Operations.getGreeting.Output.Ok {
+            internal var ok: Operations.getGreeting.Output.Ok {
                 get throws {
                     switch self {
                     case let .ok(response):
@@ -180,10 +191,10 @@ package enum Operations {
             /// A response with a code that is not documented in the OpenAPI document.
             case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
         }
-        @frozen package enum AcceptableContentType: AcceptableProtocol {
+        internal enum AcceptableContentType: AcceptableProtocol {
             case json
             case other(Swift.String)
-            package init?(rawValue: Swift.String) {
+            internal init?(rawValue: Swift.String) {
                 switch rawValue.lowercased() {
                 case "application/json":
                     self = .json
@@ -191,7 +202,7 @@ package enum Operations {
                     self = .other(rawValue)
                 }
             }
-            package var rawValue: Swift.String {
+            internal var rawValue: Swift.String {
                 switch self {
                 case let .other(string):
                     return string
@@ -199,7 +210,7 @@ package enum Operations {
                     return "application/json"
                 }
             }
-            package static var allCases: [Self] {
+            internal static var allCases: [Self] {
                 [
                     .json
                 ]

--- a/IntegrationTest/Sources/MockTransportClient/Client.swift
+++ b/IntegrationTest/Sources/MockTransportClient/Client.swift
@@ -24,6 +24,6 @@ struct MockClientTransport: ClientTransport {
 }
 
 func run() async throws {
-    let client = Client(serverURL: try Servers.server1(), transport: MockClientTransport())
+    let client = Client(serverURL: try Servers.Server1.url(), transport: MockClientTransport())
     _ = try await client.getGreeting(.init())
 }

--- a/IntegrationTest/Sources/MockTransportServer/Server.swift
+++ b/IntegrationTest/Sources/MockTransportServer/Server.swift
@@ -36,5 +36,5 @@ class MockServerTransport: ServerTransport {
 func initializeServer() throws {
     let handler = SimpleAPIImpl()
     let transport = MockServerTransport()
-    try handler.registerHandlers(on: transport, serverURL: Servers.server1())
+    try handler.registerHandlers(on: transport, serverURL: Servers.Server1.url())
 }


### PR DESCRIPTION
### Motivation

A drive-by fixup, I noticed the warnings when running the integration test locally.

### Modifications

Fixed up the examples and integrate test to use the new syntax. This also meant regenerating the two examples that check in generated code, which took in a few more changes since 1.0.

### Result

Syntax matches our current best practices.

### Test Plan

Looks good locally.
