### PR TITLE
[Cleanup] Make Config's namingStrategy and accessModifier params consistent

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Config.swift
+++ b/Sources/_OpenAPIGeneratorCore/Config.swift
@@ -79,7 +79,7 @@ public struct Config: Sendable {
         access: AccessModifier,
         additionalImports: [String] = [],
         filter: DocumentFilter? = nil,
-        namingStrategy: NamingStrategy = Config.defaultNamingStrategy,
+        namingStrategy: NamingStrategy,
         nameOverrides: [String: String] = [:],
         featureFlags: FeatureFlags = []
     ) {

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
@@ -165,7 +165,11 @@ final class Test_YamsParser: Test_Core {
         try YamsParser()
             .parseOpenAPI(
                 .init(absolutePath: URL(fileURLWithPath: "/foo.yaml"), contents: Data(yaml.utf8)),
-                config: .init(mode: .types, access: Config.defaultAccessModifier),
+                config: .init(
+                    mode: .types,
+                    access: Config.defaultAccessModifier,
+                    namingStrategy: Config.defaultNamingStrategy
+                ),
                 diagnostics: PrintingDiagnosticCollector()
             )
     }

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_validateDoc.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_validateDoc.swift
@@ -31,7 +31,14 @@ final class Test_validateDoc: Test_Core {
             paths: [:],
             components: .init(schemas: ["myImperfectSchema": schemaWithWarnings])
         )
-        let diagnostics = try validateDoc(doc, config: .init(mode: .types, access: Config.defaultAccessModifier))
+        let diagnostics = try validateDoc(
+            doc,
+            config: .init(
+                mode: .types,
+                access: Config.defaultAccessModifier,
+                namingStrategy: Config.defaultNamingStrategy
+            )
+        )
         XCTAssertEqual(diagnostics.count, 1)
     }
 
@@ -53,7 +60,16 @@ final class Test_validateDoc: Test_Core {
             ],
             components: .noComponents
         )
-        XCTAssertThrowsError(try validateDoc(doc, config: .init(mode: .types, access: Config.defaultAccessModifier)))
+        XCTAssertThrowsError(
+            try validateDoc(
+                doc,
+                config: .init(
+                    mode: .types,
+                    access: Config.defaultAccessModifier,
+                    namingStrategy: Config.defaultNamingStrategy
+                )
+            )
+        )
     }
 
     func testValidateContentTypes_validContentTypes() throws {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_isSchemaSupported.swift
@@ -19,7 +19,11 @@ class Test_isSchemaSupported: XCTestCase {
 
     var translator: any FileTranslator {
         TypesFileTranslator(
-            config: .init(mode: .types, access: Config.defaultAccessModifier),
+            config: .init(
+                mode: .types,
+                access: Config.defaultAccessModifier,
+                namingStrategy: Config.defaultNamingStrategy
+            ),
             diagnostics: PrintingDiagnosticCollector(),
             components: .init(schemas: [
                 "Foo": .string, "MyObj": .object, "MyObj2": .object,

--- a/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/CompatabilityTest.swift
@@ -254,7 +254,7 @@ fileprivate extension CompatibilityTest {
                 for mode in GeneratorMode.allCases {
                     group.addTask {
                         let generator = makeGeneratorPipeline(
-                            config: Config(mode: mode, access: .public),
+                            config: Config(mode: mode, access: .public, namingStrategy: .defensive),
                             diagnostics: diagnosticsCollector
                         )
                         return try assertNoThrowWithValue(generator.run(input))
@@ -265,7 +265,7 @@ fileprivate extension CompatibilityTest {
         } else {
             outputs = try GeneratorMode.allCases.map { mode in
                 let generator = makeGeneratorPipeline(
-                    config: Config(mode: mode, access: .public),
+                    config: Config(mode: mode, access: .public, namingStrategy: .defensive),
                     diagnostics: diagnosticsCollector
                 )
                 return try assertNoThrowWithValue(generator.run(input))

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -5868,7 +5868,7 @@ extension SnippetBasedReferenceTests {
     func makeTypesTranslator(openAPIDocumentYAML: String) throws -> TypesFileTranslator {
         let document = try YAMLDecoder().decode(OpenAPI.Document.self, from: openAPIDocumentYAML)
         return TypesFileTranslator(
-            config: Config(mode: .types, access: .public),
+            config: Config(mode: .types, access: .public, namingStrategy: .defensive),
             diagnostics: XCTestDiagnosticCollector(test: self),
             components: document.components
         )
@@ -5901,7 +5901,12 @@ extension SnippetBasedReferenceTests {
         components: OpenAPI.Components = .noComponents
     ) throws -> TypesFileTranslator {
         TypesFileTranslator(
-            config: Config(mode: .types, access: accessModifier, featureFlags: featureFlags),
+            config: Config(
+                mode: .types,
+                access: accessModifier,
+                namingStrategy: .defensive,
+                featureFlags: featureFlags
+            ),
             diagnostics: XCTestDiagnosticCollector(test: self, ignoredDiagnosticMessages: ignoredDiagnosticMessages),
             components: components
         )
@@ -5915,17 +5920,17 @@ extension SnippetBasedReferenceTests {
         let collector = XCTestDiagnosticCollector(test: self, ignoredDiagnosticMessages: ignoredDiagnosticMessages)
         return (
             TypesFileTranslator(
-                config: Config(mode: .types, access: .public, featureFlags: featureFlags),
+                config: Config(mode: .types, access: .public, namingStrategy: .defensive, featureFlags: featureFlags),
                 diagnostics: collector,
                 components: components
             ),
             ClientFileTranslator(
-                config: Config(mode: .client, access: .public, featureFlags: featureFlags),
+                config: Config(mode: .client, access: .public, namingStrategy: .defensive, featureFlags: featureFlags),
                 diagnostics: collector,
                 components: components
             ),
             ServerFileTranslator(
-                config: Config(mode: .server, access: .public, featureFlags: featureFlags),
+                config: Config(mode: .server, access: .public, namingStrategy: .defensive, featureFlags: featureFlags),
                 diagnostics: collector,
                 components: components
             )


### PR DESCRIPTION
### Motivation

A missed fixup from #708: https://github.com/apple/swift-openapi-generator/pull/708#discussion_r1903932794

### Modifications

Removed the default from Config.init and forced all callers to make a choice on the naming strategy, just like for accessModifier.

### Result

Consistent handling of these two parameters.

### Test Plan

Tests passed locally.
