### PR TITLE
Add missing imports to fix Swift 6.1+

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,6 +29,7 @@ jobs:
         with:
             name: "Integration test"
             matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
+            matrix_linux_nightly_main_enabled: false
 
     compatibility-test:
       name: Compatibility test
@@ -55,3 +56,4 @@ jobs:
         with:
             name: "Example packages"
             matrix_linux_command: "./scripts/test-examples.sh"
+            matrix_linux_nightly_main_enabled: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_nightly_main_enabled: false
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
     integration-test:
         name: Integration test
@@ -29,7 +29,6 @@ jobs:
         with:
             name: "Integration test"
             matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
-            matrix_linux_nightly_main_enabled: false
 
     compatibility-test:
       name: Compatibility test
@@ -56,4 +55,3 @@ jobs:
         with:
             name: "Example packages"
             matrix_linux_command: "./scripts/test-examples.sh"
-            matrix_linux_nightly_main_enabled: false

--- a/Sources/_OpenAPIGeneratorCore/Extensions/SwiftStandardLibrary.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/SwiftStandardLibrary.swift
@@ -11,6 +11,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import Foundation
+
 extension Int {
     /// Returns the digits for the number using the specified radix.
     /// - Parameter radix: The radix used to format the integer.

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/StructBlueprint.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import OpenAPIKit
+import Foundation
 
 /// A structure that contains the information about an OpenAPI object that is
 /// required to generate a matching Swift structure.

--- a/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Content/ContentInspector.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import OpenAPIKit
+import Foundation
 
 /// Utilities for asking questions about OpenAPI.Content
 extension FileTranslator {

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateServersVariables.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateServersVariables.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import OpenAPIKit
+import Foundation
 
 /// Represents a server variable and the function of generation that should be applied.
 protocol ServerVariableGenerator {


### PR DESCRIPTION
### Motivation

Currently unit tests on Swift 6.1+ toolchains are failing due to a few missing imports.

That these are coming up is good, that's why we've enabled `MemberImportVisibility`.

### Modifications

Add the missing imports to stop relying on implicitly imported extension methods.

### Result

Unit tests compile again on Swift 6.1+.

### Test Plan

Tested locally, will further verify CI is happy.
