### PR TITLE
Access properties with explicit self in `encode(to encoder:)`

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
@@ -156,7 +156,7 @@ extension FileTranslator {
             .try(
                 .identifierPattern("container").dot("encode\(property.typeUsage.isOptional ? "IfPresent" : "")")
                     .call([
-                        .init(label: nil, expression: .identifierPattern(property.swiftSafeName)),
+                        .init(label: nil, expression: .identifierPattern("self").dot(property.swiftSafeName)),
                         .init(label: "forKey", expression: .dot(property.swiftSafeName)),
                     ])
             )

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/Docs/petstore.yaml
@@ -406,6 +406,14 @@ components:
           type: [array, null]
           items:
             type: [string, null]
+    # To catch the clashes of members and the decoding container.
+    TypedAdditionalPropertiesWithPropertyNamedContainer:
+      type: object
+      properties:
+        container:
+          type: string
+      additionalProperties:
+        type: integer
     CodeError:
       type: object
       properties:

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -637,7 +637,7 @@ public enum Components {
             public func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfPresent(
-                    foo,
+                    self.foo,
                     forKey: .foo
                 )
                 try encoder.encodeAdditionalProperties(additionalProperties)
@@ -677,7 +677,7 @@ public enum Components {
             public func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfPresent(
-                    foo,
+                    self.foo,
                     forKey: .foo
                 )
                 try encoder.encodeAdditionalProperties(additionalProperties)
@@ -696,6 +696,46 @@ public enum Components {
             }
             public enum CodingKeys: String, CodingKey {
                 case foo
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/TypedAdditionalPropertiesWithPropertyNamedContainer`.
+        public struct TypedAdditionalPropertiesWithPropertyNamedContainer: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/TypedAdditionalPropertiesWithPropertyNamedContainer/container`.
+            public var container: Swift.String?
+            /// A container of undocumented properties.
+            public var additionalProperties: [String: Swift.Int]
+            /// Creates a new `TypedAdditionalPropertiesWithPropertyNamedContainer`.
+            ///
+            /// - Parameters:
+            ///   - container:
+            ///   - additionalProperties: A container of undocumented properties.
+            public init(
+                container: Swift.String? = nil,
+                additionalProperties: [String: Swift.Int] = .init()
+            ) {
+                self.container = container
+                self.additionalProperties = additionalProperties
+            }
+            public enum CodingKeys: String, CodingKey {
+                case container
+            }
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.container = try container.decodeIfPresent(
+                    Swift.String.self,
+                    forKey: .container
+                )
+                additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [
+                    "container"
+                ])
+            }
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeIfPresent(
+                    self.container,
+                    forKey: .container
+                )
+                try encoder.encodeAdditionalProperties(additionalProperties)
             }
         }
         /// - Remark: Generated from `#/components/schemas/CodeError`.

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -547,20 +547,42 @@ final class SnippetBasedReferenceTests: XCTestCase {
             schemas:
               MyObject:
                 type: object
-                properties: {}
+                properties:
+                  id:
+                    type: string
                 additionalProperties: true
             """,
             """
             public enum Schemas {
                 public struct MyObject: Codable, Hashable, Sendable {
+                    public var id: Swift.String?
                     public var additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer
-                    public init(additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer = .init()) {
+                    public init(
+                        id: Swift.String? = nil,
+                        additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer = .init()
+                    ) {
+                        self.id = id
                         self.additionalProperties = additionalProperties
                     }
+                    public enum CodingKeys: String, CodingKey {
+                        case id
+                    }
                     public init(from decoder: any Decoder) throws {
-                        additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.id = try container.decodeIfPresent(
+                            Swift.String.self,
+                            forKey: .id
+                        )
+                        additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [
+                            "id"
+                        ])
                     }
                     public func encode(to encoder: any Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        try container.encodeIfPresent(
+                            self.id,
+                            forKey: .id
+                        )
                         try encoder.encodeAdditionalProperties(additionalProperties)
                     }
                 }


### PR DESCRIPTION
### Motivation

In #696 we avoided clashing with a property called `container` in certain schemas by making use of explicit self in `init(from decoder:)`. We didn't have access to the OpenAPI document and hadn't caught the case where this was used in a schema that supported additional properties, where we also need to avoid the clash in `encode(to encoder:)`.

### Modifications

- Access properties with explicit self in `encode(to encoder:)`.

### Result

- Fixes #695 

### Test Plan

More snippet tests and reference tests. 