### PR TITLE
bullet format file errors

### DIFF
--- a/Plugins/PluginsShared/PluginError.swift
+++ b/Plugins/PluginsShared/PluginError.swift
@@ -37,7 +37,7 @@ enum PluginError: Swift.Error, CustomStringConvertible, LocalizedError {
             let targetNames = targetNames.joined(separator: ", ", lastSeparator: " and ")
             return "Found no targets with names \(targetNames)."
         case .fileErrors(let fileErrors):
-            return "Issues with required files: \(fileErrors.map(\.description).joined(separator: ", and"))."
+            return "Issues with required files:\n\(fileErrors.map { $0 .description.prepended("- ") }.joined(separator: "\n"))."
         }
     }
 

--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -97,3 +97,9 @@ extension Array where Element == String {
         return "\(self.dropLast().joined(separator: separator))\(lastSeparator)\(self.last!)"
     }
 }
+
+extension String {
+    func prepended(_ prefix: String) -> String {
+        return prefix + self
+    }
+}


### PR DESCRIPTION
### Motivation

Generated my first package and initially had my config and schema files in the wrong location which generated the following error message:

```
error: Issues with required files: No config file found in the target named 'BlueskyKit'. Add a file called 'openapi-generator-config.yaml' or 'openapi-generator-config.yml' to the target's source directory. See documentation for details., andNo OpenAPI document found in the target named 'BlueskyKit'. Add a file called 'openapi.yaml', 'openapi.yml' or 'openapi.json' (can also be a symlink) to the target's source directory. See documentation for details..
```

The issue is the separation between multiple error messages, resulting in `etails., andNo` and that was confusing.

### Modifications

For these file error messages, formats them to spit out into a bulleted `-` list.

Note: This does not fix the (pretty much) unnecessary added periods to the end of these messages that wrap other messages that have periods. I will save that for a later time.

### Result

```
error: Issues with required files:
- No config file found in the target named 'BlueskyKit'. Add a file called 'openapi-generator-config.yaml' or 'openapi-generator-config.yml' to the target's source directory. See documentation for details.
- No OpenAPI document found in the target named 'BlueskyKit'. Add a file called 'openapi.yaml', 'openapi.yml' or 'openapi.json' (can also be a symlink) to the target's source directory. See documentation for details..
```