### PR TITLE
Use self for member access/assignment in all initializers, decoders, and encoders

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -1354,6 +1354,16 @@ extension Expression {
     /// - Returns: A new expression representing member access with a dot prefix.
     static func dot(_ member: String) -> Self { Self.memberAccess(.init(right: member)) }
 
+    /// Returns a new member access expression with `self` as the receiver.
+    ///
+    /// For example: `self.foo`, where `member` is `foo`.
+    ///
+    /// - Parameter member: The name of the member to access on the expression.
+    /// - Returns: A new expression representing member access.
+    static func selfDot(_ member: String) -> Expression {
+        .memberAccess(.init(left: .identifier(.pattern("self")), right: member))
+    }
+
     /// Returns a new identifier expression for the provided pattern, such
     /// as a variable or function name.
     /// - Parameter name: The name of the identifier.
@@ -1555,6 +1565,7 @@ extension Expression {
     /// - Parameter expressions: The member expressions.
     /// - Returns: A tuple expression.
     static func tuple(_ expressions: [Expression]) -> Self { .tuple(.init(members: expressions)) }
+
 }
 
 extension MemberAccessDescription {

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateCodable.swift
@@ -118,7 +118,7 @@ extension FileTranslator {
         let assignExprs: [Expression] = properties.map { property in
             let typeUsage = property.typeUsage
             return .assignment(
-                left: .identifierPattern("self").dot(property.swiftSafeName),
+                left: .selfDot(property.swiftSafeName),
                 right: .try(
                     .identifierPattern("container").dot("decode\(typeUsage.isOptional ? "IfPresent" : "")")
                         .call([
@@ -156,7 +156,7 @@ extension FileTranslator {
             .try(
                 .identifierPattern("container").dot("encode\(property.typeUsage.isOptional ? "IfPresent" : "")")
                     .call([
-                        .init(label: nil, expression: .identifierPattern("self").dot(property.swiftSafeName)),
+                        .init(label: nil, expression: .selfDot(property.swiftSafeName)),
                         .init(label: "forKey", expression: .dot(property.swiftSafeName)),
                     ])
             )
@@ -181,7 +181,7 @@ extension FileTranslator {
         let assignExprs: [Expression] = properties.map { property, isKeyValuePair in
             let decoderExpr: Expression =
                 isKeyValuePair ? .initFromDecoderExpr() : .decodeFromSingleValueContainerExpr()
-            return .assignment(left: .identifierPattern(property.swiftSafeName), right: .try(decoderExpr))
+            return .assignment(left: .selfDot(property.swiftSafeName), right: .try(decoderExpr))
         }
         return decoderInitializer(body: assignExprs.map { .expression($0) })
     }
@@ -194,12 +194,11 @@ extension FileTranslator {
     {
         let exprs: [Expression]
         if let firstSingleValue = properties.first(where: { !$0.isKeyValuePair }) {
-            let expr: Expression = .identifierPattern(firstSingleValue.property.swiftSafeName)
+            let expr: Expression = .selfDot(firstSingleValue.property.swiftSafeName)
                 .encodeToSingleValueContainerExpr(gracefully: false)
             exprs = [expr]
         } else {
-            exprs = properties.filter { $0.isKeyValuePair }.map(\.property.swiftSafeName)
-                .map { name in .identifierPattern(name).encodeExpr() }
+            exprs = properties.filter(\.isKeyValuePair).map { .selfDot($0.property.swiftSafeName).encodeExpr() }
         }
         return encoderFunction(body: exprs.map { .expression($0) })
     }
@@ -216,10 +215,7 @@ extension FileTranslator {
         let assignBlocks: [CodeBlock] = properties.map { (property, isKeyValuePair) in
             let decoderExpr: Expression =
                 isKeyValuePair ? .initFromDecoderExpr() : .decodeFromSingleValueContainerExpr()
-            let assignExpr: Expression = .assignment(
-                left: .identifierPattern(property.swiftSafeName),
-                right: .try(decoderExpr)
-            )
+            let assignExpr: Expression = .assignment(left: .selfDot(property.swiftSafeName), right: .try(decoderExpr))
             return .expression(assignExpr.wrapInDoCatchAppendArrayExpr())
         }
         let atLeastOneNotNilCheckExpr: Expression = .try(
@@ -227,7 +223,7 @@ extension FileTranslator {
                 .call([
                     .init(
                         label: nil,
-                        expression: .literal(.array(properties.map { .identifierPattern($0.property.swiftSafeName) }))
+                        expression: .literal(.array(properties.map { .selfDot($0.property.swiftSafeName) }))
                     ), .init(label: "type", expression: .identifierPattern("Self").dot("self")),
                     .init(label: "codingPath", expression: .identifierPattern("decoder").dot("codingPath")),
                     .init(label: "errors", expression: .identifierPattern("errors")),
@@ -250,14 +246,12 @@ extension FileTranslator {
             ? nil
             : .try(
                 .identifierPattern("encoder").dot("encodeFirstNonNilValueToSingleValueContainer")
-                    .call([
-                        .init(label: nil, expression: .literal(.array(singleValueNames.map { .identifierPattern($0) })))
-                    ])
+                    .call([.init(label: nil, expression: .literal(.array(singleValueNames.map { .selfDot($0) })))])
             )
         let encodeExprs: [Expression] =
             (encodeSingleValuesExpr.flatMap { [$0] } ?? [])
             + properties.filter { $0.isKeyValuePair }.map(\.property)
-            .map { property in .identifierPattern(property.swiftSafeName).optionallyChained().encodeExpr() }
+            .map { property in .selfDot(property.swiftSafeName).optionallyChained().encodeExpr() }
         return encoderFunction(body: encodeExprs.map { .expression($0) })
     }
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
@@ -107,10 +107,8 @@ extension TypesFileTranslator {
                 case .variable(var variableDescription) = commented
             else { return member }
             let name = TextBasedRenderer.renderedExpressionAsString(variableDescription.left)
-            variableDescription.getter = [.expression(.identifierPattern("storage").dot("value").dot(name))]
-            variableDescription.modify = [
-                .expression(.yield(.inOut(.identifierPattern("storage").dot("value").dot(name))))
-            ]
+            variableDescription.getter = [.expression(.selfDot("storage").dot("value").dot(name))]
+            variableDescription.modify = [.expression(.yield(.inOut(.selfDot("storage").dot("value").dot(name))))]
             return .commentable(comment, .variable(variableDescription))
         }
 
@@ -127,7 +125,7 @@ extension TypesFileTranslator {
             funcDesc.body = [
                 .expression(
                     .assignment(
-                        left: .identifierPattern("storage"),
+                        left: .selfDot("storage"),
                         right: .dot("init")
                             .call([
                                 .init(
@@ -167,7 +165,7 @@ extension TypesFileTranslator {
                 body: [
                     .expression(
                         .assignment(
-                            left: .identifierPattern("storage"),
+                            left: .selfDot("storage"),
                             right: .try(
                                 .dot("init").call([.init(label: "from", expression: .identifierPattern("decoder"))])
                             )
@@ -185,7 +183,7 @@ extension TypesFileTranslator {
                 body: [
                     .expression(
                         .try(
-                            .identifierPattern("storage").dot("encode")
+                            .selfDot("storage").dot("encode")
                                 .call([.init(label: "to", expression: .identifierPattern("encoder"))])
                         )
                     )

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -355,31 +355,31 @@ public enum Components {
             public init(from decoder: any Decoder) throws {
                 var errors: [any Error] = []
                 do {
-                    value1 = try decoder.decodeFromSingleValueContainer()
+                    self.value1 = try decoder.decodeFromSingleValueContainer()
                 } catch {
                     errors.append(error)
                 }
                 do {
-                    value2 = try decoder.decodeFromSingleValueContainer()
+                    self.value2 = try decoder.decodeFromSingleValueContainer()
                 } catch {
                     errors.append(error)
                 }
                 do {
-                    value3 = try .init(from: decoder)
+                    self.value3 = try .init(from: decoder)
                 } catch {
                     errors.append(error)
                 }
                 do {
-                    value4 = try decoder.decodeFromSingleValueContainer()
+                    self.value4 = try decoder.decodeFromSingleValueContainer()
                 } catch {
                     errors.append(error)
                 }
                 try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                     [
-                        value1,
-                        value2,
-                        value3,
-                        value4
+                        self.value1,
+                        self.value2,
+                        self.value3,
+                        self.value4
                     ],
                     type: Self.self,
                     codingPath: decoder.codingPath,
@@ -388,11 +388,11 @@ public enum Components {
             }
             public func encode(to encoder: any Encoder) throws {
                 try encoder.encodeFirstNonNilValueToSingleValueContainer([
-                    value1,
-                    value2,
-                    value4
+                    self.value1,
+                    self.value2,
+                    self.value4
                 ])
-                try value3?.encode(to: encoder)
+                try self.value3?.encode(to: encoder)
             }
         }
         /// - Remark: Generated from `#/components/schemas/MixedOneOf`.
@@ -459,11 +459,11 @@ public enum Components {
                 self.value2 = value2
             }
             public init(from decoder: any Decoder) throws {
-                value1 = try decoder.decodeFromSingleValueContainer()
-                value2 = try decoder.decodeFromSingleValueContainer()
+                self.value1 = try decoder.decodeFromSingleValueContainer()
+                self.value2 = try decoder.decodeFromSingleValueContainer()
             }
             public func encode(to encoder: any Encoder) throws {
-                try encoder.encodeToSingleValueContainer(value1)
+                try encoder.encodeToSingleValueContainer(self.value1)
             }
         }
         /// Kind of pet
@@ -787,12 +787,12 @@ public enum Components {
                 self.value2 = value2
             }
             public init(from decoder: any Decoder) throws {
-                value1 = try .init(from: decoder)
-                value2 = try .init(from: decoder)
+                self.value1 = try .init(from: decoder)
+                self.value2 = try .init(from: decoder)
             }
             public func encode(to encoder: any Encoder) throws {
-                try value1.encode(to: encoder)
-                try value2.encode(to: encoder)
+                try self.value1.encode(to: encoder)
+                try self.value2.encode(to: encoder)
             }
         }
         /// - Remark: Generated from `#/components/schemas/AnyOfObjects`.
@@ -831,19 +831,19 @@ public enum Components {
             public init(from decoder: any Decoder) throws {
                 var errors: [any Error] = []
                 do {
-                    value1 = try .init(from: decoder)
+                    self.value1 = try .init(from: decoder)
                 } catch {
                     errors.append(error)
                 }
                 do {
-                    value2 = try .init(from: decoder)
+                    self.value2 = try .init(from: decoder)
                 } catch {
                     errors.append(error)
                 }
                 try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                     [
-                        value1,
-                        value2
+                        self.value1,
+                        self.value2
                     ],
                     type: Self.self,
                     codingPath: decoder.codingPath,
@@ -851,8 +851,8 @@ public enum Components {
                 )
             }
             public func encode(to encoder: any Encoder) throws {
-                try value1?.encode(to: encoder)
-                try value2?.encode(to: encoder)
+                try self.value1?.encode(to: encoder)
+                try self.value2?.encode(to: encoder)
             }
         }
         /// - Remark: Generated from `#/components/schemas/OneOfAny`.
@@ -997,12 +997,12 @@ public enum Components {
                 self.value2 = value2
             }
             public init(from decoder: any Decoder) throws {
-                value1 = try .init(from: decoder)
-                value2 = try .init(from: decoder)
+                self.value1 = try .init(from: decoder)
+                self.value2 = try .init(from: decoder)
             }
             public func encode(to encoder: any Encoder) throws {
-                try value1.encode(to: encoder)
-                try value2.encode(to: encoder)
+                try self.value1.encode(to: encoder)
+                try self.value2.encode(to: encoder)
             }
         }
         /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator`.
@@ -1062,19 +1062,19 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/RecursivePet/name`.
             public var name: Swift.String {
                 get  {
-                    storage.value.name
+                    self.storage.value.name
                 }
                 _modify {
-                    yield &storage.value.name
+                    yield &self.storage.value.name
                 }
             }
             /// - Remark: Generated from `#/components/schemas/RecursivePet/parent`.
             public var parent: Components.Schemas.RecursivePet? {
                 get  {
-                    storage.value.parent
+                    self.storage.value.parent
                 }
                 _modify {
-                    yield &storage.value.parent
+                    yield &self.storage.value.parent
                 }
             }
             /// Creates a new `RecursivePet`.
@@ -1086,7 +1086,7 @@ public enum Components {
                 name: Swift.String,
                 parent: Components.Schemas.RecursivePet? = nil
             ) {
-                storage = .init(value: .init(
+                self.storage = .init(value: .init(
                     name: name,
                     parent: parent
                 ))
@@ -1096,10 +1096,10 @@ public enum Components {
                 case parent
             }
             public init(from decoder: any Decoder) throws {
-                storage = try .init(from: decoder)
+                self.storage = try .init(from: decoder)
             }
             public func encode(to encoder: any Encoder) throws {
-                try storage.encode(to: encoder)
+                try self.storage.encode(to: encoder)
             }
             /// Internal reference storage to allow type recursion.
             private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
@@ -1123,10 +1123,10 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/RecursivePetNested/name`.
             public var name: Swift.String {
                 get  {
-                    storage.value.name
+                    self.storage.value.name
                 }
                 _modify {
-                    yield &storage.value.name
+                    yield &self.storage.value.name
                 }
             }
             /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent`.
@@ -1147,10 +1147,10 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent`.
             public var parent: Components.Schemas.RecursivePetNested.parentPayload? {
                 get  {
-                    storage.value.parent
+                    self.storage.value.parent
                 }
                 _modify {
-                    yield &storage.value.parent
+                    yield &self.storage.value.parent
                 }
             }
             /// Creates a new `RecursivePetNested`.
@@ -1162,7 +1162,7 @@ public enum Components {
                 name: Swift.String,
                 parent: Components.Schemas.RecursivePetNested.parentPayload? = nil
             ) {
-                storage = .init(value: .init(
+                self.storage = .init(value: .init(
                     name: name,
                     parent: parent
                 ))
@@ -1172,10 +1172,10 @@ public enum Components {
                 case parent
             }
             public init(from decoder: any Decoder) throws {
-                storage = try .init(from: decoder)
+                self.storage = try .init(from: decoder)
             }
             public func encode(to encoder: any Encoder) throws {
-                try storage.encode(to: encoder)
+                try self.storage.encode(to: encoder)
             }
             /// Internal reference storage to allow type recursion.
             private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
@@ -1214,10 +1214,10 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value1`.
             public var value1: Components.Schemas.RecursivePetOneOf {
                 get  {
-                    storage.value.value1
+                    self.storage.value.value1
                 }
                 _modify {
-                    yield &storage.value.value1
+                    yield &self.storage.value.value1
                 }
             }
             /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2`.
@@ -1238,10 +1238,10 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2`.
             public var value2: Components.Schemas.RecursivePetOneOfFirst.Value2Payload {
                 get  {
-                    storage.value.value2
+                    self.storage.value.value2
                 }
                 _modify {
-                    yield &storage.value.value2
+                    yield &self.storage.value.value2
                 }
             }
             /// Creates a new `RecursivePetOneOfFirst`.
@@ -1253,16 +1253,16 @@ public enum Components {
                 value1: Components.Schemas.RecursivePetOneOf,
                 value2: Components.Schemas.RecursivePetOneOfFirst.Value2Payload
             ) {
-                storage = .init(value: .init(
+                self.storage = .init(value: .init(
                     value1: value1,
                     value2: value2
                 ))
             }
             public init(from decoder: any Decoder) throws {
-                storage = try .init(from: decoder)
+                self.storage = try .init(from: decoder)
             }
             public func encode(to encoder: any Encoder) throws {
-                try storage.encode(to: encoder)
+                try self.storage.encode(to: encoder)
             }
             /// Internal reference storage to allow type recursion.
             private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
@@ -1294,12 +1294,12 @@ public enum Components {
                     self.value2 = value2
                 }
                 init(from decoder: any Decoder) throws {
-                    value1 = try .init(from: decoder)
-                    value2 = try .init(from: decoder)
+                    self.value1 = try .init(from: decoder)
+                    self.value2 = try .init(from: decoder)
                 }
                 func encode(to encoder: any Encoder) throws {
-                    try value1.encode(to: encoder)
-                    try value2.encode(to: encoder)
+                    try self.value1.encode(to: encoder)
+                    try self.value2.encode(to: encoder)
                 }
             }
         }
@@ -1337,12 +1337,12 @@ public enum Components {
                 self.value2 = value2
             }
             public init(from decoder: any Decoder) throws {
-                value1 = try .init(from: decoder)
-                value2 = try .init(from: decoder)
+                self.value1 = try .init(from: decoder)
+                self.value2 = try .init(from: decoder)
             }
             public func encode(to encoder: any Encoder) throws {
-                try value1.encode(to: encoder)
-                try value2.encode(to: encoder)
+                try self.value1.encode(to: encoder)
+                try self.value2.encode(to: encoder)
             }
         }
         /// - Remark: Generated from `#/components/schemas/RecursivePetOneOf`.
@@ -1387,19 +1387,19 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf/value1`.
             public var value1: Components.Schemas.RecursivePetAnyOf? {
                 get  {
-                    storage.value.value1
+                    self.storage.value.value1
                 }
                 _modify {
-                    yield &storage.value.value1
+                    yield &self.storage.value.value1
                 }
             }
             /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf/value2`.
             public var value2: Swift.String? {
                 get  {
-                    storage.value.value2
+                    self.storage.value.value2
                 }
                 _modify {
-                    yield &storage.value.value2
+                    yield &self.storage.value.value2
                 }
             }
             /// Creates a new `RecursivePetAnyOf`.
@@ -1411,16 +1411,16 @@ public enum Components {
                 value1: Components.Schemas.RecursivePetAnyOf? = nil,
                 value2: Swift.String? = nil
             ) {
-                storage = .init(value: .init(
+                self.storage = .init(value: .init(
                     value1: value1,
                     value2: value2
                 ))
             }
             public init(from decoder: any Decoder) throws {
-                storage = try .init(from: decoder)
+                self.storage = try .init(from: decoder)
             }
             public func encode(to encoder: any Encoder) throws {
-                try storage.encode(to: encoder)
+                try self.storage.encode(to: encoder)
             }
             /// Internal reference storage to allow type recursion.
             private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
@@ -1439,19 +1439,19 @@ public enum Components {
                 init(from decoder: any Decoder) throws {
                     var errors: [any Error] = []
                     do {
-                        value1 = try .init(from: decoder)
+                        self.value1 = try .init(from: decoder)
                     } catch {
                         errors.append(error)
                     }
                     do {
-                        value2 = try decoder.decodeFromSingleValueContainer()
+                        self.value2 = try decoder.decodeFromSingleValueContainer()
                     } catch {
                         errors.append(error)
                     }
                     try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                         [
-                            value1,
-                            value2
+                            self.value1,
+                            self.value2
                         ],
                         type: Self.self,
                         codingPath: decoder.codingPath,
@@ -1460,9 +1460,9 @@ public enum Components {
                 }
                 func encode(to encoder: any Encoder) throws {
                     try encoder.encodeFirstNonNilValueToSingleValueContainer([
-                        value2
+                        self.value2
                     ])
-                    try value1?.encode(to: encoder)
+                    try self.value1?.encode(to: encoder)
                 }
             }
         }
@@ -1486,10 +1486,10 @@ public enum Components {
             /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1`.
             public var value1: Components.Schemas.RecursivePetAllOf.Value1Payload {
                 get  {
-                    storage.value.value1
+                    self.storage.value.value1
                 }
                 _modify {
-                    yield &storage.value.value1
+                    yield &self.storage.value.value1
                 }
             }
             /// Creates a new `RecursivePetAllOf`.
@@ -1497,13 +1497,13 @@ public enum Components {
             /// - Parameters:
             ///   - value1:
             public init(value1: Components.Schemas.RecursivePetAllOf.Value1Payload) {
-                storage = .init(value: .init(value1: value1))
+                self.storage = .init(value: .init(value1: value1))
             }
             public init(from decoder: any Decoder) throws {
-                storage = try .init(from: decoder)
+                self.storage = try .init(from: decoder)
             }
             public func encode(to encoder: any Encoder) throws {
-                try storage.encode(to: encoder)
+                try self.storage.encode(to: encoder)
             }
             /// Internal reference storage to allow type recursion.
             private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
@@ -1529,10 +1529,10 @@ public enum Components {
                     self.value1 = value1
                 }
                 init(from decoder: any Decoder) throws {
-                    value1 = try .init(from: decoder)
+                    self.value1 = try .init(from: decoder)
                 }
                 func encode(to encoder: any Encoder) throws {
-                    try value1.encode(to: encoder)
+                    try self.value1.encode(to: encoder)
                 }
             }
         }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -748,13 +748,13 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         self.value4 = value4
                     }
                     public init(from decoder: any Decoder) throws {
-                        value1 = try .init(from: decoder)
-                        value2 = try .init(from: decoder)
-                        value3 = try decoder.decodeFromSingleValueContainer()
-                        value4 = try decoder.decodeFromSingleValueContainer()
+                        self.value1 = try .init(from: decoder)
+                        self.value2 = try .init(from: decoder)
+                        self.value3 = try decoder.decodeFromSingleValueContainer()
+                        self.value4 = try decoder.decodeFromSingleValueContainer()
                     }
                     public func encode(to encoder: any Encoder) throws {
-                        try encoder.encodeToSingleValueContainer(value3)
+                        try encoder.encodeToSingleValueContainer(self.value3)
                     }
                 }
             }
@@ -800,31 +800,31 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public init(from decoder: any Decoder) throws {
                         var errors: [any Error] = []
                         do {
-                            value1 = try .init(from: decoder)
+                            self.value1 = try .init(from: decoder)
                         } catch {
                             errors.append(error)
                         }
                         do {
-                            value2 = try .init(from: decoder)
+                            self.value2 = try .init(from: decoder)
                         } catch {
                             errors.append(error)
                         }
                         do {
-                            value3 = try decoder.decodeFromSingleValueContainer()
+                            self.value3 = try decoder.decodeFromSingleValueContainer()
                         } catch {
                             errors.append(error)
                         }
                         do {
-                            value4 = try decoder.decodeFromSingleValueContainer()
+                            self.value4 = try decoder.decodeFromSingleValueContainer()
                         } catch {
                             errors.append(error)
                         }
                         try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                             [
-                                value1,
-                                value2,
-                                value3,
-                                value4
+                                self.value1,
+                                self.value2,
+                                self.value3,
+                                self.value4
                             ],
                             type: Self.self,
                             codingPath: decoder.codingPath,
@@ -833,11 +833,11 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     }
                     public func encode(to encoder: any Encoder) throws {
                         try encoder.encodeFirstNonNilValueToSingleValueContainer([
-                            value3,
-                            value4
+                            self.value3,
+                            self.value4
                         ])
-                        try value1?.encode(to: encoder)
-                        try value2?.encode(to: encoder)
+                        try self.value1?.encode(to: encoder)
+                        try self.value2?.encode(to: encoder)
                     }
                 }
             }
@@ -1176,19 +1176,19 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public init(from decoder: any Decoder) throws {
                         var errors: [any Error] = []
                         do {
-                            value1 = try .init(from: decoder)
+                            self.value1 = try .init(from: decoder)
                         } catch {
                             errors.append(error)
                         }
                         do {
-                            value2 = try .init(from: decoder)
+                            self.value2 = try .init(from: decoder)
                         } catch {
                             errors.append(error)
                         }
                         try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                             [
-                                value1,
-                                value2
+                                self.value1,
+                                self.value2
                             ],
                             type: Self.self,
                             codingPath: decoder.codingPath,
@@ -1196,8 +1196,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         )
                     }
                     public func encode(to encoder: any Encoder) throws {
-                        try value1?.encode(to: encoder)
-                        try value2?.encode(to: encoder)
+                        try self.value1?.encode(to: encoder)
+                        try self.value2?.encode(to: encoder)
                     }
                 }
             }
@@ -1224,10 +1224,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         self.value1 = value1
                     }
                     public init(from decoder: any Decoder) throws {
-                        value1 = try decoder.decodeFromSingleValueContainer()
+                        self.value1 = try decoder.decodeFromSingleValueContainer()
                     }
                     public func encode(to encoder: any Encoder) throws {
-                        try encoder.encodeToSingleValueContainer(value1)
+                        try encoder.encodeToSingleValueContainer(self.value1)
                     }
                 }
             }
@@ -1260,10 +1260,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                             self.value1 = value1
                         }
                         public init(from decoder: any Decoder) throws {
-                            value1 = try decoder.decodeFromSingleValueContainer()
+                            self.value1 = try decoder.decodeFromSingleValueContainer()
                         }
                         public func encode(to encoder: any Encoder) throws {
-                            try encoder.encodeToSingleValueContainer(value1)
+                            try encoder.encodeToSingleValueContainer(self.value1)
                         }
                     }
                     public var c: Components.Schemas.B.cPayload
@@ -1303,10 +1303,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                             self.value1 = value1
                         }
                         public init(from decoder: any Decoder) throws {
-                            value1 = try decoder.decodeFromSingleValueContainer()
+                            self.value1 = try decoder.decodeFromSingleValueContainer()
                         }
                         public func encode(to encoder: any Encoder) throws {
-                            try encoder.encodeToSingleValueContainer(value1)
+                            try encoder.encodeToSingleValueContainer(self.value1)
                         }
                     }
                     public var c: Components.Schemas.B.cPayload?
@@ -1428,19 +1428,19 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     public init(from decoder: any Decoder) throws {
                         var errors: [any Error] = []
                         do {
-                            value1 = try decoder.decodeFromSingleValueContainer()
+                            self.value1 = try decoder.decodeFromSingleValueContainer()
                         } catch {
                             errors.append(error)
                         }
                         do {
-                            value2 = try decoder.decodeFromSingleValueContainer()
+                            self.value2 = try decoder.decodeFromSingleValueContainer()
                         } catch {
                             errors.append(error)
                         }
                         try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                             [
-                                value1,
-                                value2
+                                self.value1,
+                                self.value2
                             ],
                             type: Self.self,
                             codingPath: decoder.codingPath,
@@ -1449,8 +1449,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     }
                     public func encode(to encoder: any Encoder) throws {
                         try encoder.encodeFirstNonNilValueToSingleValueContainer([
-                            value1,
-                            value2
+                            self.value1,
+                            self.value2
                         ])
                     }
                 }
@@ -1585,23 +1585,23 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 public struct Node: Codable, Hashable, Sendable {
                     public var parent: Components.Schemas.Node? {
                         get  {
-                            storage.value.parent
+                            self.storage.value.parent
                         }
                         _modify {
-                            yield &storage.value.parent
+                            yield &self.storage.value.parent
                         }
                     }
                     public init(parent: Components.Schemas.Node? = nil) {
-                        storage = .init(value: .init(parent: parent))
+                        self.storage = .init(value: .init(parent: parent))
                     }
                     public enum CodingKeys: String, CodingKey {
                         case parent
                     }
                     public init(from decoder: any Decoder) throws {
-                        storage = try .init(from: decoder)
+                        self.storage = try .init(from: decoder)
                     }
                     public func encode(to encoder: any Encoder) throws {
-                        try storage.encode(to: encoder)
+                        try self.storage.encode(to: encoder)
                     }
                     private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
                     private struct Storage: Codable, Hashable, Sendable {
@@ -1641,10 +1641,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 public struct Node: Codable, Hashable, Sendable {
                     public var name: Swift.String {
                         get  {
-                            storage.value.name
+                            self.storage.value.name
                         }
                         _modify {
-                            yield &storage.value.name
+                            yield &self.storage.value.name
                         }
                     }
                     public struct parentPayload: Codable, Hashable, Sendable {
@@ -1658,17 +1658,17 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     }
                     public var parent: Components.Schemas.Node.parentPayload? {
                         get  {
-                            storage.value.parent
+                            self.storage.value.parent
                         }
                         _modify {
-                            yield &storage.value.parent
+                            yield &self.storage.value.parent
                         }
                     }
                     public init(
                         name: Swift.String,
                         parent: Components.Schemas.Node.parentPayload? = nil
                     ) {
-                        storage = .init(value: .init(
+                        self.storage = .init(value: .init(
                             name: name,
                             parent: parent
                         ))
@@ -1678,10 +1678,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         case parent
                     }
                     public init(from decoder: any Decoder) throws {
-                        storage = try .init(from: decoder)
+                        self.storage = try .init(from: decoder)
                     }
                     public func encode(to encoder: any Encoder) throws {
-                        try storage.encode(to: encoder)
+                        try self.storage.encode(to: encoder)
                     }
                     private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
                     private struct Storage: Codable, Hashable, Sendable {
@@ -1736,20 +1736,20 @@ final class SnippetBasedReferenceTests: XCTestCase {
                     }
                     public var value1: Components.Schemas.Node.Value1Payload {
                         get  {
-                            storage.value.value1
+                            self.storage.value.value1
                         }
                         _modify {
-                            yield &storage.value.value1
+                            yield &self.storage.value.value1
                         }
                     }
                     public init(value1: Components.Schemas.Node.Value1Payload) {
-                        storage = .init(value: .init(value1: value1))
+                        self.storage = .init(value: .init(value1: value1))
                     }
                     public init(from decoder: any Decoder) throws {
-                        storage = try .init(from: decoder)
+                        self.storage = try .init(from: decoder)
                     }
                     public func encode(to encoder: any Encoder) throws {
-                        try storage.encode(to: encoder)
+                        try self.storage.encode(to: encoder)
                     }
                     private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
                     private struct Storage: Codable, Hashable, Sendable {
@@ -1767,10 +1767,10 @@ final class SnippetBasedReferenceTests: XCTestCase {
                             self.value1 = value1
                         }
                         init(from decoder: any Decoder) throws {
-                            value1 = try .init(from: decoder)
+                            self.value1 = try .init(from: decoder)
                         }
                         func encode(to encoder: any Encoder) throws {
-                            try value1.encode(to: encoder)
+                            try self.value1.encode(to: encoder)
                         }
                     }
                 }
@@ -1793,34 +1793,34 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 public struct Node: Codable, Hashable, Sendable {
                     public var value1: Components.Schemas.Node? {
                         get  {
-                            storage.value.value1
+                            self.storage.value.value1
                         }
                         _modify {
-                            yield &storage.value.value1
+                            yield &self.storage.value.value1
                         }
                     }
                     public var value2: Swift.String? {
                         get  {
-                            storage.value.value2
+                            self.storage.value.value2
                         }
                         _modify {
-                            yield &storage.value.value2
+                            yield &self.storage.value.value2
                         }
                     }
                     public init(
                         value1: Components.Schemas.Node? = nil,
                         value2: Swift.String? = nil
                     ) {
-                        storage = .init(value: .init(
+                        self.storage = .init(value: .init(
                             value1: value1,
                             value2: value2
                         ))
                     }
                     public init(from decoder: any Decoder) throws {
-                        storage = try .init(from: decoder)
+                        self.storage = try .init(from: decoder)
                     }
                     public func encode(to encoder: any Encoder) throws {
-                        try storage.encode(to: encoder)
+                        try self.storage.encode(to: encoder)
                     }
                     private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
                     private struct Storage: Codable, Hashable, Sendable {
@@ -1836,19 +1836,19 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         init(from decoder: any Decoder) throws {
                             var errors: [any Error] = []
                             do {
-                                value1 = try .init(from: decoder)
+                                self.value1 = try .init(from: decoder)
                             } catch {
                                 errors.append(error)
                             }
                             do {
-                                value2 = try decoder.decodeFromSingleValueContainer()
+                                self.value2 = try decoder.decodeFromSingleValueContainer()
                             } catch {
                                 errors.append(error)
                             }
                             try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
                                 [
-                                    value1,
-                                    value2
+                                    self.value1,
+                                    self.value2
                                 ],
                                 type: Self.self,
                                 codingPath: decoder.codingPath,
@@ -1857,9 +1857,9 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         }
                         func encode(to encoder: any Encoder) throws {
                             try encoder.encodeFirstNonNilValueToSingleValueContainer([
-                                value2
+                                self.value2
                             ])
-                            try value1?.encode(to: encoder)
+                            try self.value1?.encode(to: encoder)
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation

In order to address #695 we made some targeted fixes (#696, #699) to use explicit-self to avoid clashing with schema property names. This addressed a clash with a specific variable with properties of only certain schemas, but there are more places where we might encounter future issues. Specifically, we have other variable names which might cause a clash (e.g. `storage` and `discriminator`), and there are other flavours of initializers, encoders, and decoders that were not updated in the targeted fix.

 In this PR, we update all access and assignment in the generated code dealing with schemas to use explicit-self.


### Modifications

- Use self for member access and assignment in all initializers, decoders, and encoders.
- Update the reference tests and snippet tests.

### Result

Removed some cases where valid OpenAPI docs would produce non-compiling code.

### Test Plan

Snippet and reference tests. The latter is actually compiled during the CI.