### PR TITLE
Assign to properties with explicit self in encode(to encoder: any Encoder)

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
@@ -156,7 +156,7 @@ extension FileTranslator {
             .try(
                 .identifierPattern("container").dot("encode\(property.typeUsage.isOptional ? "IfPresent" : "")")
                     .call([
-                        .init(label: nil, expression: .identifierPattern(property.swiftSafeName)),
+                        .init(label: nil, expression: .identifierPattern("self").dot(property.swiftSafeName)),
                         .init(label: "forKey", expression: .dot(property.swiftSafeName)),
                     ])
             )

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -637,7 +637,7 @@ public enum Components {
             public func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfPresent(
-                    foo,
+                    self.foo,
                     forKey: .foo
                 )
                 try encoder.encodeAdditionalProperties(additionalProperties)
@@ -677,7 +677,7 @@ public enum Components {
             public func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfPresent(
-                    foo,
+                    self.foo,
                     forKey: .foo
                 )
                 try encoder.encodeAdditionalProperties(additionalProperties)


### PR DESCRIPTION
### Motivation

The generated `encode(to encoder: any Encoder)` assigns to properties without using explicit self. This is a problem because it can produce conflicts with the local variables created in the function, e.g. the encoding container, which will then fail to compile for schemas with properties named `container`, as found in https://github.com/apple/swift-openapi-generator/issues/695.

### Modifications

- Assign to properties with explicit self in `encode(to encoder: any Encoder)`

### Test Plan

- Update the reference tests.


@simonjbeaumont it seems to be working on my project with this change, sadly I didn't know what updates I should make for the snippet tests 😕. I you have any insight on this that would be helpful 🙏 .
