### PR TITLE
Add a CLI option for selecting the naming strategy

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Config.swift
+++ b/Sources/_OpenAPIGeneratorCore/Config.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A strategy for turning OpenAPI identifiers into Swift identifiers.
-public enum NamingStrategy: String, Sendable, Codable, Equatable {
+public enum NamingStrategy: String, Sendable, Codable, Equatable, CaseIterable {
 
     /// A defensive strategy that can handle any OpenAPI identifier and produce a non-conflicting Swift identifier.
     ///
@@ -53,6 +53,9 @@ public struct Config: Sendable {
     ///
     /// Defaults to `defensive`.
     public var namingStrategy: NamingStrategy
+
+    /// The default naming strategy.
+    public static let defaultNamingStrategy: NamingStrategy = .defensive
 
     /// A map of OpenAPI identifiers to desired Swift identifiers, used instead of the naming strategy.
     public var nameOverrides: [String: String]

--- a/Sources/_OpenAPIGeneratorCore/Config.swift
+++ b/Sources/_OpenAPIGeneratorCore/Config.swift
@@ -79,7 +79,7 @@ public struct Config: Sendable {
         access: AccessModifier,
         additionalImports: [String] = [],
         filter: DocumentFilter? = nil,
-        namingStrategy: NamingStrategy = .defensive,
+        namingStrategy: NamingStrategy = Config.defaultNamingStrategy,
         nameOverrides: [String: String] = [:],
         featureFlags: FeatureFlags = []
     ) {

--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -50,7 +50,7 @@ struct ImportDescription: Equatable, Codable {
 /// A description of an access modifier.
 ///
 /// For example: `public`.
-public enum AccessModifier: String, Sendable, Equatable, Codable {
+public enum AccessModifier: String, Sendable, Equatable, Codable, CaseIterable {
 
     /// A declaration accessible outside of the module.
     case `public`

--- a/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
@@ -30,7 +30,7 @@ extension _GenerateOptions {
     func runGenerator(outputDirectory: URL, pluginSource: PluginSource?, isDryRun: Bool) async throws {
         let config = try loadedConfig()
         let sortedModes = try resolvedModes(config)
-        let resolvedAccessModifier = resolvedAccessModifier(config) ?? Config.defaultAccessModifier
+        let resolvedAccessModifier = resolvedAccessModifier(config)
         let resolvedAdditionalImports = resolvedAdditionalImports(config)
         let resolvedNamingStragy = resolvedNamingStrategy(config)
         let resolvedNameOverrides = resolvedNameOverrides(config)

--- a/Sources/swift-openapi-generator/GenerateOptions.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions.swift
@@ -28,10 +28,13 @@ struct _GenerateOptions: ParsableArguments {
             "The Swift files to generate. Options: \(GeneratorMode.prettyListing). Note that '\(GeneratorMode.client.rawValue)' and '\(GeneratorMode.server.rawValue)' depend on declarations in '\(GeneratorMode.types.rawValue)'."
     ) var mode: [GeneratorMode] = []
 
+    @Option(help: "The access modifier to use for the API of generated code. Default: \(Config.defaultAccessModifier.rawValue)")
+    var accessModifier: AccessModifier?
+
     @Option(
         help:
-            "The access modifier to use for the API of generated code. Default: \(Config.defaultAccessModifier.rawValue)"
-    ) var accessModifier: AccessModifier?
+            "The strategy for converting OpenAPI names into Swift names. Default: \(Config.defaultNamingStrategy.rawValue)"
+    ) var namingStrategy: NamingStrategy?
 
     @Option(help: "Additional import to add to all generated files.") var additionalImport: [String] = []
 
@@ -44,6 +47,7 @@ struct _GenerateOptions: ParsableArguments {
 }
 
 extension AccessModifier: ExpressibleByArgument {}
+extension NamingStrategy: ExpressibleByArgument {}
 
 extension _GenerateOptions {
 
@@ -78,7 +82,10 @@ extension _GenerateOptions {
     /// Returns the naming strategy requested by the user.
     /// - Parameter config: The configuration specified by the user.
     /// - Returns: The naming strategy requestd by the user.
-    func resolvedNamingStrategy(_ config: _UserConfig?) -> NamingStrategy { config?.namingStrategy ?? .defensive }
+    func resolvedNamingStrategy(_ config: _UserConfig?) -> NamingStrategy {
+        if let namingStrategy { return namingStrategy }
+        return config?.namingStrategy ?? .defensive
+    }
 
     /// Returns the name overrides requested by the user.
     /// - Parameter config: The configuration specified by the user.

--- a/Sources/swift-openapi-generator/GenerateOptions.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions.swift
@@ -28,8 +28,10 @@ struct _GenerateOptions: ParsableArguments {
             "The Swift files to generate. Options: \(GeneratorMode.prettyListing). Note that '\(GeneratorMode.client.rawValue)' and '\(GeneratorMode.server.rawValue)' depend on declarations in '\(GeneratorMode.types.rawValue)'."
     ) var mode: [GeneratorMode] = []
 
-    @Option(help: "The access modifier to use for the API of generated code. Default: \(Config.defaultAccessModifier.rawValue)")
-    var accessModifier: AccessModifier?
+    @Option(
+        help:
+            "The access modifier to use for the API of generated code. Default: \(Config.defaultAccessModifier.rawValue)"
+    ) var accessModifier: AccessModifier?
 
     @Option(
         help:
@@ -84,7 +86,7 @@ extension _GenerateOptions {
     /// - Returns: The naming strategy requestd by the user.
     func resolvedNamingStrategy(_ config: _UserConfig?) -> NamingStrategy {
         if let namingStrategy { return namingStrategy }
-        return config?.namingStrategy ?? .defensive
+        return config?.namingStrategy ?? Config.defaultNamingStrategy
     }
 
     /// Returns the name overrides requested by the user.

--- a/Sources/swift-openapi-generator/GenerateOptions.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions.swift
@@ -66,10 +66,10 @@ extension _GenerateOptions {
     /// Returns the access modifier requested by the user.
     /// - Parameter config: The configuration specified by the user.
     /// - Returns: The access modifier requested by the user, or nil if the default should be used.
-    func resolvedAccessModifier(_ config: _UserConfig?) -> AccessModifier? {
+    func resolvedAccessModifier(_ config: _UserConfig?) -> AccessModifier {
         if let accessModifier { return accessModifier }
         if let accessModifier = config?.accessModifier { return accessModifier }
-        return nil
+        return Config.defaultAccessModifier
     }
 
     /// Returns a list of additional imports requested by the user.


### PR DESCRIPTION
### Motivation

The recently introduced naming strategy is only configurable in the config file, but pure CLI users might also want to use it without creating a config file.

### Modifications

Add a `--naming-strategy` option to the `swift-openapi-generator` CLI.

### Result

Users can use the new naming strategy without creating a config file, if they didn't have one before.

### Test Plan

Tested manually on a sample project.
