### PR TITLE
examples: Add streaming ChatGPT proxy from FOSDEM 2025

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -1,6 +1,7 @@
 .gitignore
 .licenseignore
 .swiftformatignore
+.unacceptablelanguageignore
 .spi.yml
 .swift-format
 .github/*
@@ -37,6 +38,8 @@ Examples/HelloWorldiOSClientAppExample/HelloWorldiOSClientApp.*
 Examples/HelloWorldiOSClientAppExample/HelloWorldiOSClientApp/Assets.xcassets/*
 Examples/HelloWorldiOSClientAppExample/HelloWorldiOSClientApp/Preview*
 Examples/**/Generated*
+Examples/streaming-chatgpt-proxy/.env.example
+Examples/streaming-chatgpt-proxy/players.txt
 **/Makefile
 **/*.html
 .editorconfig

--- a/.swiftformatignore
+++ b/.swiftformatignore
@@ -2,4 +2,5 @@ Tests/OpenAPIGeneratorReferenceTests/Resources
 Sources/swift-openapi-generator/Documentation.docc
 Examples/**/Generated/*
 Examples/**/GeneratedSources/*
+Examples/streaming-chatgpt-proxy/**
 **Package.swift

--- a/.unacceptablelanguageignore
+++ b/.unacceptablelanguageignore
@@ -1,0 +1,1 @@
+Examples/streaming-chatgpt-proxy/Sources/ChatGPT/openapi.yaml

--- a/Examples/streaming-chatgpt-proxy/.devcontainer/devcontainer.json
+++ b/Examples/streaming-chatgpt-proxy/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+    "name": "Swift",
+    "image": "swift:6.0",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "lldb.library": "/usr/lib/liblldb.so"
+            },
+            "extensions": [
+                "sswg.swift-lang",
+                "42Crunch.vscode-openapi"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "root"
+}

--- a/Examples/streaming-chatgpt-proxy/.env.example
+++ b/Examples/streaming-chatgpt-proxy/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to just .env and paste your token below.
+OPENAI_TOKEN=PASTE_YOUR_TOKEN_HERE

--- a/Examples/streaming-chatgpt-proxy/.gitignore
+++ b/Examples/streaming-chatgpt-proxy/.gitignore
@@ -1,0 +1,13 @@
+.DS_Store
+.build/
+.build-linux/
+.env
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.vscode
+/Package.resolved
+.ci/
+.docc-build/

--- a/Examples/streaming-chatgpt-proxy/.vscode/settings.json
+++ b/Examples/streaming-chatgpt-proxy/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+    "editor.lightbulb.enabled": "off",
+    "explorer.decorations.badges": false,
+    "explorer.decorations.colors": false,
+    "files.exclude": {
+        "**/.build": true,
+        "**/.build-linux": true,
+        "**/.gitignore": true,
+        "**/.swiftpm": true,
+        "**/.vscode": true,
+        ".env": true,
+        "*.o": true,
+        "*.d": true,
+        "*.swiftdeps": true,
+        "*.swiftdeps~": true,
+    },
+    "outline.problems.colors": false,
+    "outline.problems.badges": false,
+    "lldb.library": "/usr/lib/liblldb.so",
+    "lldb.launch.expressions": "native",
+    "swift.diagnosticsStyle": "default",
+    "swift.disableAutoResolve": true,
+    "swift.sourcekit-lsp.backgroundIndexing": "off",
+    "swift.sourcekit-lsp.disable": true,
+    "swift.buildPath": ".build-linux",
+    "workbench.colorCustomizations": {
+        "editorError.foreground": "#00000000",
+        "editorWarning.foreground": "#00000000",
+    },
+    "workbench.startupEditor": "none"
+}

--- a/Examples/streaming-chatgpt-proxy/Package.swift
+++ b/Examples/streaming-chatgpt-proxy/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "fosdem-2025-demo",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.6.0"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.6.0"),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.2"),
+        .package(url: "https://github.com/swift-server/swift-openapi-vapor", from: "1.0.1"),
+        .package(url: "https://github.com/swift-server/swift-openapi-async-http-client", from: "1.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "ChatGPT",
+            dependencies: [
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+            ],
+            plugins: [
+                .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
+            ]
+        ),
+        .executableTarget(
+            name: "ClientCLI",
+            dependencies: [
+                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
+            ],
+            plugins: [
+                .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
+            ]
+        ),
+        .executableTarget(
+            name: "ProxyServer",
+            dependencies: [
+                "ChatGPT",
+                .product(name: "OpenAPIAsyncHTTPClient", package: "swift-openapi-async-http-client"),
+                .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
+            ],
+            plugins: [
+                .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
+            ]
+        ),
+    ]
+)

--- a/Examples/streaming-chatgpt-proxy/README.md
+++ b/Examples/streaming-chatgpt-proxy/README.md
@@ -1,0 +1,73 @@
+# Streaming ChatGPT Proxy
+
+An example project using [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator).
+
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
+## Overview
+
+A tailored API server, backed by ChatGPT, and client CLI, with end-to-end
+streaming.
+
+This package is the reference sources for the demo presented at [FOSDEM 2025:
+_Live coding a streaming ChatGPT proxy with Swift OpenAPI—from
+scratch!_][fosdem25-swift-openapi]
+
+> Join us as we build a ChatGPT client, from scratch, using Swift OpenAPI Generator. We’ll take advantage of Swift OpenAPI’s pluggable HTTP transports to reuse the same generated client to make upstream calls from a Linux server, providing end-to-end streaming, backed by async sequences, without buffering upstream responses.
+>
+> In this session you’ll learn how to:
+>
+> * Generate a type-safe ChatGPT macOS client and use URLSession OpenAPI transport.
+> * Stream LLM responses using Server Sent Events (SSE).
+> * Bootstrap a Linux proxy server using the Vapor OpenAPI transport.
+> * Use the same generated ChatGPT client within the proxy by switching to the AsyncHTTPClient transport.
+> * Efficiently transform responses from SSE to JSON Lines, maintaining end-to-end streaming.
+
+The example provides an API for a fictitious _ChantGPT_ service, which produces
+creative chants to sing at basketball games. 🙌 🏀 🙌
+
+## Usage
+
+The upstream calls to ChatGPT require an API token, which is configured using the `OPENAI_TOKEN` environment variable.
+Rename `.env.example` to `.env` and replace the placeholder with your token.
+
+Build and run the server using:
+
+```console
+% swift run ProxyServer
+2025-01-30T09:12:23+0000 notice codes.vapor.application : [Vapor] Server starting on http://127.0.0.1:8080
+...
+```
+
+Then, from another terminal, run the proxy client using:
+
+```console
+% swift run ClientCLI "That team with the Bull logo"
+Build of product 'ClientCLI' complete! (7.24s)
+🧑‍💼: That one with the bull logo
+---
+🤖: **"Charge Ahead, Chicago Bulls!"**
+
+(Verse 1)
+Red and black, we’re on the prowl,
+Chicago Bulls, hear us growl!
+From the Windy City, we take the lead,
+Charging forward with lightning speed!
+
+(Chorus)
+B-U-L-L-S, Bulls! Bulls! Bulls!
+We’re the team that never dulls!
+Hoops and hustle, heart and soul,
+Chicago Bulls, we’re on a roll!
+...
+```
+
+## Linux development with VS Code Dev Containers
+
+The package also contains configuration for developing with VS Code [Dev
+Containers][dev-containers].
+
+If you have the Dev Containers extension installed, use the `Dev Containers: Reopen in Container` command to switch to build and run for Linux.
+
+[fosdem25-swift-openapi]: https://fosdem.org/2025/schedule/event/fosdem-2025-5230-live-coding-a-streaming-chatgpt-proxy-with-swift-openapi-from-scratch-/
+[dev-containers]: https://code.visualstudio.com/docs/devcontainers/containers

--- a/Examples/streaming-chatgpt-proxy/Sources/ChatGPT/Middleware.swift
+++ b/Examples/streaming-chatgpt-proxy/Sources/ChatGPT/Middleware.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+
+package struct HeaderFieldMiddleware: ClientMiddleware {
+    var name: HTTPField.Name
+    var value: String
+
+    package static func authTokenFromEnvironment(_ environmentVariable: String) -> Self {
+        guard let token = ProcessInfo.processInfo.environment[environmentVariable] else {
+            fatalError("Please set \(environmentVariable) environment variable.")
+        }
+        return Self(name: .authorization, value: "Bearer \(token)")
+    }
+
+    package func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var request = request
+        request.headerFields[name] = value
+        return try await next(request, body, baseURL)
+    }
+}

--- a/Examples/streaming-chatgpt-proxy/Sources/ChatGPT/openapi-generator-config.yaml
+++ b/Examples/streaming-chatgpt-proxy/Sources/ChatGPT/openapi-generator-config.yaml
@@ -1,0 +1,6 @@
+generate: [types, client]
+accessModifier: package
+filter:
+  paths:
+    - /chat/completions
+namingStrategy: idiomatic

--- a/Examples/streaming-chatgpt-proxy/Sources/ChatGPT/openapi.yaml
+++ b/Examples/streaming-chatgpt-proxy/Sources/ChatGPT/openapi.yaml
@@ -1,0 +1,26823 @@
+openapi: 3.0.0
+info:
+  title: OpenAI API
+  description: The OpenAI REST API. Please see
+    https://platform.openai.com/docs/api-reference for more details.
+  version: 2.3.0
+  termsOfService: https://openai.com/policies/terms-of-use
+  contact:
+    name: OpenAI Support
+    url: https://help.openai.com/
+  license:
+    name: MIT
+    url: https://github.com/openai/openai-openapi/blob/master/LICENSE
+servers:
+  - url: https://api.openai.com/v1
+tags:
+  - name: Assistants
+    description: Build Assistants that can call models and use tools.
+  - name: Audio
+    description: Turn audio into text or text into audio.
+  - name: Chat
+    description: Given a list of messages comprising a conversation, the model will
+      return a response.
+  - name: Completions
+    description: Given a prompt, the model will return one or more predicted
+      completions, and can also return the probabilities of alternative tokens
+      at each position.
+  - name: Embeddings
+    description: Get a vector representation of a given input that can be easily
+      consumed by machine learning models and algorithms.
+  - name: Fine-tuning
+    description: Manage fine-tuning jobs to tailor a model to your specific training data.
+  - name: Batch
+    description: Create large batches of API requests to run asynchronously.
+  - name: Files
+    description: Files are used to upload documents that can be used with features
+      like Assistants and Fine-tuning.
+  - name: Uploads
+    description: Use Uploads to upload large files in multiple parts.
+  - name: Images
+    description: Given a prompt and/or an input image, the model will generate a new image.
+  - name: Models
+    description: List and describe the various models available in the API.
+  - name: Moderations
+    description: Given text and/or image inputs, classifies if those inputs are
+      potentially harmful.
+  - name: Audit Logs
+    description: List user actions and configuration changes within this organization.
+paths:
+  /assistants:
+    get:
+      operationId: listAssistants
+      tags:
+        - Assistants
+      summary: Returns a list of assistants.
+      parameters:
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: order
+          in: query
+          description: >
+            Sort order by the `created_at` timestamp of the objects. `asc` for
+            ascending order and `desc` for descending order.
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: >
+            A cursor for use in pagination. `before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, starting with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the
+            previous page of the list.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAssistantsResponse"
+      x-oaiMeta:
+        name: List assistants
+        group: assistants
+        beta: true
+        returns: A list of [assistant](/docs/api-reference/assistants/object) objects.
+        examples:
+          request:
+            curl: |
+              curl "https://api.openai.com/v1/assistants?order=desc&limit=20" \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              my_assistants = client.beta.assistants.list(
+                  order="desc",
+                  limit="20",
+              )
+              print(my_assistants.data)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const myAssistants = await openai.beta.assistants.list({
+                  order: "desc",
+                  limit: "20",
+                });
+
+                console.log(myAssistants.data);
+              }
+
+              main();
+          response: >
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "asst_abc123",
+                  "object": "assistant",
+                  "created_at": 1698982736,
+                  "name": "Coding Tutor",
+                  "description": null,
+                  "model": "gpt-4o",
+                  "instructions": "You are a helpful assistant designed to make me better at coding!",
+                  "tools": [],
+                  "tool_resources": {},
+                  "metadata": {},
+                  "top_p": 1.0,
+                  "temperature": 1.0,
+                  "response_format": "auto"
+                },
+                {
+                  "id": "asst_abc456",
+                  "object": "assistant",
+                  "created_at": 1698982718,
+                  "name": "My Assistant",
+                  "description": null,
+                  "model": "gpt-4o",
+                  "instructions": "You are a helpful assistant designed to make me better at coding!",
+                  "tools": [],
+                  "tool_resources": {},
+                  "metadata": {},
+                  "top_p": 1.0,
+                  "temperature": 1.0,
+                  "response_format": "auto"
+                },
+                {
+                  "id": "asst_abc789",
+                  "object": "assistant",
+                  "created_at": 1698982643,
+                  "name": null,
+                  "description": null,
+                  "model": "gpt-4o",
+                  "instructions": null,
+                  "tools": [],
+                  "tool_resources": {},
+                  "metadata": {},
+                  "top_p": 1.0,
+                  "temperature": 1.0,
+                  "response_format": "auto"
+                }
+              ],
+              "first_id": "asst_abc123",
+              "last_id": "asst_abc789",
+              "has_more": false
+            }
+    post:
+      operationId: createAssistant
+      tags:
+        - Assistants
+      summary: Create an assistant with a model and instructions.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAssistantRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssistantObject"
+      x-oaiMeta:
+        name: Create assistant
+        group: assistants
+        beta: true
+        returns: An [assistant](/docs/api-reference/assistants/object) object.
+        examples:
+          - title: Code Interpreter
+            request:
+              curl: >
+                curl "https://api.openai.com/v1/assistants" \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                    "name": "Math Tutor",
+                    "tools": [{"type": "code_interpreter"}],
+                    "model": "gpt-4o"
+                  }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                my_assistant = client.beta.assistants.create(
+                    instructions="You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                    name="Math Tutor",
+                    tools=[{"type": "code_interpreter"}],
+                    model="gpt-4o",
+                )
+
+                print(my_assistant)
+              node.js: >-
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const myAssistant = await openai.beta.assistants.create({
+                    instructions:
+                      "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                    name: "Math Tutor",
+                    tools: [{ type: "code_interpreter" }],
+                    model: "gpt-4o",
+                  });
+
+                  console.log(myAssistant);
+                }
+
+
+                main();
+            response: >
+              {
+                "id": "asst_abc123",
+                "object": "assistant",
+                "created_at": 1698984975,
+                "name": "Math Tutor",
+                "description": null,
+                "model": "gpt-4o",
+                "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+                "tools": [
+                  {
+                    "type": "code_interpreter"
+                  }
+                ],
+                "metadata": {},
+                "top_p": 1.0,
+                "temperature": 1.0,
+                "response_format": "auto"
+              }
+          - title: Files
+            request:
+              curl: >
+                curl https://api.openai.com/v1/assistants \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                    "tools": [{"type": "file_search"}],
+                    "tool_resources": {"file_search": {"vector_store_ids": ["vs_123"]}},
+                    "model": "gpt-4o"
+                  }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                my_assistant = client.beta.assistants.create(
+                    instructions="You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                    name="HR Helper",
+                    tools=[{"type": "file_search"}],
+                    tool_resources={"file_search": {"vector_store_ids": ["vs_123"]}},
+                    model="gpt-4o"
+                )
+
+                print(my_assistant)
+              node.js: >-
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const myAssistant = await openai.beta.assistants.create({
+                    instructions:
+                      "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                    name: "HR Helper",
+                    tools: [{ type: "file_search" }],
+                    tool_resources: {
+                      file_search: {
+                        vector_store_ids: ["vs_123"]
+                      }
+                    },
+                    model: "gpt-4o"
+                  });
+
+                  console.log(myAssistant);
+                }
+
+
+                main();
+            response: >
+              {
+                "id": "asst_abc123",
+                "object": "assistant",
+                "created_at": 1699009403,
+                "name": "HR Helper",
+                "description": null,
+                "model": "gpt-4o",
+                "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+                "tools": [
+                  {
+                    "type": "file_search"
+                  }
+                ],
+                "tool_resources": {
+                  "file_search": {
+                    "vector_store_ids": ["vs_123"]
+                  }
+                },
+                "metadata": {},
+                "top_p": 1.0,
+                "temperature": 1.0,
+                "response_format": "auto"
+              }
+  /assistants/{assistant_id}:
+    get:
+      operationId: getAssistant
+      tags:
+        - Assistants
+      summary: Retrieves an assistant.
+      parameters:
+        - in: path
+          name: assistant_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the assistant to retrieve.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssistantObject"
+      x-oaiMeta:
+        name: Retrieve assistant
+        group: assistants
+        beta: true
+        returns: The [assistant](/docs/api-reference/assistants/object) object matching
+          the specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/assistants/asst_abc123 \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              my_assistant = client.beta.assistants.retrieve("asst_abc123")
+              print(my_assistant)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const myAssistant = await openai.beta.assistants.retrieve(
+                  "asst_abc123"
+                );
+
+                console.log(myAssistant);
+              }
+
+              main();
+          response: >
+            {
+              "id": "asst_abc123",
+              "object": "assistant",
+              "created_at": 1699009709,
+              "name": "HR Helper",
+              "description": null,
+              "model": "gpt-4o",
+              "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies.",
+              "tools": [
+                {
+                  "type": "file_search"
+                }
+              ],
+              "metadata": {},
+              "top_p": 1.0,
+              "temperature": 1.0,
+              "response_format": "auto"
+            }
+    post:
+      operationId: modifyAssistant
+      tags:
+        - Assistants
+      summary: Modifies an assistant.
+      parameters:
+        - in: path
+          name: assistant_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the assistant to modify.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModifyAssistantRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssistantObject"
+      x-oaiMeta:
+        name: Modify assistant
+        group: assistants
+        beta: true
+        returns: The modified [assistant](/docs/api-reference/assistants/object) object.
+        examples:
+          request:
+            curl: >
+              curl https://api.openai.com/v1/assistants/asst_abc123 \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -d '{
+                    "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                    "tools": [{"type": "file_search"}],
+                    "model": "gpt-4o"
+                  }'
+            python: >
+              from openai import OpenAI
+
+              client = OpenAI()
+
+
+              my_updated_assistant = client.beta.assistants.update(
+                "asst_abc123",
+                instructions="You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                name="HR Helper",
+                tools=[{"type": "file_search"}],
+                model="gpt-4o"
+              )
+
+
+              print(my_updated_assistant)
+            node.js: >-
+              import OpenAI from "openai";
+
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const myUpdatedAssistant = await openai.beta.assistants.update(
+                  "asst_abc123",
+                  {
+                    instructions:
+                      "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+                    name: "HR Helper",
+                    tools: [{ type: "file_search" }],
+                    model: "gpt-4o"
+                  }
+                );
+
+                console.log(myUpdatedAssistant);
+              }
+
+
+              main();
+          response: >
+            {
+              "id": "asst_123",
+              "object": "assistant",
+              "created_at": 1699009709,
+              "name": "HR Helper",
+              "description": null,
+              "model": "gpt-4o",
+              "instructions": "You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.",
+              "tools": [
+                {
+                  "type": "file_search"
+                }
+              ],
+              "tool_resources": {
+                "file_search": {
+                  "vector_store_ids": []
+                }
+              },
+              "metadata": {},
+              "top_p": 1.0,
+              "temperature": 1.0,
+              "response_format": "auto"
+            }
+    delete:
+      operationId: deleteAssistant
+      tags:
+        - Assistants
+      summary: Delete an assistant.
+      parameters:
+        - in: path
+          name: assistant_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the assistant to delete.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteAssistantResponse"
+      x-oaiMeta:
+        name: Delete assistant
+        group: assistants
+        beta: true
+        returns: Deletion status
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/assistants/asst_abc123 \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -X DELETE
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              response = client.beta.assistants.delete("asst_abc123")
+              print(response)
+            node.js: >-
+              import OpenAI from "openai";
+
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const response = await openai.beta.assistants.del("asst_abc123");
+
+                console.log(response);
+              }
+
+              main();
+          response: |
+            {
+              "id": "asst_abc123",
+              "object": "assistant.deleted",
+              "deleted": true
+            }
+  /audio/speech:
+    post:
+      operationId: createSpeech
+      tags:
+        - Audio
+      summary: Generates audio from the input text.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSpeechRequest"
+      responses:
+        "200":
+          description: OK
+          headers:
+            Transfer-Encoding:
+              schema:
+                type: string
+              description: chunked
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+      x-oaiMeta:
+        name: Create speech
+        group: audio
+        returns: The audio file content.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/audio/speech \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                  "model": "tts-1",
+                  "input": "The quick brown fox jumped over the lazy dog.",
+                  "voice": "alloy"
+                }' \
+                --output speech.mp3
+            python: |
+              from pathlib import Path
+              import openai
+
+              speech_file_path = Path(__file__).parent / "speech.mp3"
+              response = openai.audio.speech.create(
+                model="tts-1",
+                voice="alloy",
+                input="The quick brown fox jumped over the lazy dog."
+              )
+              response.stream_to_file(speech_file_path)
+            node: >
+              import fs from "fs";
+
+              import path from "path";
+
+              import OpenAI from "openai";
+
+
+              const openai = new OpenAI();
+
+
+              const speechFile = path.resolve("./speech.mp3");
+
+
+              async function main() {
+                const mp3 = await openai.audio.speech.create({
+                  model: "tts-1",
+                  voice: "alloy",
+                  input: "Today is a wonderful day to build something people love!",
+                });
+                console.log(speechFile);
+                const buffer = Buffer.from(await mp3.arrayBuffer());
+                await fs.promises.writeFile(speechFile, buffer);
+              }
+
+              main();
+  /audio/transcriptions:
+    post:
+      operationId: createTranscription
+      tags:
+        - Audio
+      summary: Transcribes audio into the input language.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/CreateTranscriptionRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/CreateTranscriptionResponseJson"
+                  - $ref: "#/components/schemas/CreateTranscriptionResponseVerboseJson"
+      x-oaiMeta:
+        name: Create transcription
+        group: audio
+        returns: The [transcription object](/docs/api-reference/audio/json-object) or a
+          [verbose transcription
+          object](/docs/api-reference/audio/verbose-json-object).
+        examples:
+          - title: Default
+            request:
+              curl: |
+                curl https://api.openai.com/v1/audio/transcriptions \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: multipart/form-data" \
+                  -F file="@/path/to/file/audio.mp3" \
+                  -F model="whisper-1"
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                audio_file = open("speech.mp3", "rb")
+                transcript = client.audio.transcriptions.create(
+                  model="whisper-1",
+                  file=audio_file
+                )
+              node: >
+                import fs from "fs";
+
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const transcription = await openai.audio.transcriptions.create({
+                    file: fs.createReadStream("audio.mp3"),
+                    model: "whisper-1",
+                  });
+
+                  console.log(transcription.text);
+                }
+
+                main();
+            response: >
+              {
+                "text": "Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."
+              }
+          - title: Word timestamps
+            request:
+              curl: |
+                curl https://api.openai.com/v1/audio/transcriptions \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: multipart/form-data" \
+                  -F file="@/path/to/file/audio.mp3" \
+                  -F "timestamp_granularities[]=word" \
+                  -F model="whisper-1" \
+                  -F response_format="verbose_json"
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                audio_file = open("speech.mp3", "rb")
+                transcript = client.audio.transcriptions.create(
+                  file=audio_file,
+                  model="whisper-1",
+                  response_format="verbose_json",
+                  timestamp_granularities=["word"]
+                )
+
+                print(transcript.words)
+              node: >
+                import fs from "fs";
+
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const transcription = await openai.audio.transcriptions.create({
+                    file: fs.createReadStream("audio.mp3"),
+                    model: "whisper-1",
+                    response_format: "verbose_json",
+                    timestamp_granularities: ["word"]
+                  });
+
+                  console.log(transcription.text);
+                }
+
+                main();
+            response: >
+              {
+                "task": "transcribe",
+                "language": "english",
+                "duration": 8.470000267028809,
+                "text": "The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.",
+                "words": [
+                  {
+                    "word": "The",
+                    "start": 0.0,
+                    "end": 0.23999999463558197
+                  },
+                  ...
+                  {
+                    "word": "volleyball",
+                    "start": 7.400000095367432,
+                    "end": 7.900000095367432
+                  }
+                ]
+              }
+          - title: Segment timestamps
+            request:
+              curl: |
+                curl https://api.openai.com/v1/audio/transcriptions \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: multipart/form-data" \
+                  -F file="@/path/to/file/audio.mp3" \
+                  -F "timestamp_granularities[]=segment" \
+                  -F model="whisper-1" \
+                  -F response_format="verbose_json"
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                audio_file = open("speech.mp3", "rb")
+                transcript = client.audio.transcriptions.create(
+                  file=audio_file,
+                  model="whisper-1",
+                  response_format="verbose_json",
+                  timestamp_granularities=["segment"]
+                )
+
+                print(transcript.words)
+              node: >
+                import fs from "fs";
+
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const transcription = await openai.audio.transcriptions.create({
+                    file: fs.createReadStream("audio.mp3"),
+                    model: "whisper-1",
+                    response_format: "verbose_json",
+                    timestamp_granularities: ["segment"]
+                  });
+
+                  console.log(transcription.text);
+                }
+
+                main();
+            response: >
+              {
+                "task": "transcribe",
+                "language": "english",
+                "duration": 8.470000267028809,
+                "text": "The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.",
+                "segments": [
+                  {
+                    "id": 0,
+                    "seek": 0,
+                    "start": 0.0,
+                    "end": 3.319999933242798,
+                    "text": " The beach was a popular spot on a hot summer day.",
+                    "tokens": [
+                      50364, 440, 7534, 390, 257, 3743, 4008, 322, 257, 2368, 4266, 786, 13, 50530
+                    ],
+                    "temperature": 0.0,
+                    "avg_logprob": -0.2860786020755768,
+                    "compression_ratio": 1.2363636493682861,
+                    "no_speech_prob": 0.00985979475080967
+                  },
+                  ...
+                ]
+              }
+  /audio/translations:
+    post:
+      operationId: createTranslation
+      tags:
+        - Audio
+      summary: Translates audio into English.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/CreateTranslationRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/CreateTranslationResponseJson"
+                  - $ref: "#/components/schemas/CreateTranslationResponseVerboseJson"
+      x-oaiMeta:
+        name: Create translation
+        group: audio
+        returns: The translated text.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/audio/translations \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: multipart/form-data" \
+                -F file="@/path/to/file/german.m4a" \
+                -F model="whisper-1"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              audio_file = open("speech.mp3", "rb")
+              transcript = client.audio.translations.create(
+                model="whisper-1",
+                file=audio_file
+              )
+            node: |
+              import fs from "fs";
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                  const translation = await openai.audio.translations.create({
+                      file: fs.createReadStream("speech.mp3"),
+                      model: "whisper-1",
+                  });
+
+                  console.log(translation.text);
+              }
+              main();
+          response: >
+            {
+              "text": "Hello, my name is Wolfgang and I come from Germany. Where are you heading today?"
+            }
+  /batches:
+    post:
+      summary: Creates and executes a batch from an uploaded file of requests
+      operationId: createBatch
+      tags:
+        - Batch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - input_file_id
+                - endpoint
+                - completion_window
+              properties:
+                input_file_id:
+                  type: string
+                  description: >
+                    The ID of an uploaded file that contains requests for the
+                    new batch.
+
+
+                    See [upload file](/docs/api-reference/files/create) for how
+                    to upload a file.
+
+
+                    Your input file must be formatted as a [JSONL
+                    file](/docs/api-reference/batch/request-input), and must be
+                    uploaded with the purpose `batch`. The file can contain up
+                    to 50,000 requests, and can be up to 200 MB in size.
+                endpoint:
+                  type: string
+                  enum:
+                    - /v1/chat/completions
+                    - /v1/embeddings
+                    - /v1/completions
+                  description: The endpoint to be used for all requests in the batch. Currently
+                    `/v1/chat/completions`, `/v1/embeddings`, and
+                    `/v1/completions` are supported. Note that `/v1/embeddings`
+                    batches are also restricted to a maximum of 50,000 embedding
+                    inputs across all requests in the batch.
+                completion_window:
+                  type: string
+                  enum:
+                    - 24h
+                  description: The time frame within which the batch should be processed.
+                    Currently only `24h` is supported.
+                metadata:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: Optional custom metadata for the batch.
+                  nullable: true
+      responses:
+        "200":
+          description: Batch created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Batch"
+      x-oaiMeta:
+        name: Create batch
+        group: batch
+        returns: The created [Batch](/docs/api-reference/batch/object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/batches \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                  "input_file_id": "file-abc123",
+                  "endpoint": "/v1/chat/completions",
+                  "completion_window": "24h"
+                }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.batches.create(
+                input_file_id="file-abc123",
+                endpoint="/v1/chat/completions",
+                completion_window="24h"
+              )
+            node: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const batch = await openai.batches.create({
+                  input_file_id: "file-abc123",
+                  endpoint: "/v1/chat/completions",
+                  completion_window: "24h"
+                });
+
+                console.log(batch);
+              }
+
+              main();
+          response: |
+            {
+              "id": "batch_abc123",
+              "object": "batch",
+              "endpoint": "/v1/chat/completions",
+              "errors": null,
+              "input_file_id": "file-abc123",
+              "completion_window": "24h",
+              "status": "validating",
+              "output_file_id": null,
+              "error_file_id": null,
+              "created_at": 1711471533,
+              "in_progress_at": null,
+              "expires_at": null,
+              "finalizing_at": null,
+              "completed_at": null,
+              "failed_at": null,
+              "expired_at": null,
+              "cancelling_at": null,
+              "cancelled_at": null,
+              "request_counts": {
+                "total": 0,
+                "completed": 0,
+                "failed": 0
+              },
+              "metadata": {
+                "customer_id": "user_123456789",
+                "batch_description": "Nightly eval job",
+              }
+            }
+    get:
+      operationId: listBatches
+      tags:
+        - Batch
+      summary: List your organization's batches.
+      parameters:
+        - in: query
+          name: after
+          required: false
+          schema:
+            type: string
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: Batch listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListBatchesResponse"
+      x-oaiMeta:
+        name: List batch
+        group: batch
+        returns: A list of paginated [Batch](/docs/api-reference/batch/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/batches?limit=2 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.batches.list()
+            node: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.batches.list();
+
+                for await (const batch of list) {
+                  console.log(batch);
+                }
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "batch_abc123",
+                  "object": "batch",
+                  "endpoint": "/v1/chat/completions",
+                  "errors": null,
+                  "input_file_id": "file-abc123",
+                  "completion_window": "24h",
+                  "status": "completed",
+                  "output_file_id": "file-cvaTdG",
+                  "error_file_id": "file-HOWS94",
+                  "created_at": 1711471533,
+                  "in_progress_at": 1711471538,
+                  "expires_at": 1711557933,
+                  "finalizing_at": 1711493133,
+                  "completed_at": 1711493163,
+                  "failed_at": null,
+                  "expired_at": null,
+                  "cancelling_at": null,
+                  "cancelled_at": null,
+                  "request_counts": {
+                    "total": 100,
+                    "completed": 95,
+                    "failed": 5
+                  },
+                  "metadata": {
+                    "customer_id": "user_123456789",
+                    "batch_description": "Nightly job",
+                  }
+                },
+                { ... },
+              ],
+              "first_id": "batch_abc123",
+              "last_id": "batch_abc456",
+              "has_more": true
+            }
+  /batches/{batch_id}:
+    get:
+      operationId: retrieveBatch
+      tags:
+        - Batch
+      summary: Retrieves a batch.
+      parameters:
+        - in: path
+          name: batch_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the batch to retrieve.
+      responses:
+        "200":
+          description: Batch retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Batch"
+      x-oaiMeta:
+        name: Retrieve batch
+        group: batch
+        returns: The [Batch](/docs/api-reference/batch/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/batches/batch_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.batches.retrieve("batch_abc123")
+            node: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const batch = await openai.batches.retrieve("batch_abc123");
+
+                console.log(batch);
+              }
+
+              main();
+          response: |
+            {
+              "id": "batch_abc123",
+              "object": "batch",
+              "endpoint": "/v1/completions",
+              "errors": null,
+              "input_file_id": "file-abc123",
+              "completion_window": "24h",
+              "status": "completed",
+              "output_file_id": "file-cvaTdG",
+              "error_file_id": "file-HOWS94",
+              "created_at": 1711471533,
+              "in_progress_at": 1711471538,
+              "expires_at": 1711557933,
+              "finalizing_at": 1711493133,
+              "completed_at": 1711493163,
+              "failed_at": null,
+              "expired_at": null,
+              "cancelling_at": null,
+              "cancelled_at": null,
+              "request_counts": {
+                "total": 100,
+                "completed": 95,
+                "failed": 5
+              },
+              "metadata": {
+                "customer_id": "user_123456789",
+                "batch_description": "Nightly eval job",
+              }
+            }
+  /batches/{batch_id}/cancel:
+    post:
+      operationId: cancelBatch
+      tags:
+        - Batch
+      summary: Cancels an in-progress batch. The batch will be in status `cancelling`
+        for up to 10 minutes, before changing to `cancelled`, where it will have
+        partial results (if any) available in the output file.
+      parameters:
+        - in: path
+          name: batch_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the batch to cancel.
+      responses:
+        "200":
+          description: Batch is cancelling. Returns the cancelling batch's details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Batch"
+      x-oaiMeta:
+        name: Cancel batch
+        group: batch
+        returns: The [Batch](/docs/api-reference/batch/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/batches/batch_abc123/cancel \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -X POST
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.batches.cancel("batch_abc123")
+            node: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const batch = await openai.batches.cancel("batch_abc123");
+
+                console.log(batch);
+              }
+
+              main();
+          response: |
+            {
+              "id": "batch_abc123",
+              "object": "batch",
+              "endpoint": "/v1/chat/completions",
+              "errors": null,
+              "input_file_id": "file-abc123",
+              "completion_window": "24h",
+              "status": "cancelling",
+              "output_file_id": null,
+              "error_file_id": null,
+              "created_at": 1711471533,
+              "in_progress_at": 1711471538,
+              "expires_at": 1711557933,
+              "finalizing_at": null,
+              "completed_at": null,
+              "failed_at": null,
+              "expired_at": null,
+              "cancelling_at": 1711475133,
+              "cancelled_at": null,
+              "request_counts": {
+                "total": 100,
+                "completed": 23,
+                "failed": 1
+              },
+              "metadata": {
+                "customer_id": "user_123456789",
+                "batch_description": "Nightly eval job",
+              }
+            }
+  /chat/completions:
+    post:
+      operationId: createChatCompletion
+      tags:
+        - Chat
+      summary: >
+        Creates a model response for the given chat conversation. Learn more in
+        the
+
+        [text generation](/docs/guides/text-generation),
+        [vision](/docs/guides/vision),
+
+        and [audio](/docs/guides/audio) guides.
+
+
+        Parameter support can differ depending on the model used to generate the
+
+        response, particularly for newer reasoning models. Parameters that are
+        only
+
+        supported for reasoning models are noted below. For the current state
+        of 
+
+        unsupported parameters in reasoning models, 
+
+        [refer to the reasoning guide](/docs/guides/reasoning).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateChatCompletionRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateChatCompletionResponse"
+            text/event-stream:
+              schema:
+                $ref: "#/components/schemas/CreateChatCompletionStreamResponse"
+      x-oaiMeta:
+        name: Create chat completion
+        group: chat
+        returns: >
+          Returns a [chat completion](/docs/api-reference/chat/object) object,
+          or a streamed sequence of [chat completion
+          chunk](/docs/api-reference/chat/streaming) objects if the request is
+          streamed.
+        path: create
+        examples:
+          - title: Default
+            request:
+              curl: |
+                curl https://api.openai.com/v1/chat/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "VAR_chat_model_id",
+                    "messages": [
+                      {
+                        "role": "developer",
+                        "content": "You are a helpful assistant."
+                      },
+                      {
+                        "role": "user",
+                        "content": "Hello!"
+                      }
+                    ]
+                  }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                completion = client.chat.completions.create(
+                  model="VAR_chat_model_id",
+                  messages=[
+                    {"role": "developer", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Hello!"}
+                  ]
+                )
+
+
+                print(completion.choices[0].message)
+              node.js: >-
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const completion = await openai.chat.completions.create({
+                    messages: [{ role: "developer", content: "You are a helpful assistant." }],
+                    model: "VAR_chat_model_id",
+                    store: true,
+                  });
+
+                  console.log(completion.choices[0]);
+                }
+
+
+                main();
+            response: |
+              {
+                "id": "chatcmpl-123",
+                "object": "chat.completion",
+                "created": 1677652288,
+                "model": "gpt-4o-mini",
+                "system_fingerprint": "fp_44709d6fcb",
+                "choices": [{
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "\n\nHello there, how may I assist you today?",
+                  },
+                  "logprobs": null,
+                  "finish_reason": "stop"
+                }],
+                "service_tier": "default",
+                "usage": {
+                  "prompt_tokens": 9,
+                  "completion_tokens": 12,
+                  "total_tokens": 21,
+                  "completion_tokens_details": {
+                    "reasoning_tokens": 0,
+                    "accepted_prediction_tokens": 0,
+                    "rejected_prediction_tokens": 0
+                  }
+                }
+              }
+          - title: Image input
+            request:
+              curl: >
+                curl https://api.openai.com/v1/chat/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "gpt-4o",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": [
+                          {
+                            "type": "text",
+                            "text": "What'\''s in this image?"
+                          },
+                          {
+                            "type": "image_url",
+                            "image_url": {
+                              "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "max_tokens": 300
+                  }'
+              python: >
+                from openai import OpenAI
+
+
+                client = OpenAI()
+
+
+                response = client.chat.completions.create(
+                    model="gpt-4o",
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "What's in this image?"},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                                    }
+                                },
+                            ],
+                        }
+                    ],
+                    max_tokens=300,
+                )
+
+
+                print(response.choices[0])
+              node.js: >-
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const response = await openai.chat.completions.create({
+                    model: "gpt-4o",
+                    messages: [
+                      {
+                        role: "user",
+                        content: [
+                          { type: "text", text: "What's in this image?" },
+                          {
+                            type: "image_url",
+                            image_url: {
+                              "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                            },
+                          }
+                        ],
+                      },
+                    ],
+                    store: true,
+                  });
+                  console.log(response.choices[0]);
+                }
+
+                main();
+            response: >
+              {
+                "id": "chatcmpl-123",
+                "object": "chat.completion",
+                "created": 1677652288,
+                "model": "gpt-4o-mini",
+                "system_fingerprint": "fp_44709d6fcb",
+                "choices": [{
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "\n\nThis image shows a wooden boardwalk extending through a lush green marshland.",
+                  },
+                  "logprobs": null,
+                  "finish_reason": "stop"
+                }],
+                "usage": {
+                  "prompt_tokens": 9,
+                  "completion_tokens": 12,
+                  "total_tokens": 21,
+                  "completion_tokens_details": {
+                    "reasoning_tokens": 0,
+                    "accepted_prediction_tokens": 0,
+                    "rejected_prediction_tokens": 0
+                  }
+                }
+              }
+          - title: Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/chat/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "VAR_chat_model_id",
+                    "messages": [
+                      {
+                        "role": "developer",
+                        "content": "You are a helpful assistant."
+                      },
+                      {
+                        "role": "user",
+                        "content": "Hello!"
+                      }
+                    ],
+                    "stream": true
+                  }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                completion = client.chat.completions.create(
+                  model="VAR_chat_model_id",
+                  messages=[
+                    {"role": "developer", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Hello!"}
+                  ],
+                  stream=True
+                )
+
+
+                for chunk in completion:
+                  print(chunk.choices[0].delta)
+              node.js: >-
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const completion = await openai.chat.completions.create({
+                    model: "VAR_chat_model_id",
+                    messages: [
+                      {"role": "developer", "content": "You are a helpful assistant."},
+                      {"role": "user", "content": "Hello!"}
+                    ],
+                    store: true,
+                    stream: true,
+                  });
+
+                  for await (const chunk of completion) {
+                    console.log(chunk.choices[0].delta.content);
+                  }
+                }
+
+
+                main();
+            response: >
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini",
+              "system_fingerprint": "fp_44709d6fcb",
+              "choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini",
+              "system_fingerprint": "fp_44709d6fcb",
+              "choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}
+
+
+              ....
+
+
+              {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini",
+              "system_fingerprint": "fp_44709d6fcb",
+              "choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+          - title: Functions
+            request:
+              curl: >
+                curl https://api.openai.com/v1/chat/completions \
+
+                -H "Content-Type: application/json" \
+
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+
+                -d '{
+                  "model": "gpt-4o",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "What'\''s the weather like in Boston today?"
+                    }
+                  ],
+                  "tools": [
+                    {
+                      "type": "function",
+                      "function": {
+                        "name": "get_current_weather",
+                        "description": "Get the current weather in a given location",
+                        "parameters": {
+                          "type": "object",
+                          "properties": {
+                            "location": {
+                              "type": "string",
+                              "description": "The city and state, e.g. San Francisco, CA"
+                            },
+                            "unit": {
+                              "type": "string",
+                              "enum": ["celsius", "fahrenheit"]
+                            }
+                          },
+                          "required": ["location"]
+                        }
+                      }
+                    }
+                  ],
+                  "tool_choice": "auto"
+                }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                tools = [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "get_current_weather",
+                      "description": "Get the current weather in a given location",
+                      "parameters": {
+                        "type": "object",
+                        "properties": {
+                          "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                          },
+                          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                        },
+                        "required": ["location"],
+                      },
+                    }
+                  }
+                ]
+
+                messages = [{"role": "user", "content": "What's the weather like
+                in Boston today?"}]
+
+                completion = client.chat.completions.create(
+                  model="VAR_chat_model_id",
+                  messages=messages,
+                  tools=tools,
+                  tool_choice="auto"
+                )
+
+
+                print(completion)
+              node.js: >-
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const messages = [{"role": "user", "content": "What's the weather like in Boston today?"}];
+                  const tools = [
+                      {
+                        "type": "function",
+                        "function": {
+                          "name": "get_current_weather",
+                          "description": "Get the current weather in a given location",
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA",
+                              },
+                              "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                            },
+                            "required": ["location"],
+                          },
+                        }
+                      }
+                  ];
+
+                  const response = await openai.chat.completions.create({
+                    model: "gpt-4o",
+                    messages: messages,
+                    tools: tools,
+                    tool_choice: "auto",
+                    store: true,
+                  });
+
+                  console.log(response);
+                }
+
+
+                main();
+            response: |
+              {
+                "id": "chatcmpl-abc123",
+                "object": "chat.completion",
+                "created": 1699896916,
+                "model": "gpt-4o-mini",
+                "choices": [
+                  {
+                    "index": 0,
+                    "message": {
+                      "role": "assistant",
+                      "content": null,
+                      "tool_calls": [
+                        {
+                          "id": "call_abc123",
+                          "type": "function",
+                          "function": {
+                            "name": "get_current_weather",
+                            "arguments": "{\n\"location\": \"Boston, MA\"\n}"
+                          }
+                        }
+                      ]
+                    },
+                    "logprobs": null,
+                    "finish_reason": "tool_calls"
+                  }
+                ],
+                "usage": {
+                  "prompt_tokens": 82,
+                  "completion_tokens": 17,
+                  "total_tokens": 99,
+                  "completion_tokens_details": {
+                    "reasoning_tokens": 0,
+                    "accepted_prediction_tokens": 0,
+                    "rejected_prediction_tokens": 0
+                  }
+                }
+              }
+          - title: Logprobs
+            request:
+              curl: |
+                curl https://api.openai.com/v1/chat/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "VAR_chat_model_id",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": "Hello!"
+                      }
+                    ],
+                    "logprobs": true,
+                    "top_logprobs": 2
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                completion = client.chat.completions.create(
+                  model="VAR_chat_model_id",
+                  messages=[
+                    {"role": "user", "content": "Hello!"}
+                  ],
+                  logprobs=True,
+                  top_logprobs=2
+                )
+
+                print(completion.choices[0].message)
+                print(completion.choices[0].logprobs)
+              node.js: |-
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const completion = await openai.chat.completions.create({
+                    messages: [{ role: "user", content: "Hello!" }],
+                    model: "VAR_chat_model_id",
+                    store: true,
+                    logprobs: true,
+                    top_logprobs: 2,
+                  });
+
+                  console.log(completion.choices[0]);
+                }
+
+                main();
+            response: |
+              {
+                "id": "chatcmpl-123",
+                "object": "chat.completion",
+                "created": 1702685778,
+                "model": "gpt-4o-mini",
+                "choices": [
+                  {
+                    "index": 0,
+                    "message": {
+                      "role": "assistant",
+                      "content": "Hello! How can I assist you today?"
+                    },
+                    "logprobs": {
+                      "content": [
+                        {
+                          "token": "Hello",
+                          "logprob": -0.31725305,
+                          "bytes": [72, 101, 108, 108, 111],
+                          "top_logprobs": [
+                            {
+                              "token": "Hello",
+                              "logprob": -0.31725305,
+                              "bytes": [72, 101, 108, 108, 111]
+                            },
+                            {
+                              "token": "Hi",
+                              "logprob": -1.3190403,
+                              "bytes": [72, 105]
+                            }
+                          ]
+                        },
+                        {
+                          "token": "!",
+                          "logprob": -0.02380986,
+                          "bytes": [
+                            33
+                          ],
+                          "top_logprobs": [
+                            {
+                              "token": "!",
+                              "logprob": -0.02380986,
+                              "bytes": [33]
+                            },
+                            {
+                              "token": " there",
+                              "logprob": -3.787621,
+                              "bytes": [32, 116, 104, 101, 114, 101]
+                            }
+                          ]
+                        },
+                        {
+                          "token": " How",
+                          "logprob": -0.000054669687,
+                          "bytes": [32, 72, 111, 119],
+                          "top_logprobs": [
+                            {
+                              "token": " How",
+                              "logprob": -0.000054669687,
+                              "bytes": [32, 72, 111, 119]
+                            },
+                            {
+                              "token": "<|end|>",
+                              "logprob": -10.953937,
+                              "bytes": null
+                            }
+                          ]
+                        },
+                        {
+                          "token": " can",
+                          "logprob": -0.015801601,
+                          "bytes": [32, 99, 97, 110],
+                          "top_logprobs": [
+                            {
+                              "token": " can",
+                              "logprob": -0.015801601,
+                              "bytes": [32, 99, 97, 110]
+                            },
+                            {
+                              "token": " may",
+                              "logprob": -4.161023,
+                              "bytes": [32, 109, 97, 121]
+                            }
+                          ]
+                        },
+                        {
+                          "token": " I",
+                          "logprob": -3.7697225e-6,
+                          "bytes": [
+                            32,
+                            73
+                          ],
+                          "top_logprobs": [
+                            {
+                              "token": " I",
+                              "logprob": -3.7697225e-6,
+                              "bytes": [32, 73]
+                            },
+                            {
+                              "token": " assist",
+                              "logprob": -13.596657,
+                              "bytes": [32, 97, 115, 115, 105, 115, 116]
+                            }
+                          ]
+                        },
+                        {
+                          "token": " assist",
+                          "logprob": -0.04571125,
+                          "bytes": [32, 97, 115, 115, 105, 115, 116],
+                          "top_logprobs": [
+                            {
+                              "token": " assist",
+                              "logprob": -0.04571125,
+                              "bytes": [32, 97, 115, 115, 105, 115, 116]
+                            },
+                            {
+                              "token": " help",
+                              "logprob": -3.1089056,
+                              "bytes": [32, 104, 101, 108, 112]
+                            }
+                          ]
+                        },
+                        {
+                          "token": " you",
+                          "logprob": -5.4385737e-6,
+                          "bytes": [32, 121, 111, 117],
+                          "top_logprobs": [
+                            {
+                              "token": " you",
+                              "logprob": -5.4385737e-6,
+                              "bytes": [32, 121, 111, 117]
+                            },
+                            {
+                              "token": " today",
+                              "logprob": -12.807695,
+                              "bytes": [32, 116, 111, 100, 97, 121]
+                            }
+                          ]
+                        },
+                        {
+                          "token": " today",
+                          "logprob": -0.0040071653,
+                          "bytes": [32, 116, 111, 100, 97, 121],
+                          "top_logprobs": [
+                            {
+                              "token": " today",
+                              "logprob": -0.0040071653,
+                              "bytes": [32, 116, 111, 100, 97, 121]
+                            },
+                            {
+                              "token": "?",
+                              "logprob": -5.5247097,
+                              "bytes": [63]
+                            }
+                          ]
+                        },
+                        {
+                          "token": "?",
+                          "logprob": -0.0008108172,
+                          "bytes": [63],
+                          "top_logprobs": [
+                            {
+                              "token": "?",
+                              "logprob": -0.0008108172,
+                              "bytes": [63]
+                            },
+                            {
+                              "token": "?\n",
+                              "logprob": -7.184561,
+                              "bytes": [63, 10]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "finish_reason": "stop"
+                  }
+                ],
+                "usage": {
+                  "prompt_tokens": 9,
+                  "completion_tokens": 9,
+                  "total_tokens": 18,
+                  "completion_tokens_details": {
+                    "reasoning_tokens": 0,
+                    "accepted_prediction_tokens": 0,
+                    "rejected_prediction_tokens": 0
+                  }
+                },
+                "system_fingerprint": null
+              }
+  /completions:
+    post:
+      operationId: createCompletion
+      tags:
+        - Completions
+      summary: Creates a completion for the provided prompt and parameters.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCompletionRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateCompletionResponse"
+      x-oaiMeta:
+        name: Create completion
+        group: completions
+        returns: >
+          Returns a [completion](/docs/api-reference/completions/object) object,
+          or a sequence of completion objects if the request is streamed.
+        legacy: true
+        examples:
+          - title: No streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "VAR_completion_model_id",
+                    "prompt": "Say this is a test",
+                    "max_tokens": 7,
+                    "temperature": 0
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                client.completions.create(
+                  model="VAR_completion_model_id",
+                  prompt="Say this is a test",
+                  max_tokens=7,
+                  temperature=0
+                )
+              node.js: |-
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const completion = await openai.completions.create({
+                    model: "VAR_completion_model_id",
+                    prompt: "Say this is a test.",
+                    max_tokens: 7,
+                    temperature: 0,
+                  });
+
+                  console.log(completion);
+                }
+                main();
+            response: |
+              {
+                "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+                "object": "text_completion",
+                "created": 1589478378,
+                "model": "VAR_completion_model_id",
+                "system_fingerprint": "fp_44709d6fcb",
+                "choices": [
+                  {
+                    "text": "\n\nThis is indeed a test",
+                    "index": 0,
+                    "logprobs": null,
+                    "finish_reason": "length"
+                  }
+                ],
+                "usage": {
+                  "prompt_tokens": 5,
+                  "completion_tokens": 7,
+                  "total_tokens": 12
+                }
+              }
+          - title: Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/completions \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "VAR_completion_model_id",
+                    "prompt": "Say this is a test",
+                    "max_tokens": 7,
+                    "temperature": 0,
+                    "stream": true
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                for chunk in client.completions.create(
+                  model="VAR_completion_model_id",
+                  prompt="Say this is a test",
+                  max_tokens=7,
+                  temperature=0,
+                  stream=True
+                ):
+                  print(chunk.choices[0].text)
+              node.js: |-
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const stream = await openai.completions.create({
+                    model: "VAR_completion_model_id",
+                    prompt: "Say this is a test.",
+                    stream: true,
+                  });
+
+                  for await (const chunk of stream) {
+                    console.log(chunk.choices[0].text)
+                  }
+                }
+                main();
+            response: |
+              {
+                "id": "cmpl-7iA7iJjj8V2zOkCGvWF2hAkDWBQZe",
+                "object": "text_completion",
+                "created": 1690759702,
+                "choices": [
+                  {
+                    "text": "This",
+                    "index": 0,
+                    "logprobs": null,
+                    "finish_reason": null
+                  }
+                ],
+                "model": "gpt-3.5-turbo-instruct"
+                "system_fingerprint": "fp_44709d6fcb",
+              }
+  /embeddings:
+    post:
+      operationId: createEmbedding
+      tags:
+        - Embeddings
+      summary: Creates an embedding vector representing the input text.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateEmbeddingRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateEmbeddingResponse"
+      x-oaiMeta:
+        name: Create embeddings
+        group: embeddings
+        returns: A list of [embedding](/docs/api-reference/embeddings/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/embeddings \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                  "input": "The food was delicious and the waiter...",
+                  "model": "text-embedding-ada-002",
+                  "encoding_format": "float"
+                }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.embeddings.create(
+                model="text-embedding-ada-002",
+                input="The food was delicious and the waiter...",
+                encoding_format="float"
+              )
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const embedding = await openai.embeddings.create({
+                  model: "text-embedding-ada-002",
+                  input: "The quick brown fox jumped over the lazy dog",
+                  encoding_format: "float",
+                });
+
+                console.log(embedding);
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "object": "embedding",
+                  "embedding": [
+                    0.0023064255,
+                    -0.009327292,
+                    .... (1536 floats total for ada-002)
+                    -0.0028842222,
+                  ],
+                  "index": 0
+                }
+              ],
+              "model": "text-embedding-ada-002",
+              "usage": {
+                "prompt_tokens": 8,
+                "total_tokens": 8
+              }
+            }
+  /files:
+    get:
+      operationId: listFiles
+      tags:
+        - Files
+      summary: Returns a list of files.
+      parameters:
+        - in: query
+          name: purpose
+          required: false
+          schema:
+            type: string
+          description: Only return files with the given purpose.
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 10,000, and the default is 10,000.
+          required: false
+          schema:
+            type: integer
+            default: 10000
+        - name: order
+          in: query
+          description: >
+            Sort order by the `created_at` timestamp of the objects. `asc` for
+            ascending order and `desc` for descending order.
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListFilesResponse"
+      x-oaiMeta:
+        name: List files
+        group: files
+        returns: A list of [File](/docs/api-reference/files/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.files.list()
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.files.list();
+
+                for await (const file of list) {
+                  console.log(file);
+                }
+              }
+
+              main();
+          response: |
+            {
+              "data": [
+                {
+                  "id": "file-abc123",
+                  "object": "file",
+                  "bytes": 175,
+                  "created_at": 1613677385,
+                  "filename": "salesOverview.pdf",
+                  "purpose": "assistants",
+                },
+                {
+                  "id": "file-abc123",
+                  "object": "file",
+                  "bytes": 140,
+                  "created_at": 1613779121,
+                  "filename": "puppy.jsonl",
+                  "purpose": "fine-tune",
+                }
+              ],
+              "object": "list"
+            }
+    post:
+      operationId: createFile
+      tags:
+        - Files
+      summary: >
+        Upload a file that can be used across various endpoints. Individual
+        files can be up to 512 MB, and the size of all files uploaded by one
+        organization can be up to 100 GB.
+
+
+        The Assistants API supports files up to 2 million tokens and of specific
+        file types. See the [Assistants Tools guide](/docs/assistants/tools) for
+        details.
+
+
+        The Fine-tuning API only supports `.jsonl` files. The input also has
+        certain required formats for fine-tuning
+        [chat](/docs/api-reference/fine-tuning/chat-input) or
+        [completions](/docs/api-reference/fine-tuning/completions-input) models.
+
+
+        The Batch API only supports `.jsonl` files up to 200 MB in size. The
+        input also has a specific required
+        [format](/docs/api-reference/batch/request-input).
+
+
+        Please [contact us](https://help.openai.com/) if you need to increase
+        these storage limits.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/CreateFileRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpenAIFile"
+      x-oaiMeta:
+        name: Upload file
+        group: files
+        returns: The uploaded [File](/docs/api-reference/files/object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -F purpose="fine-tune" \
+                -F file="@mydata.jsonl"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.files.create(
+                file=open("mydata.jsonl", "rb"),
+                purpose="fine-tune"
+              )
+            node.js: |-
+              import fs from "fs";
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const file = await openai.files.create({
+                  file: fs.createReadStream("mydata.jsonl"),
+                  purpose: "fine-tune",
+                });
+
+                console.log(file);
+              }
+
+              main();
+          response: |
+            {
+              "id": "file-abc123",
+              "object": "file",
+              "bytes": 120000,
+              "created_at": 1677610602,
+              "filename": "mydata.jsonl",
+              "purpose": "fine-tune",
+            }
+  /files/{file_id}:
+    delete:
+      operationId: deleteFile
+      tags:
+        - Files
+      summary: Delete a file.
+      parameters:
+        - in: path
+          name: file_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the file to use for this request.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteFileResponse"
+      x-oaiMeta:
+        name: Delete file
+        group: files
+        returns: Deletion status.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files/file-abc123 \
+                -X DELETE \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.files.delete("file-abc123")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const file = await openai.files.del("file-abc123");
+
+                console.log(file);
+              }
+
+              main();
+          response: |
+            {
+              "id": "file-abc123",
+              "object": "file",
+              "deleted": true
+            }
+    get:
+      operationId: retrieveFile
+      tags:
+        - Files
+      summary: Returns information about a specific file.
+      parameters:
+        - in: path
+          name: file_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the file to use for this request.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpenAIFile"
+      x-oaiMeta:
+        name: Retrieve file
+        group: files
+        returns: The [File](/docs/api-reference/files/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files/file-abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.files.retrieve("file-abc123")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const file = await openai.files.retrieve("file-abc123");
+
+                console.log(file);
+              }
+
+              main();
+          response: |
+            {
+              "id": "file-abc123",
+              "object": "file",
+              "bytes": 120000,
+              "created_at": 1677610602,
+              "filename": "mydata.jsonl",
+              "purpose": "fine-tune",
+            }
+  /files/{file_id}/content:
+    get:
+      operationId: downloadFile
+      tags:
+        - Files
+      summary: Returns the contents of the specified file.
+      parameters:
+        - in: path
+          name: file_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the file to use for this request.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+      x-oaiMeta:
+        name: Retrieve file content
+        group: files
+        returns: The file content.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/files/file-abc123/content \
+                -H "Authorization: Bearer $OPENAI_API_KEY" > file.jsonl
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              content = client.files.content("file-abc123")
+            node.js: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const file = await openai.files.content("file-abc123");
+
+                console.log(file);
+              }
+
+              main();
+  /fine_tuning/jobs:
+    post:
+      operationId: createFineTuningJob
+      tags:
+        - Fine-tuning
+      summary: >
+        Creates a fine-tuning job which begins the process of creating a new
+        model from a given dataset.
+
+
+        Response includes details of the enqueued job including job status and
+        the name of the fine-tuned models once complete.
+
+
+        [Learn more about fine-tuning](/docs/guides/fine-tuning)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFineTuningJobRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FineTuningJob"
+      x-oaiMeta:
+        name: Create fine-tuning job
+        group: fine-tuning
+        returns: A [fine-tuning.job](/docs/api-reference/fine-tuning/object) object.
+        examples:
+          - title: Default
+            request:
+              curl: |
+                curl https://api.openai.com/v1/fine_tuning/jobs \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "training_file": "file-BK7bzQj3FfZFXr7DbL6xJwfo",
+                    "model": "gpt-4o-mini"
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                client.fine_tuning.jobs.create(
+                  training_file="file-abc123",
+                  model="gpt-4o-mini"
+                )
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const fineTune = await openai.fineTuning.jobs.create({
+                    training_file: "file-abc123"
+                  });
+
+                  console.log(fineTune);
+                }
+
+                main();
+            response: |
+              {
+                "object": "fine_tuning.job",
+                "id": "ftjob-abc123",
+                "model": "gpt-4o-mini-2024-07-18",
+                "created_at": 1721764800,
+                "fine_tuned_model": null,
+                "organization_id": "org-123",
+                "result_files": [],
+                "status": "queued",
+                "validation_file": null,
+                "training_file": "file-abc123",
+                "method": {
+                  "type": "supervised",
+                  "supervised": {
+                    "hyperparameters": {
+                      "batch_size": "auto",
+                      "learning_rate_multiplier": "auto",
+                      "n_epochs": "auto",
+                    }
+                  }
+                }
+              }
+          - title: Epochs
+            request:
+              curl: |
+                curl https://api.openai.com/v1/fine_tuning/jobs \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "training_file": "file-abc123",
+                    "model": "gpt-4o-mini",
+                    "method": {
+                      "type": "supervised",
+                      "supervised": {
+                        "hyperparameters": {
+                          "n_epochs": 2
+                        }
+                      }
+                    }
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                client.fine_tuning.jobs.create(
+                  training_file="file-abc123",
+                  model="gpt-4o-mini",
+                  method={
+                    "type": "supervised",
+                    "supervised": {
+                      "hyperparameters": {
+                        "n_epochs": 2
+                      }
+                    }
+                  }
+                )
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const fineTune = await openai.fineTuning.jobs.create({
+                    training_file: "file-abc123",
+                    model: "gpt-4o-mini",
+                    method: {
+                      type: "supervised",
+                      supervised: {
+                        hyperparameters: {
+                          n_epochs: 2
+                        }
+                      }
+                    }
+                  });
+
+                  console.log(fineTune);
+                }
+
+                main();
+            response: |
+              {
+                "object": "fine_tuning.job",
+                "id": "ftjob-abc123",
+                "model": "gpt-4o-mini-2024-07-18",
+                "created_at": 1721764800,
+                "fine_tuned_model": null,
+                "organization_id": "org-123",
+                "result_files": [],
+                "status": "queued",
+                "validation_file": null,
+                "training_file": "file-abc123",
+                "hyperparameters": {"n_epochs": 2},
+                "method": {
+                  "type": "supervised",
+                  "supervised": {
+                    "hyperparameters": {
+                      "batch_size": "auto",
+                      "learning_rate_multiplier": "auto",
+                      "n_epochs": 2,
+                    }
+                  }
+                }
+              }
+          - title: Validation file
+            request:
+              curl: |
+                curl https://api.openai.com/v1/fine_tuning/jobs \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "training_file": "file-abc123",
+                    "validation_file": "file-abc123",
+                    "model": "gpt-4o-mini"
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                client.fine_tuning.jobs.create(
+                  training_file="file-abc123",
+                  validation_file="file-def456",
+                  model="gpt-4o-mini"
+                )
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const fineTune = await openai.fineTuning.jobs.create({
+                    training_file: "file-abc123",
+                    validation_file: "file-abc123"
+                  });
+
+                  console.log(fineTune);
+                }
+
+                main();
+            response: |
+              {
+                "object": "fine_tuning.job",
+                "id": "ftjob-abc123",
+                "model": "gpt-4o-mini-2024-07-18",
+                "created_at": 1721764800,
+                "fine_tuned_model": null,
+                "organization_id": "org-123",
+                "result_files": [],
+                "status": "queued",
+                "validation_file": "file-abc123",
+                "training_file": "file-abc123",
+                "method": {
+                  "type": "supervised",
+                  "supervised": {
+                    "hyperparameters": {
+                      "batch_size": "auto",
+                      "learning_rate_multiplier": "auto",
+                      "n_epochs": "auto",
+                    }
+                  }
+                }
+              }
+          - title: DPO
+            request:
+              curl: |
+                curl https://api.openai.com/v1/fine_tuning/jobs \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "training_file": "file-abc123",
+                    "validation_file": "file-abc123",
+                    "model": "gpt-4o-mini",
+                    "method": {
+                      "type": "dpo",
+                      "dpo": {
+                        "hyperparameters": {
+                          "beta": 0.1,
+                        }
+                      }
+                    }
+                  }'
+            response: |
+              {
+                "object": "fine_tuning.job",
+                "id": "ftjob-abc123",
+                "model": "gpt-4o-mini-2024-07-18",
+                "created_at": 1721764800,
+                "fine_tuned_model": null,
+                "organization_id": "org-123",
+                "result_files": [],
+                "status": "queued",
+                "validation_file": "file-abc123",
+                "training_file": "file-abc123",
+                "method": {
+                  "type": "dpo",
+                  "dpo": {
+                    "hyperparameters": {
+                      "beta": 0.1,
+                      "batch_size": "auto",
+                      "learning_rate_multiplier": "auto",
+                      "n_epochs": "auto",
+                    }
+                  }
+                }
+              }
+          - title: W&B Integration
+            request:
+              curl: |
+                curl https://api.openai.com/v1/fine_tuning/jobs \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "training_file": "file-abc123",
+                    "validation_file": "file-abc123",
+                    "model": "gpt-4o-mini",
+                    "integrations": [
+                      {
+                        "type": "wandb",
+                        "wandb": {
+                          "project": "my-wandb-project",
+                          "name": "ft-run-display-name"
+                          "tags": [
+                            "first-experiment", "v2"
+                          ]
+                        }
+                      }
+                    ]
+                  }'
+            response: |
+              {
+                "object": "fine_tuning.job",
+                "id": "ftjob-abc123",
+                "model": "gpt-4o-mini-2024-07-18",
+                "created_at": 1721764800,
+                "fine_tuned_model": null,
+                "organization_id": "org-123",
+                "result_files": [],
+                "status": "queued",
+                "validation_file": "file-abc123",
+                "training_file": "file-abc123",
+                "integrations": [
+                  {
+                    "type": "wandb",
+                    "wandb": {
+                      "project": "my-wandb-project",
+                      "entity": None,
+                      "run_id": "ftjob-abc123"
+                    }
+                  }
+                ],
+                "method": {
+                  "type": "supervised",
+                  "supervised": {
+                    "hyperparameters": {
+                      "batch_size": "auto",
+                      "learning_rate_multiplier": "auto",
+                      "n_epochs": "auto",
+                    }
+                  }
+                }
+              }
+    get:
+      operationId: listPaginatedFineTuningJobs
+      tags:
+        - Fine-tuning
+      summary: |
+        List your organization's fine-tuning jobs
+      parameters:
+        - name: after
+          in: query
+          description: Identifier for the last job from the previous pagination request.
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Number of fine-tuning jobs to retrieve.
+          required: false
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListPaginatedFineTuningJobsResponse"
+      x-oaiMeta:
+        name: List fine-tuning jobs
+        group: fine-tuning
+        returns: A list of paginated [fine-tuning
+          job](/docs/api-reference/fine-tuning/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/fine_tuning/jobs?limit=2 \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.fine_tuning.jobs.list()
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.fineTuning.jobs.list();
+
+                for await (const fineTune of list) {
+                  console.log(fineTune);
+                }
+              }
+
+              main();
+          response: >
+            {
+              "object": "list",
+              "data": [
+                {
+                  "object": "fine_tuning.job.event",
+                  "id": "ft-event-TjX0lMfOniCZX64t9PUQT5hn",
+                  "created_at": 1689813489,
+                  "level": "warn",
+                  "message": "Fine tuning process stopping due to job cancellation",
+                  "data": null,
+                  "type": "message"
+                },
+                { ... },
+                { ... }
+              ], "has_more": true
+            }
+  /fine_tuning/jobs/{fine_tuning_job_id}:
+    get:
+      operationId: retrieveFineTuningJob
+      tags:
+        - Fine-tuning
+      summary: |
+        Get info about a fine-tuning job.
+
+        [Learn more about fine-tuning](/docs/guides/fine-tuning)
+      parameters:
+        - in: path
+          name: fine_tuning_job_id
+          required: true
+          schema:
+            type: string
+            example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+          description: |
+            The ID of the fine-tuning job.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FineTuningJob"
+      x-oaiMeta:
+        name: Retrieve fine-tuning job
+        group: fine-tuning
+        returns: The [fine-tuning](/docs/api-reference/fine-tuning/object) object with
+          the given ID.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.fine_tuning.jobs.retrieve("ftjob-abc123")
+            node.js: >
+              import OpenAI from "openai";
+
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const fineTune = await openai.fineTuning.jobs.retrieve("ftjob-abc123");
+
+                console.log(fineTune);
+              }
+
+
+              main();
+          response: >
+            {
+              "object": "fine_tuning.job",
+              "id": "ftjob-abc123",
+              "model": "davinci-002",
+              "created_at": 1692661014,
+              "finished_at": 1692661190,
+              "fine_tuned_model": "ft:davinci-002:my-org:custom_suffix:7q8mpxmy",
+              "organization_id": "org-123",
+              "result_files": [
+                  "file-abc123"
+              ],
+              "status": "succeeded",
+              "validation_file": null,
+              "training_file": "file-abc123",
+              "hyperparameters": {
+                  "n_epochs": 4,
+                  "batch_size": 1,
+                  "learning_rate_multiplier": 1.0
+              },
+              "trained_tokens": 5768,
+              "integrations": [],
+              "seed": 0,
+              "estimated_finish": 0,
+              "method": {
+                "type": "supervised",
+                "supervised": {
+                  "hyperparameters": {
+                    "n_epochs": 4,
+                    "batch_size": 1,
+                    "learning_rate_multiplier": 1.0
+                  }
+                }
+              }
+            }
+  /fine_tuning/jobs/{fine_tuning_job_id}/cancel:
+    post:
+      operationId: cancelFineTuningJob
+      tags:
+        - Fine-tuning
+      summary: |
+        Immediately cancel a fine-tune job.
+      parameters:
+        - in: path
+          name: fine_tuning_job_id
+          required: true
+          schema:
+            type: string
+            example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+          description: |
+            The ID of the fine-tuning job to cancel.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FineTuningJob"
+      x-oaiMeta:
+        name: Cancel fine-tuning
+        group: fine-tuning
+        returns: The cancelled [fine-tuning](/docs/api-reference/fine-tuning/object)
+          object.
+        examples:
+          request:
+            curl: >
+              curl -X POST
+              https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/cancel \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.fine_tuning.jobs.cancel("ftjob-abc123")
+            node.js: >-
+              import OpenAI from "openai";
+
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const fineTune = await openai.fineTuning.jobs.cancel("ftjob-abc123");
+
+                console.log(fineTune);
+              }
+
+              main();
+          response: |
+            {
+              "object": "fine_tuning.job",
+              "id": "ftjob-abc123",
+              "model": "gpt-4o-mini-2024-07-18",
+              "created_at": 1721764800,
+              "fine_tuned_model": null,
+              "organization_id": "org-123",
+              "result_files": [],
+              "status": "cancelled",
+              "validation_file": "file-abc123",
+              "training_file": "file-abc123"
+            }
+  /fine_tuning/jobs/{fine_tuning_job_id}/checkpoints:
+    get:
+      operationId: listFineTuningJobCheckpoints
+      tags:
+        - Fine-tuning
+      summary: |
+        List checkpoints for a fine-tuning job.
+      parameters:
+        - in: path
+          name: fine_tuning_job_id
+          required: true
+          schema:
+            type: string
+            example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+          description: |
+            The ID of the fine-tuning job to get checkpoints for.
+        - name: after
+          in: query
+          description: Identifier for the last checkpoint ID from the previous pagination
+            request.
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Number of checkpoints to retrieve.
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListFineTuningJobCheckpointsResponse"
+      x-oaiMeta:
+        name: List fine-tuning checkpoints
+        group: fine-tuning
+        returns: A list of fine-tuning [checkpoint
+          objects](/docs/api-reference/fine-tuning/checkpoint-object) for a
+          fine-tuning job.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/checkpoints
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+          response: >
+            {
+              "object": "list"
+              "data": [
+                {
+                  "object": "fine_tuning.job.checkpoint",
+                  "id": "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
+                  "created_at": 1721764867,
+                  "fine_tuned_model_checkpoint": "ft:gpt-4o-mini-2024-07-18:my-org:custom-suffix:96olL566:ckpt-step-2000",
+                  "metrics": {
+                    "full_valid_loss": 0.134,
+                    "full_valid_mean_token_accuracy": 0.874
+                  },
+                  "fine_tuning_job_id": "ftjob-abc123",
+                  "step_number": 2000,
+                },
+                {
+                  "object": "fine_tuning.job.checkpoint",
+                  "id": "ftckpt_enQCFmOTGj3syEpYVhBRLTSy",
+                  "created_at": 1721764800,
+                  "fine_tuned_model_checkpoint": "ft:gpt-4o-mini-2024-07-18:my-org:custom-suffix:7q8mpxmy:ckpt-step-1000",
+                  "metrics": {
+                    "full_valid_loss": 0.167,
+                    "full_valid_mean_token_accuracy": 0.781
+                  },
+                  "fine_tuning_job_id": "ftjob-abc123",
+                  "step_number": 1000,
+                },
+              ],
+              "first_id": "ftckpt_zc4Q7MP6XxulcVzj4MZdwsAB",
+              "last_id": "ftckpt_enQCFmOTGj3syEpYVhBRLTSy",
+              "has_more": true
+            }
+  /fine_tuning/jobs/{fine_tuning_job_id}/events:
+    get:
+      operationId: listFineTuningEvents
+      tags:
+        - Fine-tuning
+      summary: |
+        Get status updates for a fine-tuning job.
+      parameters:
+        - in: path
+          name: fine_tuning_job_id
+          required: true
+          schema:
+            type: string
+            example: ft-AF1WoRqd3aJAHsqc9NY7iL8F
+          description: |
+            The ID of the fine-tuning job to get events for.
+        - name: after
+          in: query
+          description: Identifier for the last event from the previous pagination request.
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Number of events to retrieve.
+          required: false
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListFineTuningJobEventsResponse"
+      x-oaiMeta:
+        name: List fine-tuning events
+        group: fine-tuning
+        returns: A list of fine-tuning event objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/events \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.fine_tuning.jobs.list_events(
+                fine_tuning_job_id="ftjob-abc123",
+                limit=2
+              )
+            node.js: >-
+              import OpenAI from "openai";
+
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const list = await openai.fineTuning.list_events(id="ftjob-abc123", limit=2);
+
+                for await (const fineTune of list) {
+                  console.log(fineTune);
+                }
+              }
+
+
+              main();
+          response: >
+            {
+              "object": "list",
+              "data": [
+                {
+                  "object": "fine_tuning.job.event",
+                  "id": "ft-event-ddTJfwuMVpfLXseO0Am0Gqjm",
+                  "created_at": 1721764800,
+                  "level": "info",
+                  "message": "Fine tuning job successfully completed",
+                  "data": null,
+                  "type": "message"
+                },
+                {
+                  "object": "fine_tuning.job.event",
+                  "id": "ft-event-tyiGuB72evQncpH87xe505Sv",
+                  "created_at": 1721764800,
+                  "level": "info",
+                  "message": "New fine-tuned model created: ft:gpt-4o-mini:openai::7p4lURel",
+                  "data": null,
+                  "type": "message"
+                }
+              ],
+              "has_more": true
+            }
+  /images/edits:
+    post:
+      operationId: createImageEdit
+      tags:
+        - Images
+      summary: Creates an edited or extended image given an original image and a prompt.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/CreateImageEditRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImagesResponse"
+      x-oaiMeta:
+        name: Create image edit
+        group: images
+        returns: Returns a list of [image](/docs/api-reference/images/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/images/edits \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -F image="@otter.png" \
+                -F mask="@mask.png" \
+                -F prompt="A cute baby sea otter wearing a beret" \
+                -F n=2 \
+                -F size="1024x1024"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.images.edit(
+                image=open("otter.png", "rb"),
+                mask=open("mask.png", "rb"),
+                prompt="A cute baby sea otter wearing a beret",
+                n=2,
+                size="1024x1024"
+              )
+            node.js: |-
+              import fs from "fs";
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const image = await openai.images.edit({
+                  image: fs.createReadStream("otter.png"),
+                  mask: fs.createReadStream("mask.png"),
+                  prompt: "A cute baby sea otter wearing a beret",
+                });
+
+                console.log(image.data);
+              }
+              main();
+          response: |
+            {
+              "created": 1589478378,
+              "data": [
+                {
+                  "url": "https://..."
+                },
+                {
+                  "url": "https://..."
+                }
+              ]
+            }
+  /images/generations:
+    post:
+      operationId: createImage
+      tags:
+        - Images
+      summary: Creates an image given a prompt.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateImageRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImagesResponse"
+      x-oaiMeta:
+        name: Create image
+        group: images
+        returns: Returns a list of [image](/docs/api-reference/images/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/images/generations \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -d '{
+                  "model": "dall-e-3",
+                  "prompt": "A cute baby sea otter",
+                  "n": 1,
+                  "size": "1024x1024"
+                }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.images.generate(
+                model="dall-e-3",
+                prompt="A cute baby sea otter",
+                n=1,
+                size="1024x1024"
+              )
+            node.js: >-
+              import OpenAI from "openai";
+
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const image = await openai.images.generate({ model: "dall-e-3", prompt: "A cute baby sea otter" });
+
+                console.log(image.data);
+              }
+
+              main();
+          response: |
+            {
+              "created": 1589478378,
+              "data": [
+                {
+                  "url": "https://..."
+                },
+                {
+                  "url": "https://..."
+                }
+              ]
+            }
+  /images/variations:
+    post:
+      operationId: createImageVariation
+      tags:
+        - Images
+      summary: Creates a variation of a given image.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/CreateImageVariationRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImagesResponse"
+      x-oaiMeta:
+        name: Create image variation
+        group: images
+        returns: Returns a list of [image](/docs/api-reference/images/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/images/variations \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -F image="@otter.png" \
+                -F n=2 \
+                -F size="1024x1024"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              response = client.images.create_variation(
+                image=open("image_edit_original.png", "rb"),
+                n=2,
+                size="1024x1024"
+              )
+            node.js: |-
+              import fs from "fs";
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const image = await openai.images.createVariation({
+                  image: fs.createReadStream("otter.png"),
+                });
+
+                console.log(image.data);
+              }
+              main();
+          response: |
+            {
+              "created": 1589478378,
+              "data": [
+                {
+                  "url": "https://..."
+                },
+                {
+                  "url": "https://..."
+                }
+              ]
+            }
+  /models:
+    get:
+      operationId: listModels
+      tags:
+        - Models
+      summary: Lists the currently available models, and provides basic information
+        about each one such as the owner and availability.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListModelsResponse"
+      x-oaiMeta:
+        name: List models
+        group: models
+        returns: A list of [model](/docs/api-reference/models/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/models \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.models.list()
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const list = await openai.models.list();
+
+                for await (const model of list) {
+                  console.log(model);
+                }
+              }
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "model-id-0",
+                  "object": "model",
+                  "created": 1686935002,
+                  "owned_by": "organization-owner"
+                },
+                {
+                  "id": "model-id-1",
+                  "object": "model",
+                  "created": 1686935002,
+                  "owned_by": "organization-owner",
+                },
+                {
+                  "id": "model-id-2",
+                  "object": "model",
+                  "created": 1686935002,
+                  "owned_by": "openai"
+                },
+              ],
+              "object": "list"
+            }
+  /models/{model}:
+    get:
+      operationId: retrieveModel
+      tags:
+        - Models
+      summary: Retrieves a model instance, providing basic information about the model
+        such as the owner and permissioning.
+      parameters:
+        - in: path
+          name: model
+          required: true
+          schema:
+            type: string
+            example: gpt-4o-mini
+          description: The ID of the model to use for this request
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Model"
+      x-oaiMeta:
+        name: Retrieve model
+        group: models
+        returns: The [model](/docs/api-reference/models/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/models/VAR_chat_model_id \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.models.retrieve("VAR_chat_model_id")
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const model = await openai.models.retrieve("VAR_chat_model_id");
+
+                console.log(model);
+              }
+
+              main();
+          response: |
+            {
+              "id": "VAR_chat_model_id",
+              "object": "model",
+              "created": 1686935002,
+              "owned_by": "openai"
+            }
+    delete:
+      operationId: deleteModel
+      tags:
+        - Models
+      summary: Delete a fine-tuned model. You must have the Owner role in your
+        organization to delete a model.
+      parameters:
+        - in: path
+          name: model
+          required: true
+          schema:
+            type: string
+            example: ft:gpt-4o-mini:acemeco:suffix:abc123
+          description: The model to delete
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteModelResponse"
+      x-oaiMeta:
+        name: Delete a fine-tuned model
+        group: models
+        returns: Deletion status.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/models/ft:gpt-4o-mini:acemeco:suffix:abc123
+              \
+                -X DELETE \
+                -H "Authorization: Bearer $OPENAI_API_KEY"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              client.models.delete("ft:gpt-4o-mini:acemeco:suffix:abc123")
+            node.js: >-
+              import OpenAI from "openai";
+
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const model = await openai.models.del("ft:gpt-4o-mini:acemeco:suffix:abc123");
+
+                console.log(model);
+              }
+
+              main();
+          response: |
+            {
+              "id": "ft:gpt-4o-mini:acemeco:suffix:abc123",
+              "object": "model",
+              "deleted": true
+            }
+  /moderations:
+    post:
+      operationId: createModeration
+      tags:
+        - Moderations
+      summary: |
+        Classifies if text and/or image inputs are potentially harmful. Learn
+        more in the [moderation guide](/docs/guides/moderation).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateModerationRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateModerationResponse"
+      x-oaiMeta:
+        name: Create moderation
+        group: moderations
+        returns: A [moderation](/docs/api-reference/moderations/object) object.
+        examples:
+          - title: Single string
+            request:
+              curl: |
+                curl https://api.openai.com/v1/moderations \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "input": "I want to kill them."
+                  }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                moderation = client.moderations.create(input="I want to kill
+                them.")
+
+                print(moderation)
+              node.js: >
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const moderation = await openai.moderations.create({ input: "I want to kill them." });
+
+                  console.log(moderation);
+                }
+
+                main();
+            response: |
+              {
+                "id": "modr-AB8CjOTu2jiq12hp1AQPfeqFWaORR",
+                "model": "text-moderation-007",
+                "results": [
+                  {
+                    "flagged": true,
+                    "categories": {
+                      "sexual": false,
+                      "hate": false,
+                      "harassment": true,
+                      "self-harm": false,
+                      "sexual/minors": false,
+                      "hate/threatening": false,
+                      "violence/graphic": false,
+                      "self-harm/intent": false,
+                      "self-harm/instructions": false,
+                      "harassment/threatening": true,
+                      "violence": true
+                    },
+                    "category_scores": {
+                      "sexual": 0.000011726012417057063,
+                      "hate": 0.22706663608551025,
+                      "harassment": 0.5215635299682617,
+                      "self-harm": 2.227119921371923e-6,
+                      "sexual/minors": 7.107352217872176e-8,
+                      "hate/threatening": 0.023547329008579254,
+                      "violence/graphic": 0.00003391829886822961,
+                      "self-harm/intent": 1.646940972932498e-6,
+                      "self-harm/instructions": 1.1198755256458526e-9,
+                      "harassment/threatening": 0.5694745779037476,
+                      "violence": 0.9971134662628174
+                    }
+                  }
+                ]
+              }
+          - title: Image and text
+            request:
+              curl: >
+                curl https://api.openai.com/v1/moderations \
+                  -X POST \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -d '{
+                    "model": "omni-moderation-latest",
+                    "input": [
+                      { "type": "text", "text": "...text to classify goes here..." },
+                      {
+                        "type": "image_url",
+                        "image_url": {
+                          "url": "https://example.com/image.png"
+                        }
+                      }
+                    ]
+                  }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                response = client.moderations.create(
+                    model="omni-moderation-latest",
+                    input=[
+                        {"type": "text", "text": "...text to classify goes here..."},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "https://example.com/image.png",
+                                # can also use base64 encoded image URLs
+                                # "url": "data:image/jpeg;base64,abcdefg..."
+                            }
+                        },
+                    ],
+                )
+
+
+                print(response)
+              node.js: >
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+
+                const moderation = await openai.moderations.create({
+                    model: "omni-moderation-latest",
+                    input: [
+                        { type: "text", text: "...text to classify goes here..." },
+                        {
+                            type: "image_url",
+                            image_url: {
+                                url: "https://example.com/image.png"
+                                // can also use base64 encoded image URLs
+                                // url: "data:image/jpeg;base64,abcdefg..."
+                            }
+                        }
+                    ],
+                });
+
+
+                console.log(moderation);
+            response: |
+              {
+                "id": "modr-0d9740456c391e43c445bf0f010940c7",
+                "model": "omni-moderation-latest",
+                "results": [
+                  {
+                    "flagged": true,
+                    "categories": {
+                      "harassment": true,
+                      "harassment/threatening": true,
+                      "sexual": false,
+                      "hate": false,
+                      "hate/threatening": false,
+                      "illicit": false,
+                      "illicit/violent": false,
+                      "self-harm/intent": false,
+                      "self-harm/instructions": false,
+                      "self-harm": false,
+                      "sexual/minors": false,
+                      "violence": true,
+                      "violence/graphic": true
+                    },
+                    "category_scores": {
+                      "harassment": 0.8189693396524255,
+                      "harassment/threatening": 0.804985420696006,
+                      "sexual": 1.573112165348997e-6,
+                      "hate": 0.007562942636942845,
+                      "hate/threatening": 0.004208854591835476,
+                      "illicit": 0.030535955153511665,
+                      "illicit/violent": 0.008925306722380033,
+                      "self-harm/intent": 0.00023023930975076432,
+                      "self-harm/instructions": 0.0002293869201073356,
+                      "self-harm": 0.012598046106750154,
+                      "sexual/minors": 2.212566909570261e-8,
+                      "violence": 0.9999992735124786,
+                      "violence/graphic": 0.843064871157054
+                    },
+                    "category_applied_input_types": {
+                      "harassment": [
+                        "text"
+                      ],
+                      "harassment/threatening": [
+                        "text"
+                      ],
+                      "sexual": [
+                        "text",
+                        "image"
+                      ],
+                      "hate": [
+                        "text"
+                      ],
+                      "hate/threatening": [
+                        "text"
+                      ],
+                      "illicit": [
+                        "text"
+                      ],
+                      "illicit/violent": [
+                        "text"
+                      ],
+                      "self-harm/intent": [
+                        "text",
+                        "image"
+                      ],
+                      "self-harm/instructions": [
+                        "text",
+                        "image"
+                      ],
+                      "self-harm": [
+                        "text",
+                        "image"
+                      ],
+                      "sexual/minors": [
+                        "text"
+                      ],
+                      "violence": [
+                        "text",
+                        "image"
+                      ],
+                      "violence/graphic": [
+                        "text",
+                        "image"
+                      ]
+                    }
+                  }
+                ]
+              }
+  /organization/admin_api_keys:
+    get:
+      summary: List organization API keys
+      operationId: admin-api-keys-list
+      description: Retrieve a paginated list of organization admin API keys.
+      parameters:
+        - in: query
+          name: after
+          required: false
+          schema:
+            type: string
+            nullable: true
+            description: Return keys with IDs that come after this ID in the pagination
+              order.
+        - in: query
+          name: order
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: asc
+            description: Order results by creation time, ascending or descending.
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            default: 20
+            description: Maximum number of keys to return.
+      responses:
+        "200":
+          description: A list of organization API keys.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiKeyList"
+      x-oaiMeta:
+        name: List admin API keys
+        group: administration
+        returns: A list of admin API key objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/admin_api_keys?after=key_abc&limit=20
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "object": "organization.admin_api_key",
+                  "id": "key_abc",
+                  "name": "Main Admin Key",
+                  "redacted_value": "sk-admin...def",
+                  "created_at": 1711471533,
+                  "owner": {
+                    "type": "service_account",
+                    "object": "organization.service_account",
+                    "id": "sa_456",
+                    "name": "My Service Account",
+                    "created_at": 1711471533,
+                    "role": "member"
+                  }
+                }
+              ],
+              "first_id": "key_abc",
+              "last_id": "key_abc",
+              "has_more": false
+            }
+    post:
+      summary: Create an organization admin API key
+      operationId: admin-api-keys-create
+      description: Create a new admin-level API key for the organization.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: New Admin Key
+      responses:
+        "200":
+          description: The newly created admin API key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminApiKey"
+      x-oaiMeta:
+        name: Create admin API key
+        group: administration
+        returns: The created admin API key object.
+        examples:
+          request:
+            curl: >
+              curl -X POST https://api.openai.com/v1/organization/admin_api_keys
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "name": "New Admin Key"
+                }'
+          response: |
+            {
+              "object": "organization.admin_api_key",
+              "id": "key_xyz",
+              "name": "New Admin Key",
+              "redacted_value": "sk-admin...xyz",
+              "created_at": 1711471533,
+              "owner": {
+                "type": "user",
+                "object": "organization.user",
+                "id": "user_123",
+                "name": "John Doe",
+                "created_at": 1711471533,
+                "role": "owner"
+              },
+              "value": "sk-admin-1234abcd"
+            }
+  /organization/admin_api_keys/{key_id}:
+    get:
+      summary: Retrieve a single organization API key
+      operationId: admin-api-keys-get
+      description: Get details for a specific organization API key by its ID.
+      parameters:
+        - in: path
+          name: key_id
+          required: true
+          schema:
+            type: string
+            description: The ID of the API key.
+      responses:
+        "200":
+          description: Details of the requested API key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminApiKey"
+      x-oaiMeta:
+        name: Retrieve admin API key
+        group: administration
+        returns: The requested admin API key object.
+        examples:
+          request:
+            curl: >
+              curl https://api.openai.com/v1/organization/admin_api_keys/key_abc
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+              "object": "organization.admin_api_key",
+              "id": "key_abc",
+              "name": "Main Admin Key",
+              "redacted_value": "sk-admin...xyz",
+              "created_at": 1711471533,
+              "owner": {
+                "type": "user",
+                "object": "organization.user",
+                "id": "user_123",
+                "name": "John Doe",
+                "created_at": 1711471533,
+                "role": "owner"
+              }
+            }
+    delete:
+      summary: Delete an organization admin API key
+      operationId: admin-api-keys-delete
+      description: Delete the specified admin API key.
+      parameters:
+        - in: path
+          name: key_id
+          required: true
+          schema:
+            type: string
+            description: The ID of the API key to be deleted.
+      responses:
+        "200":
+          description: Confirmation that the API key was deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    example: key_abc
+                  object:
+                    type: string
+                    example: organization.admin_api_key.deleted
+                  deleted:
+                    type: boolean
+                    example: true
+      x-oaiMeta:
+        name: Delete admin API key
+        group: administration
+        returns: A confirmation object indicating the key was deleted.
+        examples:
+          request:
+            curl: >
+              curl -X DELETE
+              https://api.openai.com/v1/organization/admin_api_keys/key_abc \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+              "id": "key_abc",
+              "object": "organization.admin_api_key.deleted",
+              "deleted": true
+            }
+  /organization/audit_logs:
+    get:
+      summary: List user actions and configuration changes within this organization.
+      operationId: list-audit-logs
+      tags:
+        - Audit Logs
+      parameters:
+        - name: effective_at
+          in: query
+          description: Return only events whose `effective_at` (Unix seconds) is in this
+            range.
+          required: false
+          schema:
+            type: object
+            properties:
+              gt:
+                type: integer
+                description: Return only events whose `effective_at` (Unix seconds) is greater
+                  than this value.
+              gte:
+                type: integer
+                description: Return only events whose `effective_at` (Unix seconds) is greater
+                  than or equal to this value.
+              lt:
+                type: integer
+                description: Return only events whose `effective_at` (Unix seconds) is less than
+                  this value.
+              lte:
+                type: integer
+                description: Return only events whose `effective_at` (Unix seconds) is less than
+                  or equal to this value.
+        - name: project_ids[]
+          in: query
+          description: Return only events for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: event_types[]
+          in: query
+          description: Return only events with a `type` in one of these values. For
+            example, `project.created`. For all options, see the documentation
+            for the [audit log object](/docs/api-reference/audit-logs/object).
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/AuditLogEventType"
+        - name: actor_ids[]
+          in: query
+          description: Return only events performed by these actors. Can be a user ID, a
+            service account ID, or an api key tracking ID.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: actor_emails[]
+          in: query
+          description: Return only events performed by users with these emails.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: resource_ids[]
+          in: query
+          description: Return only events performed on these targets. For example, a
+            project ID updated.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: >
+            A cursor for use in pagination. `before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, starting with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the
+            previous page of the list.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Audit logs listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAuditLogsResponse"
+      x-oaiMeta:
+        name: List audit logs
+        group: audit-logs
+        returns: A list of paginated [Audit Log](/docs/api-reference/audit-logs/object)
+          objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/organization/audit_logs \
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+              -H "Content-Type: application/json"
+          response: >
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "audit_log-xxx_yyyymmdd",
+                        "type": "project.archived",
+                        "effective_at": 1722461446,
+                        "actor": {
+                            "type": "api_key",
+                            "api_key": {
+                                "type": "user",
+                                "user": {
+                                    "id": "user-xxx",
+                                    "email": "user@example.com"
+                                }
+                            }
+                        },
+                        "project.archived": {
+                            "id": "proj_abc"
+                        },
+                    },
+                    {
+                        "id": "audit_log-yyy__20240101",
+                        "type": "api_key.updated",
+                        "effective_at": 1720804190,
+                        "actor": {
+                            "type": "session",
+                            "session": {
+                                "user": {
+                                    "id": "user-xxx",
+                                    "email": "user@example.com"
+                                },
+                                "ip_address": "127.0.0.1",
+                                "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+                                "ja3": "a497151ce4338a12c4418c44d375173e",
+                                "ja4": "q13d0313h3_55b375c5d22e_c7319ce65786",
+                                "ip_address_details": {
+                                  "country": "US",
+                                  "city": "San Francisco",
+                                  "region": "California",
+                                  "region_code": "CA",
+                                  "asn": "1234",
+                                  "latitude": "37.77490",
+                                  "longitude": "-122.41940"
+                                }
+                            }
+                        },
+                        "api_key.updated": {
+                            "id": "key_xxxx",
+                            "data": {
+                                "scopes": ["resource_2.operation_2"]
+                            }
+                        },
+                    }
+                ],
+                "first_id": "audit_log-xxx__20240101",
+                "last_id": "audit_log_yyy__20240101",
+                "has_more": true
+            }
+  /organization/costs:
+    get:
+      summary: Get costs details for the organization.
+      operationId: usage-costs
+      tags:
+        - Usage
+      parameters:
+        - name: start_time
+          in: query
+          description: Start time (Unix seconds) of the query time range, inclusive.
+          required: true
+          schema:
+            type: integer
+        - name: end_time
+          in: query
+          description: End time (Unix seconds) of the query time range, exclusive.
+          required: false
+          schema:
+            type: integer
+        - name: bucket_width
+          in: query
+          description: Width of each time bucket in response. Currently only `1d` is
+            supported, default to `1d`.
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1d
+            default: 1d
+        - name: project_ids
+          in: query
+          description: Return only costs for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: group_by
+          in: query
+          description: Group the costs by the specified fields. Support fields include
+            `project_id`, `line_item` and any combination of them.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - project_id
+                - line_item
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of buckets to be returned. Limit can range
+            between 1 and 180, and the default is 7.
+          required: false
+          schema:
+            type: integer
+            default: 7
+        - name: page
+          in: query
+          description: A cursor for use in pagination. Corresponding to the `next_page`
+            field from the previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Costs data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+      x-oaiMeta:
+        name: Costs
+        group: usage-costs
+        returns: A list of paginated, time bucketed
+          [Costs](/docs/api-reference/usage/costs_object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              "https://api.openai.com/v1/organization/costs?start_time=1730419200&limit=1"
+              \
+
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+
+              -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "page",
+                "data": [
+                    {
+                        "object": "bucket",
+                        "start_time": 1730419200,
+                        "end_time": 1730505600,
+                        "results": [
+                            {
+                                "object": "organization.costs.result",
+                                "amount": {
+                                    "value": 0.06,
+                                    "currency": "usd"
+                                },
+                                "line_item": null,
+                                "project_id": null
+                            }
+                        ]
+                    }
+                ],
+                "has_more": false,
+                "next_page": null
+            }
+  /organization/invites:
+    get:
+      summary: Returns a list of invites in the organization.
+      operationId: list-invites
+      tags:
+        - Invites
+      parameters:
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Invites listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InviteListResponse"
+      x-oaiMeta:
+        name: List invites
+        group: administration
+        returns: A list of [Invite](/docs/api-reference/invite/object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/invites?after=invite-abc&limit=20
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "object": "organization.invite",
+                  "id": "invite-abc",
+                  "email": "user@example.com",
+                  "role": "owner",
+                  "status": "accepted",
+                  "invited_at": 1711471533,
+                  "expires_at": 1711471533,
+                  "accepted_at": 1711471533
+                }
+              ],
+              "first_id": "invite-abc",
+              "last_id": "invite-abc",
+              "has_more": false
+            }
+    post:
+      summary: Create an invite for a user to the organization. The invite must be
+        accepted by the user before they have access to the organization.
+      operationId: inviteUser
+      tags:
+        - Invites
+      requestBody:
+        description: The invite request payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InviteRequest"
+      responses:
+        "200":
+          description: User invited successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Invite"
+      x-oaiMeta:
+        name: Create invite
+        group: administration
+        returns: The created [Invite](/docs/api-reference/invite/object) object.
+        examples:
+          request:
+            curl: |
+              curl -X POST https://api.openai.com/v1/organization/invites \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "email": "anotheruser@example.com",
+                    "role": "reader",
+                    "projects": [
+                      {
+                        "id": "project-xyz",
+                        "role": "member"
+                      },
+                      {
+                        "id": "project-abc",
+                        "role": "owner"
+                      }
+                    ]
+                }'
+          response: |
+            {
+              "object": "organization.invite",
+              "id": "invite-def",
+              "email": "anotheruser@example.com",
+              "role": "reader",
+              "status": "pending",
+              "invited_at": 1711471533,
+              "expires_at": 1711471533,
+              "accepted_at": null,
+              "projects": [
+                {
+                  "id": "project-xyz",
+                  "role": "member"
+                },
+                {
+                  "id": "project-abc",
+                  "role": "owner"
+                }
+              ]
+            }
+  /organization/invites/{invite_id}:
+    get:
+      summary: Retrieves an invite.
+      operationId: retrieve-invite
+      tags:
+        - Invites
+      parameters:
+        - in: path
+          name: invite_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the invite to retrieve.
+      responses:
+        "200":
+          description: Invite retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Invite"
+      x-oaiMeta:
+        name: Retrieve invite
+        group: administration
+        returns: The [Invite](/docs/api-reference/invite/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/organization/invites/invite-abc \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.invite",
+                "id": "invite-abc",
+                "email": "user@example.com",
+                "role": "owner",
+                "status": "accepted",
+                "invited_at": 1711471533,
+                "expires_at": 1711471533,
+                "accepted_at": 1711471533
+            }
+    delete:
+      summary: Delete an invite. If the invite has already been accepted, it cannot be
+        deleted.
+      operationId: delete-invite
+      tags:
+        - Invites
+      parameters:
+        - in: path
+          name: invite_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the invite to delete.
+      responses:
+        "200":
+          description: Invite deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InviteDeleteResponse"
+      x-oaiMeta:
+        name: Delete invite
+        group: administration
+        returns: Confirmation that the invite has been deleted
+        examples:
+          request:
+            curl: >
+              curl -X DELETE
+              https://api.openai.com/v1/organization/invites/invite-abc \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.invite.deleted",
+                "id": "invite-abc",
+                "deleted": true
+            }
+  /organization/projects:
+    get:
+      summary: Returns a list of projects.
+      operationId: list-projects
+      tags:
+        - Projects
+      parameters:
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          required: false
+          schema:
+            type: string
+        - name: include_archived
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: If `true` returns all projects including those that have been
+            `archived`. Archived projects are not included by default.
+      responses:
+        "200":
+          description: Projects listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectListResponse"
+      x-oaiMeta:
+        name: List projects
+        group: administration
+        returns: A list of [Project](/docs/api-reference/projects/object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/projects?after=proj_abc&limit=20&include_archived=false
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "proj_abc",
+                        "object": "organization.project",
+                        "name": "Project example",
+                        "created_at": 1711471533,
+                        "archived_at": null,
+                        "status": "active"
+                    }
+                ],
+                "first_id": "proj-abc",
+                "last_id": "proj-xyz",
+                "has_more": false
+            }
+    post:
+      summary: Create a new project in the organization. Projects can be created and
+        archived, but cannot be deleted.
+      operationId: create-project
+      tags:
+        - Projects
+      requestBody:
+        description: The project create request payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectCreateRequest"
+      responses:
+        "200":
+          description: Project created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+      x-oaiMeta:
+        name: Create project
+        group: administration
+        returns: The created [Project](/docs/api-reference/projects/object) object.
+        examples:
+          request:
+            curl: |
+              curl -X POST https://api.openai.com/v1/organization/projects \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "name": "Project ABC"
+                }'
+          response: |
+            {
+                "id": "proj_abc",
+                "object": "organization.project",
+                "name": "Project ABC",
+                "created_at": 1711471533,
+                "archived_at": null,
+                "status": "active"
+            }
+  /organization/projects/{project_id}:
+    get:
+      summary: Retrieves a project.
+      operationId: retrieve-project
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+      x-oaiMeta:
+        name: Retrieve project
+        group: administration
+        description: Retrieve a project.
+        returns: The [Project](/docs/api-reference/projects/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/organization/projects/proj_abc \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "id": "proj_abc",
+                "object": "organization.project",
+                "name": "Project example",
+                "created_at": 1711471533,
+                "archived_at": null,
+                "status": "active"
+            }
+    post:
+      summary: Modifies a project in the organization.
+      operationId: modify-project
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The project update request payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectUpdateRequest"
+      responses:
+        "200":
+          description: Project updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          description: Error response when updating the default project.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-oaiMeta:
+        name: Modify project
+        group: administration
+        returns: The updated [Project](/docs/api-reference/projects/object) object.
+        examples:
+          request:
+            curl: >
+              curl -X POST
+              https://api.openai.com/v1/organization/projects/proj_abc \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "name": "Project DEF"
+                }'
+  /organization/projects/{project_id}/api_keys:
+    get:
+      summary: Returns a list of API keys in the project.
+      operationId: list-project-api-keys
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project API keys listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectApiKeyListResponse"
+      x-oaiMeta:
+        name: List project API keys
+        group: administration
+        returns: A list of [ProjectApiKey](/docs/api-reference/project-api-keys/object)
+          objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/projects/proj_abc/api_keys?after=key_abc&limit=20
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "organization.project.api_key",
+                        "redacted_value": "sk-abc...def",
+                        "name": "My API Key",
+                        "created_at": 1711471533,
+                        "id": "key_abc",
+                        "owner": {
+                            "type": "user",
+                            "user": {
+                                "object": "organization.project.user",
+                                "id": "user_abc",
+                                "name": "First Last",
+                                "email": "user@example.com",
+                                "role": "owner",
+                                "added_at": 1711471533
+                            }
+                        }
+                    }
+                ],
+                "first_id": "key_abc",
+                "last_id": "key_xyz",
+                "has_more": false
+            }
+  /organization/projects/{project_id}/api_keys/{key_id}:
+    get:
+      summary: Retrieves an API key in the project.
+      operationId: retrieve-project-api-key
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: key_id
+          in: path
+          description: The ID of the API key.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project API key retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectApiKey"
+      x-oaiMeta:
+        name: Retrieve project API key
+        group: administration
+        returns: The [ProjectApiKey](/docs/api-reference/project-api-keys/object) object
+          matching the specified ID.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/projects/proj_abc/api_keys/key_abc
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.project.api_key",
+                "redacted_value": "sk-abc...def",
+                "name": "My API Key",
+                "created_at": 1711471533,
+                "id": "key_abc",
+                "owner": {
+                    "type": "user",
+                    "user": {
+                        "object": "organization.project.user",
+                        "id": "user_abc",
+                        "name": "First Last",
+                        "email": "user@example.com",
+                        "role": "owner",
+                        "added_at": 1711471533
+                    }
+                }
+            }
+    delete:
+      summary: Deletes an API key from the project.
+      operationId: delete-project-api-key
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: key_id
+          in: path
+          description: The ID of the API key.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project API key deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectApiKeyDeleteResponse"
+        "400":
+          description: Error response for various conditions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-oaiMeta:
+        name: Delete project API key
+        group: administration
+        returns: Confirmation of the key's deletion or an error if the key belonged to a
+          service account
+        examples:
+          request:
+            curl: >
+              curl -X DELETE
+              https://api.openai.com/v1/organization/projects/proj_abc/api_keys/key_abc
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.project.api_key.deleted",
+                "id": "key_abc",
+                "deleted": true
+            }
+  /organization/projects/{project_id}/archive:
+    post:
+      summary: Archives a project in the organization. Archived projects cannot be
+        used or updated.
+      operationId: archive-project
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project archived successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+      x-oaiMeta:
+        name: Archive project
+        group: administration
+        returns: The archived [Project](/docs/api-reference/projects/object) object.
+        examples:
+          request:
+            curl: >
+              curl -X POST
+              https://api.openai.com/v1/organization/projects/proj_abc/archive \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "id": "proj_abc",
+                "object": "organization.project",
+                "name": "Project DEF",
+                "created_at": 1711471533,
+                "archived_at": 1711471533,
+                "status": "archived"
+            }
+  /organization/projects/{project_id}/rate_limits:
+    get:
+      summary: Returns the rate limits per model for a project.
+      operationId: list-project-rate-limits
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: |
+            A limit on the number of objects to be returned. The default is 100.
+          required: false
+          schema:
+            type: integer
+            default: 100
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          required: false
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: >
+            A cursor for use in pagination. `before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, beginning with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the
+            previous page of the list.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project rate limits listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectRateLimitListResponse"
+      x-oaiMeta:
+        name: List project rate limits
+        group: administration
+        returns: A list of
+          [ProjectRateLimit](/docs/api-reference/project-rate-limits/object)
+          objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/projects/proj_abc/rate_limits?after=rl_xxx&limit=20
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "list",
+                "data": [
+                    {
+                      "object": "project.rate_limit",
+                      "id": "rl-ada",
+                      "model": "ada",
+                      "max_requests_per_1_minute": 600,
+                      "max_tokens_per_1_minute": 150000,
+                      "max_images_per_1_minute": 10
+                    }
+                ],
+                "first_id": "rl-ada",
+                "last_id": "rl-ada",
+                "has_more": false
+            }
+          error_response: |
+            {
+                "code": 404,
+                "message": "The project {project_id} was not found"
+            }
+  /organization/projects/{project_id}/rate_limits/{rate_limit_id}:
+    post:
+      summary: Updates a project rate limit.
+      operationId: update-project-rate-limits
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: rate_limit_id
+          in: path
+          description: The ID of the rate limit.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The project rate limit update request payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectRateLimitUpdateRequest"
+      responses:
+        "200":
+          description: Project rate limit updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectRateLimit"
+        "400":
+          description: Error response for various conditions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-oaiMeta:
+        name: Modify project rate limit
+        group: administration
+        returns: The updated
+          [ProjectRateLimit](/docs/api-reference/project-rate-limits/object)
+          object.
+        examples:
+          request:
+            curl: >
+              curl -X POST
+              https://api.openai.com/v1/organization/projects/proj_abc/rate_limits/rl_xxx
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "max_requests_per_1_minute": 500
+                }'
+          response: |
+            {
+                "object": "project.rate_limit",
+                "id": "rl-ada",
+                "model": "ada",
+                "max_requests_per_1_minute": 600,
+                "max_tokens_per_1_minute": 150000,
+                "max_images_per_1_minute": 10
+              }
+          error_response: |
+            {
+                "code": 404,
+                "message": "The project {project_id} was not found"
+            }
+  /organization/projects/{project_id}/service_accounts:
+    get:
+      summary: Returns a list of service accounts in the project.
+      operationId: list-project-service-accounts
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project service accounts listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectServiceAccountListResponse"
+        "400":
+          description: Error response when project is archived.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-oaiMeta:
+        name: List project service accounts
+        group: administration
+        returns: A list of
+          [ProjectServiceAccount](/docs/api-reference/project-service-accounts/object)
+          objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/projects/proj_abc/service_accounts?after=custom_id&limit=20
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "organization.project.service_account",
+                        "id": "svc_acct_abc",
+                        "name": "Service Account",
+                        "role": "owner",
+                        "created_at": 1711471533
+                    }
+                ],
+                "first_id": "svc_acct_abc",
+                "last_id": "svc_acct_xyz",
+                "has_more": false
+            }
+    post:
+      summary: Creates a new service account in the project. This also returns an
+        unredacted API key for the service account.
+      operationId: create-project-service-account
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The project service account create request payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectServiceAccountCreateRequest"
+      responses:
+        "200":
+          description: Project service account created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectServiceAccountCreateResponse"
+        "400":
+          description: Error response when project is archived.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-oaiMeta:
+        name: Create project service account
+        group: administration
+        returns: The created
+          [ProjectServiceAccount](/docs/api-reference/project-service-accounts/object)
+          object.
+        examples:
+          request:
+            curl: >
+              curl -X POST
+              https://api.openai.com/v1/organization/projects/proj_abc/service_accounts
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "name": "Production App"
+                }'
+          response: |
+            {
+                "object": "organization.project.service_account",
+                "id": "svc_acct_abc",
+                "name": "Production App",
+                "role": "member",
+                "created_at": 1711471533,
+                "api_key": {
+                    "object": "organization.project.service_account.api_key",
+                    "value": "sk-abcdefghijklmnop123",
+                    "name": "Secret Key",
+                    "created_at": 1711471533,
+                    "id": "key_abc"
+                }
+            }
+  /organization/projects/{project_id}/service_accounts/{service_account_id}:
+    get:
+      summary: Retrieves a service account in the project.
+      operationId: retrieve-project-service-account
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: service_account_id
+          in: path
+          description: The ID of the service account.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project service account retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectServiceAccount"
+      x-oaiMeta:
+        name: Retrieve project service account
+        group: administration
+        returns: The
+          [ProjectServiceAccount](/docs/api-reference/project-service-accounts/object)
+          object matching the specified ID.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/projects/proj_abc/service_accounts/svc_acct_abc
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.project.service_account",
+                "id": "svc_acct_abc",
+                "name": "Service Account",
+                "role": "owner",
+                "created_at": 1711471533
+            }
+    delete:
+      summary: Deletes a service account from the project.
+      operationId: delete-project-service-account
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: service_account_id
+          in: path
+          description: The ID of the service account.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project service account deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectServiceAccountDeleteResponse"
+      x-oaiMeta:
+        name: Delete project service account
+        group: administration
+        returns: Confirmation of service account being deleted, or an error in case of
+          an archived project, which has no service accounts
+        examples:
+          request:
+            curl: >
+              curl -X DELETE
+              https://api.openai.com/v1/organization/projects/proj_abc/service_accounts/svc_acct_abc
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.project.service_account.deleted",
+                "id": "svc_acct_abc",
+                "deleted": true
+            }
+  /organization/projects/{project_id}/users:
+    get:
+      summary: Returns a list of users in the project.
+      operationId: list-project-users
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project users listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectUserListResponse"
+        "400":
+          description: Error response when project is archived.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-oaiMeta:
+        name: List project users
+        group: administration
+        returns: A list of [ProjectUser](/docs/api-reference/project-users/object)
+          objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/projects/proj_abc/users?after=user_abc&limit=20
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "organization.project.user",
+                        "id": "user_abc",
+                        "name": "First Last",
+                        "email": "user@example.com",
+                        "role": "owner",
+                        "added_at": 1711471533
+                    }
+                ],
+                "first_id": "user-abc",
+                "last_id": "user-xyz",
+                "has_more": false
+            }
+    post:
+      summary: Adds a user to the project. Users must already be members of the
+        organization to be added to a project.
+      operationId: create-project-user
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+      tags:
+        - Projects
+      requestBody:
+        description: The project user create request payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectUserCreateRequest"
+      responses:
+        "200":
+          description: User added to project successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectUser"
+        "400":
+          description: Error response for various conditions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-oaiMeta:
+        name: Create project user
+        group: administration
+        returns: The created [ProjectUser](/docs/api-reference/project-users/object)
+          object.
+        examples:
+          request:
+            curl: >
+              curl -X POST
+              https://api.openai.com/v1/organization/projects/proj_abc/users \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "user_id": "user_abc",
+                    "role": "member"
+                }'
+          response: |
+            {
+                "object": "organization.project.user",
+                "id": "user_abc",
+                "email": "user@example.com",
+                "role": "owner",
+                "added_at": 1711471533
+            }
+  /organization/projects/{project_id}/users/{user_id}:
+    get:
+      summary: Retrieves a user in the project.
+      operationId: retrieve-project-user
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: path
+          description: The ID of the user.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project user retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectUser"
+      x-oaiMeta:
+        name: Retrieve project user
+        group: administration
+        returns: The [ProjectUser](/docs/api-reference/project-users/object) object
+          matching the specified ID.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/projects/proj_abc/users/user_abc
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.project.user",
+                "id": "user_abc",
+                "name": "First Last",
+                "email": "user@example.com",
+                "role": "owner",
+                "added_at": 1711471533
+            }
+    post:
+      summary: Modifies a user's role in the project.
+      operationId: modify-project-user
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: path
+          description: The ID of the user.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The project user update request payload.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectUserUpdateRequest"
+      responses:
+        "200":
+          description: Project user's role updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectUser"
+        "400":
+          description: Error response for various conditions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-oaiMeta:
+        name: Modify project user
+        group: administration
+        returns: The updated [ProjectUser](/docs/api-reference/project-users/object)
+          object.
+        examples:
+          request:
+            curl: >
+              curl -X POST
+              https://api.openai.com/v1/organization/projects/proj_abc/users/user_abc
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "role": "owner"
+                }'
+          response: |
+            {
+                "object": "organization.project.user",
+                "id": "user_abc",
+                "name": "First Last",
+                "email": "user@example.com",
+                "role": "owner",
+                "added_at": 1711471533
+            }
+    delete:
+      summary: Deletes a user from the project.
+      operationId: delete-project-user
+      tags:
+        - Projects
+      parameters:
+        - name: project_id
+          in: path
+          description: The ID of the project.
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: path
+          description: The ID of the user.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project user deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectUserDeleteResponse"
+        "400":
+          description: Error response for various conditions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      x-oaiMeta:
+        name: Delete project user
+        group: administration
+        returns: Confirmation that project has been deleted or an error in case of an
+          archived project, which has no users
+        examples:
+          request:
+            curl: >
+              curl -X DELETE
+              https://api.openai.com/v1/organization/projects/proj_abc/users/user_abc
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.project.user.deleted",
+                "id": "user_abc",
+                "deleted": true
+            }
+  /organization/usage/audio_speeches:
+    get:
+      summary: Get audio speeches usage details for the organization.
+      operationId: usage-audio-speeches
+      tags:
+        - Usage
+      parameters:
+        - name: start_time
+          in: query
+          description: Start time (Unix seconds) of the query time range, inclusive.
+          required: true
+          schema:
+            type: integer
+        - name: end_time
+          in: query
+          description: End time (Unix seconds) of the query time range, exclusive.
+          required: false
+          schema:
+            type: integer
+        - name: bucket_width
+          in: query
+          description: Width of each time bucket in response. Currently `1m`, `1h` and
+            `1d` are supported, default to `1d`.
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1m
+              - 1h
+              - 1d
+            default: 1d
+        - name: project_ids
+          in: query
+          description: Return only usage for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: user_ids
+          in: query
+          description: Return only usage for these users.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: api_key_ids
+          in: query
+          description: Return only usage for these API keys.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: models
+          in: query
+          description: Return only usage for these models.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: group_by
+          in: query
+          description: Group the usage data by the specified fields. Support fields
+            include `project_id`, `user_id`, `api_key_id`, `model` or any
+            combination of them.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - project_id
+                - user_id
+                - api_key_id
+                - model
+        - name: limit
+          in: query
+          description: |
+            Specifies the number of buckets to return.
+            - `bucket_width=1d`: default: 7, max: 31
+            - `bucket_width=1h`: default: 24, max: 168
+            - `bucket_width=1m`: default: 60, max: 1440
+          required: false
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: A cursor for use in pagination. Corresponding to the `next_page`
+            field from the previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Usage data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+      x-oaiMeta:
+        name: Audio speeches
+        group: usage-audio-speeches
+        returns: A list of paginated, time bucketed [Audio speeches
+          usage](/docs/api-reference/usage/audio_speeches_object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              "https://api.openai.com/v1/organization/usage/audio_speeches?start_time=1730419200&limit=1"
+              \
+
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+
+              -H "Content-Type: application/json"
+          response: >
+            {
+                "object": "page",
+                "data": [
+                    {
+                        "object": "bucket",
+                        "start_time": 1730419200,
+                        "end_time": 1730505600,
+                        "results": [
+                            {
+                                "object": "organization.usage.audio_speeches.result",
+                                "characters": 45,
+                                "num_model_requests": 1,
+                                "project_id": null,
+                                "user_id": null,
+                                "api_key_id": null,
+                                "model": null
+                            }
+                        ]
+                    }
+                ],
+                "has_more": false,
+                "next_page": null
+            }
+  /organization/usage/audio_transcriptions:
+    get:
+      summary: Get audio transcriptions usage details for the organization.
+      operationId: usage-audio-transcriptions
+      tags:
+        - Usage
+      parameters:
+        - name: start_time
+          in: query
+          description: Start time (Unix seconds) of the query time range, inclusive.
+          required: true
+          schema:
+            type: integer
+        - name: end_time
+          in: query
+          description: End time (Unix seconds) of the query time range, exclusive.
+          required: false
+          schema:
+            type: integer
+        - name: bucket_width
+          in: query
+          description: Width of each time bucket in response. Currently `1m`, `1h` and
+            `1d` are supported, default to `1d`.
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1m
+              - 1h
+              - 1d
+            default: 1d
+        - name: project_ids
+          in: query
+          description: Return only usage for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: user_ids
+          in: query
+          description: Return only usage for these users.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: api_key_ids
+          in: query
+          description: Return only usage for these API keys.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: models
+          in: query
+          description: Return only usage for these models.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: group_by
+          in: query
+          description: Group the usage data by the specified fields. Support fields
+            include `project_id`, `user_id`, `api_key_id`, `model` or any
+            combination of them.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - project_id
+                - user_id
+                - api_key_id
+                - model
+        - name: limit
+          in: query
+          description: |
+            Specifies the number of buckets to return.
+            - `bucket_width=1d`: default: 7, max: 31
+            - `bucket_width=1h`: default: 24, max: 168
+            - `bucket_width=1m`: default: 60, max: 1440
+          required: false
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: A cursor for use in pagination. Corresponding to the `next_page`
+            field from the previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Usage data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+      x-oaiMeta:
+        name: Audio transcriptions
+        group: usage-audio-transcriptions
+        returns: A list of paginated, time bucketed [Audio transcriptions
+          usage](/docs/api-reference/usage/audio_transcriptions_object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              "https://api.openai.com/v1/organization/usage/audio_transcriptions?start_time=1730419200&limit=1"
+              \
+
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+
+              -H "Content-Type: application/json"
+          response: >
+            {
+                "object": "page",
+                "data": [
+                    {
+                        "object": "bucket",
+                        "start_time": 1730419200,
+                        "end_time": 1730505600,
+                        "results": [
+                            {
+                                "object": "organization.usage.audio_transcriptions.result",
+                                "seconds": 20,
+                                "num_model_requests": 1,
+                                "project_id": null,
+                                "user_id": null,
+                                "api_key_id": null,
+                                "model": null
+                            }
+                        ]
+                    }
+                ],
+                "has_more": false,
+                "next_page": null
+            }
+  /organization/usage/code_interpreter_sessions:
+    get:
+      summary: Get code interpreter sessions usage details for the organization.
+      operationId: usage-code-interpreter-sessions
+      tags:
+        - Usage
+      parameters:
+        - name: start_time
+          in: query
+          description: Start time (Unix seconds) of the query time range, inclusive.
+          required: true
+          schema:
+            type: integer
+        - name: end_time
+          in: query
+          description: End time (Unix seconds) of the query time range, exclusive.
+          required: false
+          schema:
+            type: integer
+        - name: bucket_width
+          in: query
+          description: Width of each time bucket in response. Currently `1m`, `1h` and
+            `1d` are supported, default to `1d`.
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1m
+              - 1h
+              - 1d
+            default: 1d
+        - name: project_ids
+          in: query
+          description: Return only usage for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: group_by
+          in: query
+          description: Group the usage data by the specified fields. Support fields
+            include `project_id`.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - project_id
+        - name: limit
+          in: query
+          description: |
+            Specifies the number of buckets to return.
+            - `bucket_width=1d`: default: 7, max: 31
+            - `bucket_width=1h`: default: 24, max: 168
+            - `bucket_width=1m`: default: 60, max: 1440
+          required: false
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: A cursor for use in pagination. Corresponding to the `next_page`
+            field from the previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Usage data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+      x-oaiMeta:
+        name: Code interpreter sessions
+        group: usage-code-interpreter-sessions
+        returns: A list of paginated, time bucketed [Code interpreter sessions
+          usage](/docs/api-reference/usage/code_interpreter_sessions_object)
+          objects.
+        examples:
+          request:
+            curl: >
+              curl
+              "https://api.openai.com/v1/organization/usage/code_interpreter_sessions?start_time=1730419200&limit=1"
+              \
+
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+
+              -H "Content-Type: application/json"
+          response: >
+            {
+                "object": "page",
+                "data": [
+                    {
+                        "object": "bucket",
+                        "start_time": 1730419200,
+                        "end_time": 1730505600,
+                        "results": [
+                            {
+                                "object": "organization.usage.code_interpreter_sessions.result",
+                                "sessions": 1,
+                                "project_id": null
+                            }
+                        ]
+                    }
+                ],
+                "has_more": false,
+                "next_page": null
+            }
+  /organization/usage/completions:
+    get:
+      summary: Get completions usage details for the organization.
+      operationId: usage-completions
+      tags:
+        - Usage
+      parameters:
+        - name: start_time
+          in: query
+          description: Start time (Unix seconds) of the query time range, inclusive.
+          required: true
+          schema:
+            type: integer
+        - name: end_time
+          in: query
+          description: End time (Unix seconds) of the query time range, exclusive.
+          required: false
+          schema:
+            type: integer
+        - name: bucket_width
+          in: query
+          description: Width of each time bucket in response. Currently `1m`, `1h` and
+            `1d` are supported, default to `1d`.
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1m
+              - 1h
+              - 1d
+            default: 1d
+        - name: project_ids
+          in: query
+          description: Return only usage for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: user_ids
+          in: query
+          description: Return only usage for these users.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: api_key_ids
+          in: query
+          description: Return only usage for these API keys.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: models
+          in: query
+          description: Return only usage for these models.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: batch
+          in: query
+          description: >
+            If `true`, return batch jobs only. If `false`, return non-batch jobs
+            only. By default, return both.
+          required: false
+          schema:
+            type: boolean
+        - name: group_by
+          in: query
+          description: Group the usage data by the specified fields. Support fields
+            include `project_id`, `user_id`, `api_key_id`, `model`, `batch` or
+            any combination of them.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - project_id
+                - user_id
+                - api_key_id
+                - model
+                - batch
+        - name: limit
+          in: query
+          description: |
+            Specifies the number of buckets to return.
+            - `bucket_width=1d`: default: 7, max: 31
+            - `bucket_width=1h`: default: 24, max: 168
+            - `bucket_width=1m`: default: 60, max: 1440
+          required: false
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: A cursor for use in pagination. Corresponding to the `next_page`
+            field from the previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Usage data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+      x-oaiMeta:
+        name: Completions
+        group: usage-completions
+        returns: A list of paginated, time bucketed [Completions
+          usage](/docs/api-reference/usage/completions_object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              "https://api.openai.com/v1/organization/usage/completions?start_time=1730419200&limit=1"
+              \
+
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+
+              -H "Content-Type: application/json"
+          response: >
+            {
+                "object": "page",
+                "data": [
+                    {
+                        "object": "bucket",
+                        "start_time": 1730419200,
+                        "end_time": 1730505600,
+                        "results": [
+                            {
+                                "object": "organization.usage.completions.result",
+                                "input_tokens": 1000,
+                                "output_tokens": 500,
+                                "input_cached_tokens": 800,
+                                "input_audio_tokens": 0,
+                                "output_audio_tokens": 0,
+                                "num_model_requests": 5,
+                                "project_id": null,
+                                "user_id": null,
+                                "api_key_id": null,
+                                "model": null,
+                                "batch": null
+                            }
+                        ]
+                    }
+                ],
+                "has_more": true,
+                "next_page": "page_AAAAAGdGxdEiJdKOAAAAAGcqsYA="
+            }
+  /organization/usage/embeddings:
+    get:
+      summary: Get embeddings usage details for the organization.
+      operationId: usage-embeddings
+      tags:
+        - Usage
+      parameters:
+        - name: start_time
+          in: query
+          description: Start time (Unix seconds) of the query time range, inclusive.
+          required: true
+          schema:
+            type: integer
+        - name: end_time
+          in: query
+          description: End time (Unix seconds) of the query time range, exclusive.
+          required: false
+          schema:
+            type: integer
+        - name: bucket_width
+          in: query
+          description: Width of each time bucket in response. Currently `1m`, `1h` and
+            `1d` are supported, default to `1d`.
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1m
+              - 1h
+              - 1d
+            default: 1d
+        - name: project_ids
+          in: query
+          description: Return only usage for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: user_ids
+          in: query
+          description: Return only usage for these users.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: api_key_ids
+          in: query
+          description: Return only usage for these API keys.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: models
+          in: query
+          description: Return only usage for these models.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: group_by
+          in: query
+          description: Group the usage data by the specified fields. Support fields
+            include `project_id`, `user_id`, `api_key_id`, `model` or any
+            combination of them.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - project_id
+                - user_id
+                - api_key_id
+                - model
+        - name: limit
+          in: query
+          description: |
+            Specifies the number of buckets to return.
+            - `bucket_width=1d`: default: 7, max: 31
+            - `bucket_width=1h`: default: 24, max: 168
+            - `bucket_width=1m`: default: 60, max: 1440
+          required: false
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: A cursor for use in pagination. Corresponding to the `next_page`
+            field from the previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Usage data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+      x-oaiMeta:
+        name: Embeddings
+        group: usage-embeddings
+        returns: A list of paginated, time bucketed [Embeddings
+          usage](/docs/api-reference/usage/embeddings_object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              "https://api.openai.com/v1/organization/usage/embeddings?start_time=1730419200&limit=1"
+              \
+
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+
+              -H "Content-Type: application/json"
+          response: >
+            {
+                "object": "page",
+                "data": [
+                    {
+                        "object": "bucket",
+                        "start_time": 1730419200,
+                        "end_time": 1730505600,
+                        "results": [
+                            {
+                                "object": "organization.usage.embeddings.result",
+                                "input_tokens": 16,
+                                "num_model_requests": 2,
+                                "project_id": null,
+                                "user_id": null,
+                                "api_key_id": null,
+                                "model": null
+                            }
+                        ]
+                    }
+                ],
+                "has_more": false,
+                "next_page": null
+            }
+  /organization/usage/images:
+    get:
+      summary: Get images usage details for the organization.
+      operationId: usage-images
+      tags:
+        - Usage
+      parameters:
+        - name: start_time
+          in: query
+          description: Start time (Unix seconds) of the query time range, inclusive.
+          required: true
+          schema:
+            type: integer
+        - name: end_time
+          in: query
+          description: End time (Unix seconds) of the query time range, exclusive.
+          required: false
+          schema:
+            type: integer
+        - name: bucket_width
+          in: query
+          description: Width of each time bucket in response. Currently `1m`, `1h` and
+            `1d` are supported, default to `1d`.
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1m
+              - 1h
+              - 1d
+            default: 1d
+        - name: sources
+          in: query
+          description: Return only usages for these sources. Possible values are
+            `image.generation`, `image.edit`, `image.variation` or any
+            combination of them.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - image.generation
+                - image.edit
+                - image.variation
+        - name: sizes
+          in: query
+          description: Return only usages for these image sizes. Possible values are
+            `256x256`, `512x512`, `1024x1024`, `1792x1792`, `1024x1792` or any
+            combination of them.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - 256x256
+                - 512x512
+                - 1024x1024
+                - 1792x1792
+                - 1024x1792
+        - name: project_ids
+          in: query
+          description: Return only usage for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: user_ids
+          in: query
+          description: Return only usage for these users.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: api_key_ids
+          in: query
+          description: Return only usage for these API keys.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: models
+          in: query
+          description: Return only usage for these models.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: group_by
+          in: query
+          description: Group the usage data by the specified fields. Support fields
+            include `project_id`, `user_id`, `api_key_id`, `model`, `size`,
+            `source` or any combination of them.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - project_id
+                - user_id
+                - api_key_id
+                - model
+                - size
+                - source
+        - name: limit
+          in: query
+          description: |
+            Specifies the number of buckets to return.
+            - `bucket_width=1d`: default: 7, max: 31
+            - `bucket_width=1h`: default: 24, max: 168
+            - `bucket_width=1m`: default: 60, max: 1440
+          required: false
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: A cursor for use in pagination. Corresponding to the `next_page`
+            field from the previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Usage data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+      x-oaiMeta:
+        name: Images
+        group: usage-images
+        returns: A list of paginated, time bucketed [Images
+          usage](/docs/api-reference/usage/images_object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              "https://api.openai.com/v1/organization/usage/images?start_time=1730419200&limit=1"
+              \
+
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+
+              -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "page",
+                "data": [
+                    {
+                        "object": "bucket",
+                        "start_time": 1730419200,
+                        "end_time": 1730505600,
+                        "results": [
+                            {
+                                "object": "organization.usage.images.result",
+                                "images": 2,
+                                "num_model_requests": 2,
+                                "size": null,
+                                "source": null,
+                                "project_id": null,
+                                "user_id": null,
+                                "api_key_id": null,
+                                "model": null
+                            }
+                        ]
+                    }
+                ],
+                "has_more": false,
+                "next_page": null
+            }
+  /organization/usage/moderations:
+    get:
+      summary: Get moderations usage details for the organization.
+      operationId: usage-moderations
+      tags:
+        - Usage
+      parameters:
+        - name: start_time
+          in: query
+          description: Start time (Unix seconds) of the query time range, inclusive.
+          required: true
+          schema:
+            type: integer
+        - name: end_time
+          in: query
+          description: End time (Unix seconds) of the query time range, exclusive.
+          required: false
+          schema:
+            type: integer
+        - name: bucket_width
+          in: query
+          description: Width of each time bucket in response. Currently `1m`, `1h` and
+            `1d` are supported, default to `1d`.
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1m
+              - 1h
+              - 1d
+            default: 1d
+        - name: project_ids
+          in: query
+          description: Return only usage for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: user_ids
+          in: query
+          description: Return only usage for these users.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: api_key_ids
+          in: query
+          description: Return only usage for these API keys.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: models
+          in: query
+          description: Return only usage for these models.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: group_by
+          in: query
+          description: Group the usage data by the specified fields. Support fields
+            include `project_id`, `user_id`, `api_key_id`, `model` or any
+            combination of them.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - project_id
+                - user_id
+                - api_key_id
+                - model
+        - name: limit
+          in: query
+          description: |
+            Specifies the number of buckets to return.
+            - `bucket_width=1d`: default: 7, max: 31
+            - `bucket_width=1h`: default: 24, max: 168
+            - `bucket_width=1m`: default: 60, max: 1440
+          required: false
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: A cursor for use in pagination. Corresponding to the `next_page`
+            field from the previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Usage data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+      x-oaiMeta:
+        name: Moderations
+        group: usage-moderations
+        returns: A list of paginated, time bucketed [Moderations
+          usage](/docs/api-reference/usage/moderations_object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              "https://api.openai.com/v1/organization/usage/moderations?start_time=1730419200&limit=1"
+              \
+
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+
+              -H "Content-Type: application/json"
+          response: >
+            {
+                "object": "page",
+                "data": [
+                    {
+                        "object": "bucket",
+                        "start_time": 1730419200,
+                        "end_time": 1730505600,
+                        "results": [
+                            {
+                                "object": "organization.usage.moderations.result",
+                                "input_tokens": 16,
+                                "num_model_requests": 2,
+                                "project_id": null,
+                                "user_id": null,
+                                "api_key_id": null,
+                                "model": null
+                            }
+                        ]
+                    }
+                ],
+                "has_more": false,
+                "next_page": null
+            }
+  /organization/usage/vector_stores:
+    get:
+      summary: Get vector stores usage details for the organization.
+      operationId: usage-vector-stores
+      tags:
+        - Usage
+      parameters:
+        - name: start_time
+          in: query
+          description: Start time (Unix seconds) of the query time range, inclusive.
+          required: true
+          schema:
+            type: integer
+        - name: end_time
+          in: query
+          description: End time (Unix seconds) of the query time range, exclusive.
+          required: false
+          schema:
+            type: integer
+        - name: bucket_width
+          in: query
+          description: Width of each time bucket in response. Currently `1m`, `1h` and
+            `1d` are supported, default to `1d`.
+          required: false
+          schema:
+            type: string
+            enum:
+              - 1m
+              - 1h
+              - 1d
+            default: 1d
+        - name: project_ids
+          in: query
+          description: Return only usage for these projects.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: group_by
+          in: query
+          description: Group the usage data by the specified fields. Support fields
+            include `project_id`.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - project_id
+        - name: limit
+          in: query
+          description: |
+            Specifies the number of buckets to return.
+            - `bucket_width=1d`: default: 7, max: 31
+            - `bucket_width=1h`: default: 24, max: 168
+            - `bucket_width=1m`: default: 60, max: 1440
+          required: false
+          schema:
+            type: integer
+        - name: page
+          in: query
+          description: A cursor for use in pagination. Corresponding to the `next_page`
+            field from the previous response.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Usage data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+      x-oaiMeta:
+        name: Vector stores
+        group: usage-vector-stores
+        returns: A list of paginated, time bucketed [Vector stores
+          usage](/docs/api-reference/usage/vector_stores_object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              "https://api.openai.com/v1/organization/usage/vector_stores?start_time=1730419200&limit=1"
+              \
+
+              -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+
+              -H "Content-Type: application/json"
+          response: >
+            {
+                "object": "page",
+                "data": [
+                    {
+                        "object": "bucket",
+                        "start_time": 1730419200,
+                        "end_time": 1730505600,
+                        "results": [
+                            {
+                                "object": "organization.usage.vector_stores.result",
+                                "usage_bytes": 1024,
+                                "project_id": null
+                            }
+                        ]
+                    }
+                ],
+                "has_more": false,
+                "next_page": null
+            }
+  /organization/users:
+    get:
+      summary: Lists all of the users in the organization.
+      operationId: list-users
+      tags:
+        - Users
+      parameters:
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Users listed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserListResponse"
+      x-oaiMeta:
+        name: List users
+        group: administration
+        returns: A list of [User](/docs/api-reference/users/object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/organization/users?after=user_abc&limit=20
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "organization.user",
+                        "id": "user_abc",
+                        "name": "First Last",
+                        "email": "user@example.com",
+                        "role": "owner",
+                        "added_at": 1711471533
+                    }
+                ],
+                "first_id": "user-abc",
+                "last_id": "user-xyz",
+                "has_more": false
+            }
+  /organization/users/{user_id}:
+    get:
+      summary: Retrieves a user by their identifier.
+      operationId: retrieve-user
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+      x-oaiMeta:
+        name: Retrieve user
+        group: administration
+        returns: The [User](/docs/api-reference/users/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/organization/users/user_abc \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.user",
+                "id": "user_abc",
+                "name": "First Last",
+                "email": "user@example.com",
+                "role": "owner",
+                "added_at": 1711471533
+            }
+    post:
+      summary: Modifies a user's role in the organization.
+      operationId: modify-user
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The new user role to modify. This must be one of `owner` or `member`.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserRoleUpdateRequest"
+      responses:
+        "200":
+          description: User role updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+      x-oaiMeta:
+        name: Modify user
+        group: administration
+        returns: The updated [User](/docs/api-reference/users/object) object.
+        examples:
+          request:
+            curl: >
+              curl -X POST https://api.openai.com/v1/organization/users/user_abc
+              \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "role": "owner"
+                }'
+          response: |
+            {
+                "object": "organization.user",
+                "id": "user_abc",
+                "name": "First Last",
+                "email": "user@example.com",
+                "role": "owner",
+                "added_at": 1711471533
+            }
+    delete:
+      summary: Deletes a user from the organization.
+      operationId: delete-user
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserDeleteResponse"
+      x-oaiMeta:
+        name: Delete user
+        group: administration
+        returns: Confirmation of the deleted user
+        examples:
+          request:
+            curl: >
+              curl -X DELETE
+              https://api.openai.com/v1/organization/users/user_abc \
+                -H "Authorization: Bearer $OPENAI_ADMIN_KEY" \
+                -H "Content-Type: application/json"
+          response: |
+            {
+                "object": "organization.user.deleted",
+                "id": "user_abc",
+                "deleted": true
+            }
+  /realtime/sessions:
+    post:
+      summary: >
+        Create an ephemeral API token for use in client-side applications with
+        the
+
+        Realtime API. Can be configured with the same session parameters as the
+
+        `session.update` client event.
+
+
+        It responds with a session object, plus a `client_secret` key which
+        contains
+
+        a usable ephemeral API token that can be used to authenticate browser
+        clients
+
+        for the Realtime API.
+      operationId: create-realtime-session
+      tags:
+        - Realtime
+      requestBody:
+        description: Create an ephemeral API key with the given session configuration.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RealtimeSessionCreateRequest"
+      responses:
+        "200":
+          description: Session created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RealtimeSessionCreateResponse"
+      x-oaiMeta:
+        name: Create session
+        group: realtime
+        returns: The created Realtime session object, plus an ephemeral key
+        examples:
+          request:
+            curl: |
+              curl -X POST https://api.openai.com/v1/realtime/sessions \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                  "model": "gpt-4o-realtime-preview-2024-12-17",
+                  "modalities": ["audio", "text"],
+                  "instructions": "You are a friendly assistant."
+                }'
+          response: |
+            {
+              "id": "sess_001",
+              "object": "realtime.session",
+              "model": "gpt-4o-realtime-preview-2024-12-17",
+              "modalities": ["audio", "text"],
+              "instructions": "You are a friendly assistant.",
+              "voice": "alloy",
+              "input_audio_format": "pcm16",
+              "output_audio_format": "pcm16",
+              "input_audio_transcription": {
+                  "model": "whisper-1"
+              },
+              "turn_detection": null,
+              "tools": [],
+              "tool_choice": "none",
+              "temperature": 0.7,
+              "max_response_output_tokens": 200,
+              "client_secret": {
+                "value": "ek_abc123", 
+                "expires_at": 1234567890
+              }
+            }
+  /threads:
+    post:
+      operationId: createThread
+      tags:
+        - Assistants
+      summary: Create a thread.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateThreadRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ThreadObject"
+      x-oaiMeta:
+        name: Create thread
+        group: threads
+        beta: true
+        returns: A [thread](/docs/api-reference/threads) object.
+        examples:
+          - title: Empty
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d ''
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                empty_thread = client.beta.threads.create()
+                print(empty_thread)
+              node.js: |-
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const emptyThread = await openai.beta.threads.create();
+
+                  console.log(emptyThread);
+                }
+
+                main();
+            response: |
+              {
+                "id": "thread_abc123",
+                "object": "thread",
+                "created_at": 1699012949,
+                "metadata": {},
+                "tool_resources": {}
+              }
+          - title: Messages
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -d '{
+                    "messages": [{
+                      "role": "user",
+                      "content": "Hello, what is AI?"
+                    }, {
+                      "role": "user",
+                      "content": "How does AI work? Explain it in simple terms."
+                    }]
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                message_thread = client.beta.threads.create(
+                  messages=[
+                    {
+                      "role": "user",
+                      "content": "Hello, what is AI?"
+                    },
+                    {
+                      "role": "user",
+                      "content": "How does AI work? Explain it in simple terms."
+                    },
+                  ]
+                )
+
+                print(message_thread)
+              node.js: >-
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const messageThread = await openai.beta.threads.create({
+                    messages: [
+                      {
+                        role: "user",
+                        content: "Hello, what is AI?"
+                      },
+                      {
+                        role: "user",
+                        content: "How does AI work? Explain it in simple terms.",
+                      },
+                    ],
+                  });
+
+                  console.log(messageThread);
+                }
+
+
+                main();
+            response: |
+              {
+                "id": "thread_abc123",
+                "object": "thread",
+                "created_at": 1699014083,
+                "metadata": {},
+                "tool_resources": {}
+              }
+  /threads/runs:
+    post:
+      operationId: createThreadAndRun
+      tags:
+        - Assistants
+      summary: Create a thread and run it in one request.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateThreadAndRunRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RunObject"
+      x-oaiMeta:
+        name: Create thread and run
+        group: threads
+        beta: true
+        returns: A [run](/docs/api-reference/runs/object) object.
+        examples:
+          - title: Default
+            request:
+              curl: >
+                curl https://api.openai.com/v1/threads/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                      "assistant_id": "asst_abc123",
+                      "thread": {
+                        "messages": [
+                          {"role": "user", "content": "Explain deep learning to a 5 year old."}
+                        ]
+                      }
+                    }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                run = client.beta.threads.create_and_run(
+                  assistant_id="asst_abc123",
+                  thread={
+                    "messages": [
+                      {"role": "user", "content": "Explain deep learning to a 5 year old."}
+                    ]
+                  }
+                )
+
+
+                print(run)
+              node.js: >
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const run = await openai.beta.threads.createAndRun({
+                    assistant_id: "asst_abc123",
+                    thread: {
+                      messages: [
+                        { role: "user", content: "Explain deep learning to a 5 year old." },
+                      ],
+                    },
+                  });
+
+                  console.log(run);
+                }
+
+
+                main();
+            response: |
+              {
+                "id": "run_abc123",
+                "object": "thread.run",
+                "created_at": 1699076792,
+                "assistant_id": "asst_abc123",
+                "thread_id": "thread_abc123",
+                "status": "queued",
+                "started_at": null,
+                "expires_at": 1699077392,
+                "cancelled_at": null,
+                "failed_at": null,
+                "completed_at": null,
+                "required_action": null,
+                "last_error": null,
+                "model": "gpt-4o",
+                "instructions": "You are a helpful assistant.",
+                "tools": [],
+                "tool_resources": {},
+                "metadata": {},
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "max_completion_tokens": null,
+                "max_prompt_tokens": null,
+                "truncation_strategy": {
+                  "type": "auto",
+                  "last_messages": null
+                },
+                "incomplete_details": null,
+                "usage": null,
+                "response_format": "auto",
+                "tool_choice": "auto",
+                "parallel_tool_calls": true
+              }
+          - title: Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "assistant_id": "asst_123",
+                    "thread": {
+                      "messages": [
+                        {"role": "user", "content": "Hello"}
+                      ]
+                    },
+                    "stream": true
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                stream = client.beta.threads.create_and_run(
+                  assistant_id="asst_123",
+                  thread={
+                    "messages": [
+                      {"role": "user", "content": "Hello"}
+                    ]
+                  },
+                  stream=True
+                )
+
+                for event in stream:
+                  print(event)
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const stream = await openai.beta.threads.createAndRun({
+                      assistant_id: "asst_123",
+                      thread: {
+                        messages: [
+                          { role: "user", content: "Hello" },
+                        ],
+                      },
+                      stream: true
+                  });
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
+                }
+
+                main();
+            response: >
+              event: thread.created
+
+              data:
+              {"id":"thread_123","object":"thread","created_at":1710348075,"metadata":{}}
+
+
+              event: thread.run.created
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+
+              event: thread.run.queued
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+
+              event: thread.run.in_progress
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"tool_resources":{},"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+
+              event: thread.run.step.created
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+
+              event: thread.run.step.in_progress
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+
+              event: thread.message.created
+
+              data:
+              {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],
+              "metadata":{}}
+
+
+              event: thread.message.in_progress
+
+              data:
+              {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],
+              "metadata":{}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+
+              ...
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"
+              today"}}]}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+
+              event: thread.message.completed
+
+              data:
+              {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710348077,"role":"assistant","content":[{"type":"text","text":{"value":"Hello!
+              How can I assist you today?","annotations":[]}}], "metadata":{}}
+
+
+              event: thread.run.step.completed
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710348077,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+
+              event: thread.run.completed
+
+              {"id":"run_123","object":"thread.run","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1713226836,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1713226837,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":345,"completion_tokens":11,"total_tokens":356},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}
+
+
+              event: done
+
+              data: [DONE]
+          - title: Streaming with Functions
+            request:
+              curl: >
+                curl https://api.openai.com/v1/threads/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "assistant_id": "asst_abc123",
+                    "thread": {
+                      "messages": [
+                        {"role": "user", "content": "What is the weather like in San Francisco?"}
+                      ]
+                    },
+                    "tools": [
+                      {
+                        "type": "function",
+                        "function": {
+                          "name": "get_current_weather",
+                          "description": "Get the current weather in a given location",
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA"
+                              },
+                              "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"]
+                              }
+                            },
+                            "required": ["location"]
+                          }
+                        }
+                      }
+                    ],
+                    "stream": true
+                  }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                tools = [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "get_current_weather",
+                      "description": "Get the current weather in a given location",
+                      "parameters": {
+                        "type": "object",
+                        "properties": {
+                          "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                          },
+                          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                        },
+                        "required": ["location"],
+                      },
+                    }
+                  }
+                ]
+
+
+                stream = client.beta.threads.create_and_run(
+                  thread={
+                      "messages": [
+                        {"role": "user", "content": "What is the weather like in San Francisco?"}
+                      ]
+                  },
+                  assistant_id="asst_abc123",
+                  tools=tools,
+                  stream=True
+                )
+
+
+                for event in stream:
+                  print(event)
+              node.js: >
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                const tools = [
+                    {
+                      "type": "function",
+                      "function": {
+                        "name": "get_current_weather",
+                        "description": "Get the current weather in a given location",
+                        "parameters": {
+                          "type": "object",
+                          "properties": {
+                            "location": {
+                              "type": "string",
+                              "description": "The city and state, e.g. San Francisco, CA",
+                            },
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                          },
+                          "required": ["location"],
+                        },
+                      }
+                    }
+                ];
+
+
+                async function main() {
+                  const stream = await openai.beta.threads.createAndRun({
+                    assistant_id: "asst_123",
+                    thread: {
+                      messages: [
+                        { role: "user", content: "What is the weather like in San Francisco?" },
+                      ],
+                    },
+                    tools: tools,
+                    stream: true
+                  });
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
+                }
+
+
+                main();
+            response: >
+              event: thread.created
+
+              data:
+              {"id":"thread_123","object":"thread","created_at":1710351818,"metadata":{}}
+
+
+              event: thread.run.created
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get
+              the current weather in a given
+              location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The
+              city and state, e.g. San Francisco,
+              CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.queued
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get
+              the current weather in a given
+              location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The
+              city and state, e.g. San Francisco,
+              CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.in_progress
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710351818,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get
+              the current weather in a given
+              location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The
+              city and state, e.g. San Francisco,
+              CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.step.created
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710351819,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710352418,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[]},"usage":null}
+
+
+              event: thread.run.step.in_progress
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710351819,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710352418,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[]},"usage":null}
+
+
+              event: thread.run.step.delta
+
+              data:
+              {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"id":"call_XXNp8YGaFrjrSjgqxtC8JJ1B","type":"function","function":{"name":"get_current_weather","arguments":"","output":null}}]}}}
+
+
+              event: thread.run.step.delta
+
+              data:
+              {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"{\""}}]}}}
+
+
+              event: thread.run.step.delta
+
+              data:
+              {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"location"}}]}}}
+
+
+              ...
+
+
+              event: thread.run.step.delta
+
+              data:
+              {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"ahrenheit"}}]}}}
+
+
+              event: thread.run.step.delta
+
+              data:
+              {"id":"step_001","object":"thread.run.step.delta","delta":{"step_details":{"type":"tool_calls","tool_calls":[{"index":0,"type":"function","function":{"arguments":"\"}"}}]}}}
+
+
+              event: thread.run.requires_action
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710351818,"assistant_id":"asst_123","thread_id":"thread_123","status":"requires_action","started_at":1710351818,"expires_at":1710352418,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":{"type":"submit_tool_outputs","submit_tool_outputs":{"tool_calls":[{"id":"call_XXNp8YGaFrjrSjgqxtC8JJ1B","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"San
+              Francisco,
+              CA\",\"unit\":\"fahrenheit\"}"}}]}},"last_error":null,"model":"gpt-4o","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get
+              the current weather in a given
+              location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The
+              city and state, e.g. San Francisco,
+              CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":345,"completion_tokens":11,"total_tokens":356},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: done
+
+              data: [DONE]
+  /threads/{thread_id}:
+    get:
+      operationId: getThread
+      tags:
+        - Assistants
+      summary: Retrieves a thread.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread to retrieve.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ThreadObject"
+      x-oaiMeta:
+        name: Retrieve thread
+        group: threads
+        beta: true
+        returns: The [thread](/docs/api-reference/threads/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/threads/thread_abc123 \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              my_thread = client.beta.threads.retrieve("thread_abc123")
+              print(my_thread)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const myThread = await openai.beta.threads.retrieve(
+                  "thread_abc123"
+                );
+
+                console.log(myThread);
+              }
+
+              main();
+          response: |
+            {
+              "id": "thread_abc123",
+              "object": "thread",
+              "created_at": 1699014083,
+              "metadata": {},
+              "tool_resources": {
+                "code_interpreter": {
+                  "file_ids": []
+                }
+              }
+            }
+    post:
+      operationId: modifyThread
+      tags:
+        - Assistants
+      summary: Modifies a thread.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread to modify. Only the `metadata` can be modified.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModifyThreadRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ThreadObject"
+      x-oaiMeta:
+        name: Modify thread
+        group: threads
+        beta: true
+        returns: The modified [thread](/docs/api-reference/threads/object) object
+          matching the specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/threads/thread_abc123 \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -d '{
+                    "metadata": {
+                      "modified": "true",
+                      "user": "abc123"
+                    }
+                  }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              my_updated_thread = client.beta.threads.update(
+                "thread_abc123",
+                metadata={
+                  "modified": "true",
+                  "user": "abc123"
+                }
+              )
+              print(my_updated_thread)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const updatedThread = await openai.beta.threads.update(
+                  "thread_abc123",
+                  {
+                    metadata: { modified: "true", user: "abc123" },
+                  }
+                );
+
+                console.log(updatedThread);
+              }
+
+              main();
+          response: |
+            {
+              "id": "thread_abc123",
+              "object": "thread",
+              "created_at": 1699014083,
+              "metadata": {
+                "modified": "true",
+                "user": "abc123"
+              },
+              "tool_resources": {}
+            }
+    delete:
+      operationId: deleteThread
+      tags:
+        - Assistants
+      summary: Delete a thread.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread to delete.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteThreadResponse"
+      x-oaiMeta:
+        name: Delete thread
+        group: threads
+        beta: true
+        returns: Deletion status
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/threads/thread_abc123 \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -X DELETE
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              response = client.beta.threads.delete("thread_abc123")
+              print(response)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const response = await openai.beta.threads.del("thread_abc123");
+
+                console.log(response);
+              }
+              main();
+          response: |
+            {
+              "id": "thread_abc123",
+              "object": "thread.deleted",
+              "deleted": true
+            }
+  /threads/{thread_id}/messages:
+    get:
+      operationId: listMessages
+      tags:
+        - Assistants
+      summary: Returns a list of messages for a given thread.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the [thread](/docs/api-reference/threads) the messages
+            belong to.
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: order
+          in: query
+          description: >
+            Sort order by the `created_at` timestamp of the objects. `asc` for
+            ascending order and `desc` for descending order.
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: >
+            A cursor for use in pagination. `before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, starting with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the
+            previous page of the list.
+          schema:
+            type: string
+        - name: run_id
+          in: query
+          description: |
+            Filter messages by the run ID that generated them.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListMessagesResponse"
+      x-oaiMeta:
+        name: List messages
+        group: threads
+        beta: true
+        returns: A list of [message](/docs/api-reference/messages) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/threads/thread_abc123/messages \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: >
+              from openai import OpenAI
+
+              client = OpenAI()
+
+
+              thread_messages =
+              client.beta.threads.messages.list("thread_abc123")
+
+              print(thread_messages.data)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const threadMessages = await openai.beta.threads.messages.list(
+                  "thread_abc123"
+                );
+
+                console.log(threadMessages.data);
+              }
+
+              main();
+          response: >
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "msg_abc123",
+                  "object": "thread.message",
+                  "created_at": 1699016383,
+                  "assistant_id": null,
+                  "thread_id": "thread_abc123",
+                  "run_id": null,
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "value": "How does AI work? Explain it in simple terms.",
+                        "annotations": []
+                      }
+                    }
+                  ],
+                  "attachments": [],
+                  "metadata": {}
+                },
+                {
+                  "id": "msg_abc456",
+                  "object": "thread.message",
+                  "created_at": 1699016383,
+                  "assistant_id": null,
+                  "thread_id": "thread_abc123",
+                  "run_id": null,
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "value": "Hello, what is AI?",
+                        "annotations": []
+                      }
+                    }
+                  ],
+                  "attachments": [],
+                  "metadata": {}
+                }
+              ],
+              "first_id": "msg_abc123",
+              "last_id": "msg_abc456",
+              "has_more": false
+            }
+    post:
+      operationId: createMessage
+      tags:
+        - Assistants
+      summary: Create a message.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the [thread](/docs/api-reference/threads) to create a
+            message for.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateMessageRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageObject"
+      x-oaiMeta:
+        name: Create message
+        group: threads
+        beta: true
+        returns: A [message](/docs/api-reference/messages/object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/threads/thread_abc123/messages \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -d '{
+                    "role": "user",
+                    "content": "How does AI work? Explain it in simple terms."
+                  }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              thread_message = client.beta.threads.messages.create(
+                "thread_abc123",
+                role="user",
+                content="How does AI work? Explain it in simple terms.",
+              )
+              print(thread_message)
+            node.js: >-
+              import OpenAI from "openai";
+
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const threadMessages = await openai.beta.threads.messages.create(
+                  "thread_abc123",
+                  { role: "user", content: "How does AI work? Explain it in simple terms." }
+                );
+
+                console.log(threadMessages);
+              }
+
+
+              main();
+          response: |
+            {
+              "id": "msg_abc123",
+              "object": "thread.message",
+              "created_at": 1713226573,
+              "assistant_id": null,
+              "thread_id": "thread_abc123",
+              "run_id": null,
+              "role": "user",
+              "content": [
+                {
+                  "type": "text",
+                  "text": {
+                    "value": "How does AI work? Explain it in simple terms.",
+                    "annotations": []
+                  }
+                }
+              ],
+              "attachments": [],
+              "metadata": {}
+            }
+  /threads/{thread_id}/messages/{message_id}:
+    get:
+      operationId: getMessage
+      tags:
+        - Assistants
+      summary: Retrieve a message.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the [thread](/docs/api-reference/threads) to which this
+            message belongs.
+        - in: path
+          name: message_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the message to retrieve.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageObject"
+      x-oaiMeta:
+        name: Retrieve message
+        group: threads
+        beta: true
+        returns: The [message](/docs/api-reference/messages/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123
+              \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              message = client.beta.threads.messages.retrieve(
+                message_id="msg_abc123",
+                thread_id="thread_abc123",
+              )
+              print(message)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const message = await openai.beta.threads.messages.retrieve(
+                  "thread_abc123",
+                  "msg_abc123"
+                );
+
+                console.log(message);
+              }
+
+              main();
+          response: |
+            {
+              "id": "msg_abc123",
+              "object": "thread.message",
+              "created_at": 1699017614,
+              "assistant_id": null,
+              "thread_id": "thread_abc123",
+              "run_id": null,
+              "role": "user",
+              "content": [
+                {
+                  "type": "text",
+                  "text": {
+                    "value": "How does AI work? Explain it in simple terms.",
+                    "annotations": []
+                  }
+                }
+              ],
+              "attachments": [],
+              "metadata": {}
+            }
+    post:
+      operationId: modifyMessage
+      tags:
+        - Assistants
+      summary: Modifies a message.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread to which this message belongs.
+        - in: path
+          name: message_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the message to modify.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModifyMessageRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageObject"
+      x-oaiMeta:
+        name: Modify message
+        group: threads
+        beta: true
+        returns: The modified [message](/docs/api-reference/messages/object) object.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123
+              \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -d '{
+                    "metadata": {
+                      "modified": "true",
+                      "user": "abc123"
+                    }
+                  }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              message = client.beta.threads.messages.update(
+                message_id="msg_abc12",
+                thread_id="thread_abc123",
+                metadata={
+                  "modified": "true",
+                  "user": "abc123",
+                },
+              )
+              print(message)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const message = await openai.beta.threads.messages.update(
+                  "thread_abc123",
+                  "msg_abc123",
+                  {
+                    metadata: {
+                      modified: "true",
+                      user: "abc123",
+                    },
+                  }
+                }'
+          response: |
+            {
+              "id": "msg_abc123",
+              "object": "thread.message",
+              "created_at": 1699017614,
+              "assistant_id": null,
+              "thread_id": "thread_abc123",
+              "run_id": null,
+              "role": "user",
+              "content": [
+                {
+                  "type": "text",
+                  "text": {
+                    "value": "How does AI work? Explain it in simple terms.",
+                    "annotations": []
+                  }
+                }
+              ],
+              "file_ids": [],
+              "metadata": {
+                "modified": "true",
+                "user": "abc123"
+              }
+            }
+    delete:
+      operationId: deleteMessage
+      tags:
+        - Assistants
+      summary: Deletes a message.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread to which this message belongs.
+        - in: path
+          name: message_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the message to delete.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteMessageResponse"
+      x-oaiMeta:
+        name: Delete message
+        group: threads
+        beta: true
+        returns: Deletion status
+        examples:
+          request:
+            curl: >
+              curl -X DELETE
+              https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123
+              \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              deleted_message = client.beta.threads.messages.delete(
+                message_id="msg_abc12",
+                thread_id="thread_abc123",
+              )
+              print(deleted_message)
+            node.js: |-
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const deletedMessage = await openai.beta.threads.messages.del(
+                  "thread_abc123",
+                  "msg_abc123"
+                );
+
+                console.log(deletedMessage);
+              }
+          response: |
+            {
+              "id": "msg_abc123",
+              "object": "thread.message.deleted",
+              "deleted": true
+            }
+  /threads/{thread_id}/runs:
+    get:
+      operationId: listRuns
+      tags:
+        - Assistants
+      summary: Returns a list of runs belonging to a thread.
+      parameters:
+        - name: thread_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread the run belongs to.
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: order
+          in: query
+          description: >
+            Sort order by the `created_at` timestamp of the objects. `asc` for
+            ascending order and `desc` for descending order.
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: >
+            A cursor for use in pagination. `before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, starting with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the
+            previous page of the list.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListRunsResponse"
+      x-oaiMeta:
+        name: List runs
+        group: threads
+        beta: true
+        returns: A list of [run](/docs/api-reference/runs/object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              runs = client.beta.threads.runs.list(
+                "thread_abc123"
+              )
+
+              print(runs)
+            node.js: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const runs = await openai.beta.threads.runs.list(
+                  "thread_abc123"
+                );
+
+                console.log(runs);
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "run_abc123",
+                  "object": "thread.run",
+                  "created_at": 1699075072,
+                  "assistant_id": "asst_abc123",
+                  "thread_id": "thread_abc123",
+                  "status": "completed",
+                  "started_at": 1699075072,
+                  "expires_at": null,
+                  "cancelled_at": null,
+                  "failed_at": null,
+                  "completed_at": 1699075073,
+                  "last_error": null,
+                  "model": "gpt-4o",
+                  "instructions": null,
+                  "incomplete_details": null,
+                  "tools": [
+                    {
+                      "type": "code_interpreter"
+                    }
+                  ],
+                  "tool_resources": {
+                    "code_interpreter": {
+                      "file_ids": [
+                        "file-abc123",
+                        "file-abc456"
+                      ]
+                    }
+                  },
+                  "metadata": {},
+                  "usage": {
+                    "prompt_tokens": 123,
+                    "completion_tokens": 456,
+                    "total_tokens": 579
+                  },
+                  "temperature": 1.0,
+                  "top_p": 1.0,
+                  "max_prompt_tokens": 1000,
+                  "max_completion_tokens": 1000,
+                  "truncation_strategy": {
+                    "type": "auto",
+                    "last_messages": null
+                  },
+                  "response_format": "auto",
+                  "tool_choice": "auto",
+                  "parallel_tool_calls": true
+                },
+                {
+                  "id": "run_abc456",
+                  "object": "thread.run",
+                  "created_at": 1699063290,
+                  "assistant_id": "asst_abc123",
+                  "thread_id": "thread_abc123",
+                  "status": "completed",
+                  "started_at": 1699063290,
+                  "expires_at": null,
+                  "cancelled_at": null,
+                  "failed_at": null,
+                  "completed_at": 1699063291,
+                  "last_error": null,
+                  "model": "gpt-4o",
+                  "instructions": null,
+                  "incomplete_details": null,
+                  "tools": [
+                    {
+                      "type": "code_interpreter"
+                    }
+                  ],
+                  "tool_resources": {
+                    "code_interpreter": {
+                      "file_ids": [
+                        "file-abc123",
+                        "file-abc456"
+                      ]
+                    }
+                  },
+                  "metadata": {},
+                  "usage": {
+                    "prompt_tokens": 123,
+                    "completion_tokens": 456,
+                    "total_tokens": 579
+                  },
+                  "temperature": 1.0,
+                  "top_p": 1.0,
+                  "max_prompt_tokens": 1000,
+                  "max_completion_tokens": 1000,
+                  "truncation_strategy": {
+                    "type": "auto",
+                    "last_messages": null
+                  },
+                  "response_format": "auto",
+                  "tool_choice": "auto",
+                  "parallel_tool_calls": true
+                }
+              ],
+              "first_id": "run_abc123",
+              "last_id": "run_abc456",
+              "has_more": false
+            }
+    post:
+      operationId: createRun
+      tags:
+        - Assistants
+      summary: Create a run.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread to run.
+        - name: include[]
+          in: query
+          description: >
+            A list of additional fields to include in the response. Currently
+            the only supported value is
+            `step_details.tool_calls[*].file_search.results[*].content` to fetch
+            the file search result content.
+
+
+            See the [file search tool
+            documentation](/docs/assistants/tools/file-search#customizing-file-search-settings)
+            for more information.
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - step_details.tool_calls[*].file_search.results[*].content
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRunRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RunObject"
+      x-oaiMeta:
+        name: Create run
+        group: threads
+        beta: true
+        returns: A [run](/docs/api-reference/runs/object) object.
+        examples:
+          - title: Default
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "assistant_id": "asst_abc123"
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                run = client.beta.threads.runs.create(
+                  thread_id="thread_abc123",
+                  assistant_id="asst_abc123"
+                )
+
+                print(run)
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const run = await openai.beta.threads.runs.create(
+                    "thread_abc123",
+                    { assistant_id: "asst_abc123" }
+                  );
+
+                  console.log(run);
+                }
+
+                main();
+            response: |
+              {
+                "id": "run_abc123",
+                "object": "thread.run",
+                "created_at": 1699063290,
+                "assistant_id": "asst_abc123",
+                "thread_id": "thread_abc123",
+                "status": "queued",
+                "started_at": 1699063290,
+                "expires_at": null,
+                "cancelled_at": null,
+                "failed_at": null,
+                "completed_at": 1699063291,
+                "last_error": null,
+                "model": "gpt-4o",
+                "instructions": null,
+                "incomplete_details": null,
+                "tools": [
+                  {
+                    "type": "code_interpreter"
+                  }
+                ],
+                "metadata": {},
+                "usage": null,
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "max_prompt_tokens": 1000,
+                "max_completion_tokens": 1000,
+                "truncation_strategy": {
+                  "type": "auto",
+                  "last_messages": null
+                },
+                "response_format": "auto",
+                "tool_choice": "auto",
+                "parallel_tool_calls": true
+              }
+          - title: Streaming
+            request:
+              curl: |
+                curl https://api.openai.com/v1/threads/thread_123/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "assistant_id": "asst_123",
+                    "stream": true
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                stream = client.beta.threads.runs.create(
+                  thread_id="thread_123",
+                  assistant_id="asst_123",
+                  stream=True
+                )
+
+                for event in stream:
+                  print(event)
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const stream = await openai.beta.threads.runs.create(
+                    "thread_123",
+                    { assistant_id: "asst_123", stream: true }
+                  );
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
+                }
+
+                main();
+            response: >
+              event: thread.run.created
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.queued
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.in_progress
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710330641,"expires_at":1710331240,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.step.created
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+
+              event: thread.run.step.in_progress
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+
+              event: thread.message.created
+
+              data:
+              {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+
+              event: thread.message.in_progress
+
+              data:
+              {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+
+              ...
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"
+              today"}}]}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+
+              event: thread.message.completed
+
+              data:
+              {"id":"msg_001","object":"thread.message","created_at":1710330641,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710330642,"role":"assistant","content":[{"type":"text","text":{"value":"Hello!
+              How can I assist you today?","annotations":[]}}],"metadata":{}}
+
+
+              event: thread.run.step.completed
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710330641,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710330642,"expires_at":1710331240,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+
+              event: thread.run.completed
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710330640,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710330641,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710330642,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: done
+
+              data: [DONE]
+          - title: Streaming with Functions
+            request:
+              curl: >
+                curl https://api.openai.com/v1/threads/thread_abc123/runs \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "assistant_id": "asst_abc123",
+                    "tools": [
+                      {
+                        "type": "function",
+                        "function": {
+                          "name": "get_current_weather",
+                          "description": "Get the current weather in a given location",
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g. San Francisco, CA"
+                              },
+                              "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"]
+                              }
+                            },
+                            "required": ["location"]
+                          }
+                        }
+                      }
+                    ],
+                    "stream": true
+                  }'
+              python: >
+                from openai import OpenAI
+
+                client = OpenAI()
+
+
+                tools = [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "get_current_weather",
+                      "description": "Get the current weather in a given location",
+                      "parameters": {
+                        "type": "object",
+                        "properties": {
+                          "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                          },
+                          "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                        },
+                        "required": ["location"],
+                      },
+                    }
+                  }
+                ]
+
+
+                stream = client.beta.threads.runs.create(
+                  thread_id="thread_abc123",
+                  assistant_id="asst_abc123",
+                  tools=tools,
+                  stream=True
+                )
+
+
+                for event in stream:
+                  print(event)
+              node.js: >
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                const tools = [
+                    {
+                      "type": "function",
+                      "function": {
+                        "name": "get_current_weather",
+                        "description": "Get the current weather in a given location",
+                        "parameters": {
+                          "type": "object",
+                          "properties": {
+                            "location": {
+                              "type": "string",
+                              "description": "The city and state, e.g. San Francisco, CA",
+                            },
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                          },
+                          "required": ["location"],
+                        },
+                      }
+                    }
+                ];
+
+
+                async function main() {
+                  const stream = await openai.beta.threads.runs.create(
+                    "thread_abc123",
+                    {
+                      assistant_id: "asst_abc123",
+                      tools: tools,
+                      stream: true
+                    }
+                  );
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
+                }
+
+
+                main();
+            response: >
+              event: thread.run.created
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.queued
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":null,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.in_progress
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710348075,"expires_at":1710348675,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.step.created
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+
+              event: thread.run.step.in_progress
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":null}
+
+
+              event: thread.message.created
+
+              data:
+              {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+
+              event: thread.message.in_progress
+
+              data:
+              {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"Hello","annotations":[]}}]}}
+
+
+              ...
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"
+              today"}}]}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_001","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"?"}}]}}
+
+
+              event: thread.message.completed
+
+              data:
+              {"id":"msg_001","object":"thread.message","created_at":1710348076,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710348077,"role":"assistant","content":[{"type":"text","text":{"value":"Hello!
+              How can I assist you today?","annotations":[]}}],"metadata":{}}
+
+
+              event: thread.run.step.completed
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710348076,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710348077,"expires_at":1710348675,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_001"}},"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31}}
+
+
+              event: thread.run.completed
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710348075,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710348075,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710348077,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: done
+
+              data: [DONE]
+  /threads/{thread_id}/runs/{run_id}:
+    get:
+      operationId: getRun
+      tags:
+        - Assistants
+      summary: Retrieves a run.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the [thread](/docs/api-reference/threads) that was run.
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the run to retrieve.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RunObject"
+      x-oaiMeta:
+        name: Retrieve run
+        group: threads
+        beta: true
+        returns: The [run](/docs/api-reference/runs/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              run = client.beta.threads.runs.retrieve(
+                thread_id="thread_abc123",
+                run_id="run_abc123"
+              )
+
+              print(run)
+            node.js: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const run = await openai.beta.threads.runs.retrieve(
+                  "thread_abc123",
+                  "run_abc123"
+                );
+
+                console.log(run);
+              }
+
+              main();
+          response: |
+            {
+              "id": "run_abc123",
+              "object": "thread.run",
+              "created_at": 1699075072,
+              "assistant_id": "asst_abc123",
+              "thread_id": "thread_abc123",
+              "status": "completed",
+              "started_at": 1699075072,
+              "expires_at": null,
+              "cancelled_at": null,
+              "failed_at": null,
+              "completed_at": 1699075073,
+              "last_error": null,
+              "model": "gpt-4o",
+              "instructions": null,
+              "incomplete_details": null,
+              "tools": [
+                {
+                  "type": "code_interpreter"
+                }
+              ],
+              "metadata": {},
+              "usage": {
+                "prompt_tokens": 123,
+                "completion_tokens": 456,
+                "total_tokens": 579
+              },
+              "temperature": 1.0,
+              "top_p": 1.0,
+              "max_prompt_tokens": 1000,
+              "max_completion_tokens": 1000,
+              "truncation_strategy": {
+                "type": "auto",
+                "last_messages": null
+              },
+              "response_format": "auto",
+              "tool_choice": "auto",
+              "parallel_tool_calls": true
+            }
+    post:
+      operationId: modifyRun
+      tags:
+        - Assistants
+      summary: Modifies a run.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the [thread](/docs/api-reference/threads) that was run.
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the run to modify.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModifyRunRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RunObject"
+      x-oaiMeta:
+        name: Modify run
+        group: threads
+        beta: true
+        returns: The modified [run](/docs/api-reference/runs/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -d '{
+                  "metadata": {
+                    "user_id": "user_abc123"
+                  }
+                }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              run = client.beta.threads.runs.update(
+                thread_id="thread_abc123",
+                run_id="run_abc123",
+                metadata={"user_id": "user_abc123"},
+              )
+
+              print(run)
+            node.js: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const run = await openai.beta.threads.runs.update(
+                  "thread_abc123",
+                  "run_abc123",
+                  {
+                    metadata: {
+                      user_id: "user_abc123",
+                    },
+                  }
+                );
+
+                console.log(run);
+              }
+
+              main();
+          response: |
+            {
+              "id": "run_abc123",
+              "object": "thread.run",
+              "created_at": 1699075072,
+              "assistant_id": "asst_abc123",
+              "thread_id": "thread_abc123",
+              "status": "completed",
+              "started_at": 1699075072,
+              "expires_at": null,
+              "cancelled_at": null,
+              "failed_at": null,
+              "completed_at": 1699075073,
+              "last_error": null,
+              "model": "gpt-4o",
+              "instructions": null,
+              "incomplete_details": null,
+              "tools": [
+                {
+                  "type": "code_interpreter"
+                }
+              ],
+              "tool_resources": {
+                "code_interpreter": {
+                  "file_ids": [
+                    "file-abc123",
+                    "file-abc456"
+                  ]
+                }
+              },
+              "metadata": {
+                "user_id": "user_abc123"
+              },
+              "usage": {
+                "prompt_tokens": 123,
+                "completion_tokens": 456,
+                "total_tokens": 579
+              },
+              "temperature": 1.0,
+              "top_p": 1.0,
+              "max_prompt_tokens": 1000,
+              "max_completion_tokens": 1000,
+              "truncation_strategy": {
+                "type": "auto",
+                "last_messages": null
+              },
+              "response_format": "auto",
+              "tool_choice": "auto",
+              "parallel_tool_calls": true
+            }
+  /threads/{thread_id}/runs/{run_id}/cancel:
+    post:
+      operationId: cancelRun
+      tags:
+        - Assistants
+      summary: Cancels a run that is `in_progress`.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread to which this run belongs.
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the run to cancel.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RunObject"
+      x-oaiMeta:
+        name: Cancel a run
+        group: threads
+        beta: true
+        returns: The modified [run](/docs/api-reference/runs/object) object matching the
+          specified ID.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/cancel
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -X POST
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              run = client.beta.threads.runs.cancel(
+                thread_id="thread_abc123",
+                run_id="run_abc123"
+              )
+
+              print(run)
+            node.js: |
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+              async function main() {
+                const run = await openai.beta.threads.runs.cancel(
+                  "thread_abc123",
+                  "run_abc123"
+                );
+
+                console.log(run);
+              }
+
+              main();
+          response: |
+            {
+              "id": "run_abc123",
+              "object": "thread.run",
+              "created_at": 1699076126,
+              "assistant_id": "asst_abc123",
+              "thread_id": "thread_abc123",
+              "status": "cancelling",
+              "started_at": 1699076126,
+              "expires_at": 1699076726,
+              "cancelled_at": null,
+              "failed_at": null,
+              "completed_at": null,
+              "last_error": null,
+              "model": "gpt-4o",
+              "instructions": "You summarize books.",
+              "tools": [
+                {
+                  "type": "file_search"
+                }
+              ],
+              "tool_resources": {
+                "file_search": {
+                  "vector_store_ids": ["vs_123"]
+                }
+              },
+              "metadata": {},
+              "usage": null,
+              "temperature": 1.0,
+              "top_p": 1.0,
+              "response_format": "auto",
+              "tool_choice": "auto",
+              "parallel_tool_calls": true
+            }
+  /threads/{thread_id}/runs/{run_id}/steps:
+    get:
+      operationId: listRunSteps
+      tags:
+        - Assistants
+      summary: Returns a list of run steps belonging to a run.
+      parameters:
+        - name: thread_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread the run and run steps belong to.
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ID of the run the run steps belong to.
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: order
+          in: query
+          description: >
+            Sort order by the `created_at` timestamp of the objects. `asc` for
+            ascending order and `desc` for descending order.
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: >
+            A cursor for use in pagination. `before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, starting with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the
+            previous page of the list.
+          schema:
+            type: string
+        - name: include[]
+          in: query
+          description: >
+            A list of additional fields to include in the response. Currently
+            the only supported value is
+            `step_details.tool_calls[*].file_search.results[*].content` to fetch
+            the file search result content.
+
+
+            See the [file search tool
+            documentation](/docs/assistants/tools/file-search#customizing-file-search-settings)
+            for more information.
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - step_details.tool_calls[*].file_search.results[*].content
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListRunStepsResponse"
+      x-oaiMeta:
+        name: List run steps
+        group: threads
+        beta: true
+        returns: A list of [run step](/docs/api-reference/run-steps/step-object)
+          objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              run_steps = client.beta.threads.runs.steps.list(
+                  thread_id="thread_abc123",
+                  run_id="run_abc123"
+              )
+
+              print(run_steps)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const runStep = await openai.beta.threads.runs.steps.list(
+                  "thread_abc123",
+                  "run_abc123"
+                );
+                console.log(runStep);
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "step_abc123",
+                  "object": "thread.run.step",
+                  "created_at": 1699063291,
+                  "run_id": "run_abc123",
+                  "assistant_id": "asst_abc123",
+                  "thread_id": "thread_abc123",
+                  "type": "message_creation",
+                  "status": "completed",
+                  "cancelled_at": null,
+                  "completed_at": 1699063291,
+                  "expired_at": null,
+                  "failed_at": null,
+                  "last_error": null,
+                  "step_details": {
+                    "type": "message_creation",
+                    "message_creation": {
+                      "message_id": "msg_abc123"
+                    }
+                  },
+                  "usage": {
+                    "prompt_tokens": 123,
+                    "completion_tokens": 456,
+                    "total_tokens": 579
+                  }
+                }
+              ],
+              "first_id": "step_abc123",
+              "last_id": "step_abc456",
+              "has_more": false
+            }
+  /threads/{thread_id}/runs/{run_id}/steps/{step_id}:
+    get:
+      operationId: getRunStep
+      tags:
+        - Assistants
+      summary: Retrieves a run step.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the thread to which the run and run step belongs.
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the run to which the run step belongs.
+        - in: path
+          name: step_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the run step to retrieve.
+        - name: include[]
+          in: query
+          description: >
+            A list of additional fields to include in the response. Currently
+            the only supported value is
+            `step_details.tool_calls[*].file_search.results[*].content` to fetch
+            the file search result content.
+
+
+            See the [file search tool
+            documentation](/docs/assistants/tools/file-search#customizing-file-search-settings)
+            for more information.
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - step_details.tool_calls[*].file_search.results[*].content
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RunStepObject"
+      x-oaiMeta:
+        name: Retrieve run step
+        group: threads
+        beta: true
+        returns: The [run step](/docs/api-reference/run-steps/step-object) object
+          matching the specified ID.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              run_step = client.beta.threads.runs.steps.retrieve(
+                  thread_id="thread_abc123",
+                  run_id="run_abc123",
+                  step_id="step_abc123"
+              )
+
+              print(run_step)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const runStep = await openai.beta.threads.runs.steps.retrieve(
+                  "thread_abc123",
+                  "run_abc123",
+                  "step_abc123"
+                );
+                console.log(runStep);
+              }
+
+              main();
+          response: |
+            {
+              "id": "step_abc123",
+              "object": "thread.run.step",
+              "created_at": 1699063291,
+              "run_id": "run_abc123",
+              "assistant_id": "asst_abc123",
+              "thread_id": "thread_abc123",
+              "type": "message_creation",
+              "status": "completed",
+              "cancelled_at": null,
+              "completed_at": 1699063291,
+              "expired_at": null,
+              "failed_at": null,
+              "last_error": null,
+              "step_details": {
+                "type": "message_creation",
+                "message_creation": {
+                  "message_id": "msg_abc123"
+                }
+              },
+              "usage": {
+                "prompt_tokens": 123,
+                "completion_tokens": 456,
+                "total_tokens": 579
+              }
+            }
+  /threads/{thread_id}/runs/{run_id}/submit_tool_outputs:
+    post:
+      operationId: submitToolOuputsToRun
+      tags:
+        - Assistants
+      summary: >
+        When a run has the `status: "requires_action"` and
+        `required_action.type` is `submit_tool_outputs`, this endpoint can be
+        used to submit the outputs from the tool calls once they're all
+        completed. All outputs must be submitted in a single request.
+      parameters:
+        - in: path
+          name: thread_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the [thread](/docs/api-reference/threads) to which this
+            run belongs.
+        - in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the run that requires the tool output submission.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubmitToolOutputsRunRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RunObject"
+      x-oaiMeta:
+        name: Submit tool outputs to run
+        group: threads
+        beta: true
+        returns: The modified [run](/docs/api-reference/runs/object) object matching the
+          specified ID.
+        examples:
+          - title: Default
+            request:
+              curl: >
+                curl
+                https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs
+                \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "tool_outputs": [
+                      {
+                        "tool_call_id": "call_001",
+                        "output": "70 degrees and sunny."
+                      }
+                    ]
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                run = client.beta.threads.runs.submit_tool_outputs(
+                  thread_id="thread_123",
+                  run_id="run_123",
+                  tool_outputs=[
+                    {
+                      "tool_call_id": "call_001",
+                      "output": "70 degrees and sunny."
+                    }
+                  ]
+                )
+
+                print(run)
+              node.js: |
+                import OpenAI from "openai";
+
+                const openai = new OpenAI();
+
+                async function main() {
+                  const run = await openai.beta.threads.runs.submitToolOutputs(
+                    "thread_123",
+                    "run_123",
+                    {
+                      tool_outputs: [
+                        {
+                          tool_call_id: "call_001",
+                          output: "70 degrees and sunny.",
+                        },
+                      ],
+                    }
+                  );
+
+                  console.log(run);
+                }
+
+                main();
+            response: >
+              {
+                "id": "run_123",
+                "object": "thread.run",
+                "created_at": 1699075592,
+                "assistant_id": "asst_123",
+                "thread_id": "thread_123",
+                "status": "queued",
+                "started_at": 1699075592,
+                "expires_at": 1699076192,
+                "cancelled_at": null,
+                "failed_at": null,
+                "completed_at": null,
+                "last_error": null,
+                "model": "gpt-4o",
+                "instructions": null,
+                "tools": [
+                  {
+                    "type": "function",
+                    "function": {
+                      "name": "get_current_weather",
+                      "description": "Get the current weather in a given location",
+                      "parameters": {
+                        "type": "object",
+                        "properties": {
+                          "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA"
+                          },
+                          "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"]
+                          }
+                        },
+                        "required": ["location"]
+                      }
+                    }
+                  }
+                ],
+                "metadata": {},
+                "usage": null,
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "max_prompt_tokens": 1000,
+                "max_completion_tokens": 1000,
+                "truncation_strategy": {
+                  "type": "auto",
+                  "last_messages": null
+                },
+                "response_format": "auto",
+                "tool_choice": "auto",
+                "parallel_tool_calls": true
+              }
+          - title: Streaming
+            request:
+              curl: >
+                curl
+                https://api.openai.com/v1/threads/thread_123/runs/run_123/submit_tool_outputs
+                \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "tool_outputs": [
+                      {
+                        "tool_call_id": "call_001",
+                        "output": "70 degrees and sunny."
+                      }
+                    ],
+                    "stream": true
+                  }'
+              python: |
+                from openai import OpenAI
+                client = OpenAI()
+
+                stream = client.beta.threads.runs.submit_tool_outputs(
+                  thread_id="thread_123",
+                  run_id="run_123",
+                  tool_outputs=[
+                    {
+                      "tool_call_id": "call_001",
+                      "output": "70 degrees and sunny."
+                    }
+                  ],
+                  stream=True
+                )
+
+                for event in stream:
+                  print(event)
+              node.js: >
+                import OpenAI from "openai";
+
+
+                const openai = new OpenAI();
+
+
+                async function main() {
+                  const stream = await openai.beta.threads.runs.submitToolOutputs(
+                    "thread_123",
+                    "run_123",
+                    {
+                      tool_outputs: [
+                        {
+                          tool_call_id: "call_001",
+                          output: "70 degrees and sunny.",
+                        },
+                      ],
+                    }
+                  );
+
+                  for await (const event of stream) {
+                    console.log(event);
+                  }
+                }
+
+
+                main();
+            response: >
+              event: thread.run.step.completed
+
+              data:
+              {"id":"step_001","object":"thread.run.step","created_at":1710352449,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"tool_calls","status":"completed","cancelled_at":null,"completed_at":1710352475,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"tool_calls","tool_calls":[{"id":"call_iWr0kQ2EaYMaxNdl0v3KYkx7","type":"function","function":{"name":"get_current_weather","arguments":"{\"location\":\"San
+              Francisco, CA\",\"unit\":\"fahrenheit\"}","output":"70 degrees and
+              sunny."}}]},"usage":{"prompt_tokens":291,"completion_tokens":24,"total_tokens":315}}
+
+
+              event: thread.run.queued
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"queued","started_at":1710352448,"expires_at":1710353047,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get
+              the current weather in a given
+              location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The
+              city and state, e.g. San Francisco,
+              CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.in_progress
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"in_progress","started_at":1710352475,"expires_at":1710353047,"cancelled_at":null,"failed_at":null,"completed_at":null,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get
+              the current weather in a given
+              location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The
+              city and state, e.g. San Francisco,
+              CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":null,"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: thread.run.step.created
+
+              data:
+              {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":null}
+
+
+              event: thread.run.step.in_progress
+
+              data:
+              {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"in_progress","cancelled_at":null,"completed_at":null,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":null}
+
+
+              event: thread.message.created
+
+              data:
+              {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+
+              event: thread.message.in_progress
+
+              data:
+              {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"in_progress","incomplete_details":null,"incomplete_at":null,"completed_at":null,"role":"assistant","content":[],"metadata":{}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"The","annotations":[]}}]}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"
+              current"}}]}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"
+              weather"}}]}}
+
+
+              ...
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"
+              sunny"}}]}}
+
+
+              event: thread.message.delta
+
+              data:
+              {"id":"msg_002","object":"thread.message.delta","delta":{"content":[{"index":0,"type":"text","text":{"value":"."}}]}}
+
+
+              event: thread.message.completed
+
+              data:
+              {"id":"msg_002","object":"thread.message","created_at":1710352476,"assistant_id":"asst_123","thread_id":"thread_123","run_id":"run_123","status":"completed","incomplete_details":null,"incomplete_at":null,"completed_at":1710352477,"role":"assistant","content":[{"type":"text","text":{"value":"The
+              current weather in San Francisco, CA is 70 degrees Fahrenheit and
+              sunny.","annotations":[]}}],"metadata":{}}
+
+
+              event: thread.run.step.completed
+
+              data:
+              {"id":"step_002","object":"thread.run.step","created_at":1710352476,"run_id":"run_123","assistant_id":"asst_123","thread_id":"thread_123","type":"message_creation","status":"completed","cancelled_at":null,"completed_at":1710352477,"expires_at":1710353047,"failed_at":null,"last_error":null,"step_details":{"type":"message_creation","message_creation":{"message_id":"msg_002"}},"usage":{"prompt_tokens":329,"completion_tokens":18,"total_tokens":347}}
+
+
+              event: thread.run.completed
+
+              data:
+              {"id":"run_123","object":"thread.run","created_at":1710352447,"assistant_id":"asst_123","thread_id":"thread_123","status":"completed","started_at":1710352475,"expires_at":null,"cancelled_at":null,"failed_at":null,"completed_at":1710352477,"required_action":null,"last_error":null,"model":"gpt-4o","instructions":null,"tools":[{"type":"function","function":{"name":"get_current_weather","description":"Get
+              the current weather in a given
+              location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The
+              city and state, e.g. San Francisco,
+              CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["location"]}}}],"metadata":{},"temperature":1.0,"top_p":1.0,"max_completion_tokens":null,"max_prompt_tokens":null,"truncation_strategy":{"type":"auto","last_messages":null},"incomplete_details":null,"usage":{"prompt_tokens":20,"completion_tokens":11,"total_tokens":31},"response_format":"auto","tool_choice":"auto","parallel_tool_calls":true}}
+
+
+              event: done
+
+              data: [DONE]
+  /uploads:
+    post:
+      operationId: createUpload
+      tags:
+        - Uploads
+      summary: >
+        Creates an intermediate [Upload](/docs/api-reference/uploads/object)
+        object that you can add [Parts](/docs/api-reference/uploads/part-object)
+        to. Currently, an Upload can accept at most 8 GB in total and expires
+        after an hour after you create it.
+
+
+        Once you complete the Upload, we will create a
+        [File](/docs/api-reference/files/object) object that contains all the
+        parts you uploaded. This File is usable in the rest of our platform as a
+        regular File object.
+
+
+        For certain `purpose`s, the correct `mime_type` must be specified.
+        Please refer to documentation for the supported MIME types for your use
+        case:
+
+        - [Assistants](/docs/assistants/tools/file-search#supported-files)
+
+
+        For guidance on the proper filename extensions for each purpose, please
+        follow the documentation on [creating a
+        File](/docs/api-reference/files/create).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateUploadRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Upload"
+      x-oaiMeta:
+        name: Create upload
+        group: uploads
+        returns: The [Upload](/docs/api-reference/uploads/object) object with status
+          `pending`.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/uploads \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -d '{
+                  "purpose": "fine-tune",
+                  "filename": "training_examples.jsonl",
+                  "bytes": 2147483648,
+                  "mime_type": "text/jsonl"
+                }'
+          response: |
+            {
+              "id": "upload_abc123",
+              "object": "upload",
+              "bytes": 2147483648,
+              "created_at": 1719184911,
+              "filename": "training_examples.jsonl",
+              "purpose": "fine-tune",
+              "status": "pending",
+              "expires_at": 1719127296
+            }
+  /uploads/{upload_id}/cancel:
+    post:
+      operationId: cancelUpload
+      tags:
+        - Uploads
+      summary: |
+        Cancels the Upload. No Parts may be added after an Upload is cancelled.
+      parameters:
+        - in: path
+          name: upload_id
+          required: true
+          schema:
+            type: string
+            example: upload_abc123
+          description: |
+            The ID of the Upload.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Upload"
+      x-oaiMeta:
+        name: Cancel upload
+        group: uploads
+        returns: The [Upload](/docs/api-reference/uploads/object) object with status
+          `cancelled`.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/uploads/upload_abc123/cancel
+          response: |
+            {
+              "id": "upload_abc123",
+              "object": "upload",
+              "bytes": 2147483648,
+              "created_at": 1719184911,
+              "filename": "training_examples.jsonl",
+              "purpose": "fine-tune",
+              "status": "cancelled",
+              "expires_at": 1719127296
+            }
+  /uploads/{upload_id}/complete:
+    post:
+      operationId: completeUpload
+      tags:
+        - Uploads
+      summary: >
+        Completes the [Upload](/docs/api-reference/uploads/object). 
+
+
+        Within the returned Upload object, there is a nested
+        [File](/docs/api-reference/files/object) object that is ready to use in
+        the rest of the platform.
+
+
+        You can specify the order of the Parts by passing in an ordered list of
+        the Part IDs.
+
+
+        The number of bytes uploaded upon completion must match the number of
+        bytes initially specified when creating the Upload object. No Parts may
+        be added after an Upload is completed.
+      parameters:
+        - in: path
+          name: upload_id
+          required: true
+          schema:
+            type: string
+            example: upload_abc123
+          description: |
+            The ID of the Upload.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompleteUploadRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Upload"
+      x-oaiMeta:
+        name: Complete upload
+        group: uploads
+        returns: The [Upload](/docs/api-reference/uploads/object) object with status
+          `completed` with an additional `file` property containing the created
+          usable File object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/uploads/upload_abc123/complete
+                -d '{
+                  "part_ids": ["part_def456", "part_ghi789"]
+                }'
+          response: |
+            {
+              "id": "upload_abc123",
+              "object": "upload",
+              "bytes": 2147483648,
+              "created_at": 1719184911,
+              "filename": "training_examples.jsonl",
+              "purpose": "fine-tune",
+              "status": "completed",
+              "expires_at": 1719127296,
+              "file": {
+                "id": "file-xyz321",
+                "object": "file",
+                "bytes": 2147483648,
+                "created_at": 1719186911,
+                "filename": "training_examples.jsonl",
+                "purpose": "fine-tune",
+              }
+            }
+  /uploads/{upload_id}/parts:
+    post:
+      operationId: addUploadPart
+      tags:
+        - Uploads
+      summary: >
+        Adds a [Part](/docs/api-reference/uploads/part-object) to an
+        [Upload](/docs/api-reference/uploads/object) object. A Part represents a
+        chunk of bytes from the file you are trying to upload. 
+
+
+        Each Part can be at most 64 MB, and you can add Parts until you hit the
+        Upload maximum of 8 GB.
+
+
+        It is possible to add multiple Parts in parallel. You can decide the
+        intended order of the Parts when you [complete the
+        Upload](/docs/api-reference/uploads/complete).
+      parameters:
+        - in: path
+          name: upload_id
+          required: true
+          schema:
+            type: string
+            example: upload_abc123
+          description: |
+            The ID of the Upload.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/AddUploadPartRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadPart"
+      x-oaiMeta:
+        name: Add upload part
+        group: uploads
+        returns: The upload [Part](/docs/api-reference/uploads/part-object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/uploads/upload_abc123/parts
+                -F data="aHR0cHM6Ly9hcGkub3BlbmFpLmNvbS92MS91cGxvYWRz..."
+          response: |
+            {
+              "id": "part_def456",
+              "object": "upload.part",
+              "created_at": 1719185911,
+              "upload_id": "upload_abc123"
+            }
+  /vector_stores:
+    get:
+      operationId: listVectorStores
+      tags:
+        - Vector stores
+      summary: Returns a list of vector stores.
+      parameters:
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: order
+          in: query
+          description: >
+            Sort order by the `created_at` timestamp of the objects. `asc` for
+            ascending order and `desc` for descending order.
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: >
+            A cursor for use in pagination. `before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, starting with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the
+            previous page of the list.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListVectorStoresResponse"
+      x-oaiMeta:
+        name: List vector stores
+        group: vector_stores
+        beta: true
+        returns: A list of [vector store](/docs/api-reference/vector-stores/object)
+          objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_stores = client.beta.vector_stores.list()
+              print(vector_stores)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStores = await openai.beta.vectorStores.list();
+                console.log(vectorStores);
+              }
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "vs_abc123",
+                  "object": "vector_store",
+                  "created_at": 1699061776,
+                  "name": "Support FAQ",
+                  "bytes": 139920,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
+                },
+                {
+                  "id": "vs_abc456",
+                  "object": "vector_store",
+                  "created_at": 1699061776,
+                  "name": "Support FAQ v2",
+                  "bytes": 139920,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
+                }
+              ],
+              "first_id": "vs_abc123",
+              "last_id": "vs_abc456",
+              "has_more": false
+            }
+    post:
+      operationId: createVectorStore
+      tags:
+        - Vector stores
+      summary: Create a vector store.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateVectorStoreRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreObject"
+      x-oaiMeta:
+        name: Create vector store
+        group: vector_stores
+        beta: true
+        returns: A [vector store](/docs/api-reference/vector-stores/object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+                -d '{
+                  "name": "Support FAQ"
+                }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store = client.beta.vector_stores.create(
+                name="Support FAQ"
+              )
+              print(vector_store)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStore = await openai.beta.vectorStores.create({
+                  name: "Support FAQ"
+                });
+                console.log(vectorStore);
+              }
+
+              main();
+          response: |
+            {
+              "id": "vs_abc123",
+              "object": "vector_store",
+              "created_at": 1699061776,
+              "name": "Support FAQ",
+              "bytes": 139920,
+              "file_counts": {
+                "in_progress": 0,
+                "completed": 3,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 3
+              }
+            }
+  /vector_stores/{vector_store_id}:
+    get:
+      operationId: getVectorStore
+      tags:
+        - Vector stores
+      summary: Retrieves a vector store.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store to retrieve.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreObject"
+      x-oaiMeta:
+        name: Retrieve vector store
+        group: vector_stores
+        beta: true
+        returns: The [vector store](/docs/api-reference/vector-stores/object) object
+          matching the specified ID.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store = client.beta.vector_stores.retrieve(
+                vector_store_id="vs_abc123"
+              )
+              print(vector_store)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStore = await openai.beta.vectorStores.retrieve(
+                  "vs_abc123"
+                );
+                console.log(vectorStore);
+              }
+
+              main();
+          response: |
+            {
+              "id": "vs_abc123",
+              "object": "vector_store",
+              "created_at": 1699061776
+            }
+    post:
+      operationId: modifyVectorStore
+      tags:
+        - Vector stores
+      summary: Modifies a vector store.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store to modify.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateVectorStoreRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreObject"
+      x-oaiMeta:
+        name: Modify vector store
+        group: vector_stores
+        beta: true
+        returns: The modified [vector store](/docs/api-reference/vector-stores/object)
+          object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+                -d '{
+                  "name": "Support FAQ"
+                }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store = client.beta.vector_stores.update(
+                vector_store_id="vs_abc123",
+                name="Support FAQ"
+              )
+              print(vector_store)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const vectorStore = await openai.beta.vectorStores.update(
+                  "vs_abc123",
+                  {
+                    name: "Support FAQ"
+                  }
+                );
+                console.log(vectorStore);
+              }
+
+              main();
+          response: |
+            {
+              "id": "vs_abc123",
+              "object": "vector_store",
+              "created_at": 1699061776,
+              "name": "Support FAQ",
+              "bytes": 139920,
+              "file_counts": {
+                "in_progress": 0,
+                "completed": 3,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 3
+              }
+            }
+    delete:
+      operationId: deleteVectorStore
+      tags:
+        - Vector stores
+      summary: Delete a vector store.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store to delete.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteVectorStoreResponse"
+      x-oaiMeta:
+        name: Delete vector store
+        group: vector_stores
+        beta: true
+        returns: Deletion status
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123 \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -X DELETE
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              deleted_vector_store = client.beta.vector_stores.delete(
+                vector_store_id="vs_abc123"
+              )
+              print(deleted_vector_store)
+            node.js: |
+              import OpenAI from "openai";
+              const openai = new OpenAI();
+
+              async function main() {
+                const deletedVectorStore = await openai.beta.vectorStores.del(
+                  "vs_abc123"
+                );
+                console.log(deletedVectorStore);
+              }
+
+              main();
+          response: |
+            {
+              id: "vs_abc123",
+              object: "vector_store.deleted",
+              deleted: true
+            }
+  /vector_stores/{vector_store_id}/file_batches:
+    post:
+      operationId: createVectorStoreFileBatch
+      tags:
+        - Vector stores
+      summary: Create a vector store file batch.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+            example: vs_abc123
+          description: |
+            The ID of the vector store for which to create a File Batch.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateVectorStoreFileBatchRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+      x-oaiMeta:
+        name: Create vector store file batch
+        group: vector_stores
+        beta: true
+        returns: A [vector store file
+          batch](/docs/api-reference/vector-stores-file-batches/batch-object)
+          object.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/vector_stores/vs_abc123/file_batches \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "file_ids": ["file-abc123", "file-abc456"]
+                  }'
+            python: >
+              from openai import OpenAI
+
+              client = OpenAI()
+
+
+              vector_store_file_batch =
+              client.beta.vector_stores.file_batches.create(
+                vector_store_id="vs_abc123",
+                file_ids=["file-abc123", "file-abc456"]
+              )
+
+              print(vector_store_file_batch)
+            node.js: >
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const myVectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.create(
+                  "vs_abc123",
+                  {
+                    file_ids: ["file-abc123", "file-abc456"]
+                  }
+                );
+                console.log(myVectorStoreFileBatch);
+              }
+
+
+              main();
+          response: |
+            {
+              "id": "vsfb_abc123",
+              "object": "vector_store.file_batch",
+              "created_at": 1699061776,
+              "vector_store_id": "vs_abc123",
+              "status": "in_progress",
+              "file_counts": {
+                "in_progress": 1,
+                "completed": 1,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 0,
+              }
+            }
+  /vector_stores/{vector_store_id}/file_batches/{batch_id}:
+    get:
+      operationId: getVectorStoreFileBatch
+      tags:
+        - Vector stores
+      summary: Retrieves a vector store file batch.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+            example: vs_abc123
+          description: The ID of the vector store that the file batch belongs to.
+        - in: path
+          name: batch_id
+          required: true
+          schema:
+            type: string
+            example: vsfb_abc123
+          description: The ID of the file batch being retrieved.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+      x-oaiMeta:
+        name: Retrieve vector store file batch
+        group: vector_stores
+        beta: true
+        returns: The [vector store file
+          batch](/docs/api-reference/vector-stores-file-batches/batch-object)
+          object.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: >
+              from openai import OpenAI
+
+              client = OpenAI()
+
+
+              vector_store_file_batch =
+              client.beta.vector_stores.file_batches.retrieve(
+                vector_store_id="vs_abc123",
+                batch_id="vsfb_abc123"
+              )
+
+              print(vector_store_file_batch)
+            node.js: >
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const vectorStoreFileBatch = await openai.beta.vectorStores.fileBatches.retrieve(
+                  "vs_abc123",
+                  "vsfb_abc123"
+                );
+                console.log(vectorStoreFileBatch);
+              }
+
+
+              main();
+          response: |
+            {
+              "id": "vsfb_abc123",
+              "object": "vector_store.file_batch",
+              "created_at": 1699061776,
+              "vector_store_id": "vs_abc123",
+              "status": "in_progress",
+              "file_counts": {
+                "in_progress": 1,
+                "completed": 1,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 0,
+              }
+            }
+  /vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel:
+    post:
+      operationId: cancelVectorStoreFileBatch
+      tags:
+        - Vector stores
+      summary: Cancel a vector store file batch. This attempts to cancel the
+        processing of files in this batch as soon as possible.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store that the file batch belongs to.
+        - in: path
+          name: batch_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the file batch to cancel.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreFileBatchObject"
+      x-oaiMeta:
+        name: Cancel vector store file batch
+        group: vector_stores
+        beta: true
+        returns: The modified vector store file batch object.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/cancel
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -X POST
+            python: >
+              from openai import OpenAI
+
+              client = OpenAI()
+
+
+              deleted_vector_store_file_batch =
+              client.beta.vector_stores.file_batches.cancel(
+                  vector_store_id="vs_abc123",
+                  file_batch_id="vsfb_abc123"
+              )
+
+              print(deleted_vector_store_file_batch)
+            node.js: >
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const deletedVectorStoreFileBatch = await openai.vector_stores.fileBatches.cancel(
+                  "vs_abc123",
+                  "vsfb_abc123"
+                );
+                console.log(deletedVectorStoreFileBatch);
+              }
+
+
+              main();
+          response: |
+            {
+              "id": "vsfb_abc123",
+              "object": "vector_store.file_batch",
+              "created_at": 1699061776,
+              "vector_store_id": "vs_abc123",
+              "status": "in_progress",
+              "file_counts": {
+                "in_progress": 12,
+                "completed": 3,
+                "failed": 0,
+                "cancelled": 0,
+                "total": 15,
+              }
+            }
+  /vector_stores/{vector_store_id}/file_batches/{batch_id}/files:
+    get:
+      operationId: listFilesInVectorStoreBatch
+      tags:
+        - Vector stores
+      summary: Returns a list of vector store files in a batch.
+      parameters:
+        - name: vector_store_id
+          in: path
+          description: The ID of the vector store that the files belong to.
+          required: true
+          schema:
+            type: string
+        - name: batch_id
+          in: path
+          description: The ID of the file batch that the files belong to.
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: order
+          in: query
+          description: >
+            Sort order by the `created_at` timestamp of the objects. `asc` for
+            ascending order and `desc` for descending order.
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: >
+            A cursor for use in pagination. `before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, starting with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the
+            previous page of the list.
+          schema:
+            type: string
+        - name: filter
+          in: query
+          description: Filter by file status. One of `in_progress`, `completed`, `failed`,
+            `cancelled`.
+          schema:
+            type: string
+            enum:
+              - in_progress
+              - completed
+              - failed
+              - cancelled
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+      x-oaiMeta:
+        name: List vector store files in a batch
+        group: vector_stores
+        beta: true
+        returns: A list of [vector store
+          file](/docs/api-reference/vector-stores-files/file-object) objects.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/vector_stores/vs_abc123/files_batches/vsfb_abc123/files
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: >
+              from openai import OpenAI
+
+              client = OpenAI()
+
+
+              vector_store_files =
+              client.beta.vector_stores.file_batches.list_files(
+                vector_store_id="vs_abc123",
+                batch_id="vsfb_abc123"
+              )
+
+              print(vector_store_files)
+            node.js: >
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const vectorStoreFiles = await openai.beta.vectorStores.fileBatches.listFiles(
+                  "vs_abc123",
+                  "vsfb_abc123"
+                );
+                console.log(vectorStoreFiles);
+              }
+
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "file-abc123",
+                  "object": "vector_store.file",
+                  "created_at": 1699061776,
+                  "vector_store_id": "vs_abc123"
+                },
+                {
+                  "id": "file-abc456",
+                  "object": "vector_store.file",
+                  "created_at": 1699061776,
+                  "vector_store_id": "vs_abc123"
+                }
+              ],
+              "first_id": "file-abc123",
+              "last_id": "file-abc456",
+              "has_more": false
+            }
+  /vector_stores/{vector_store_id}/files:
+    get:
+      operationId: listVectorStoreFiles
+      tags:
+        - Vector stores
+      summary: Returns a list of vector store files.
+      parameters:
+        - name: vector_store_id
+          in: path
+          description: The ID of the vector store that the files belong to.
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: >
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 20.
+          required: false
+          schema:
+            type: integer
+            default: 20
+        - name: order
+          in: query
+          description: >
+            Sort order by the `created_at` timestamp of the objects. `asc` for
+            ascending order and `desc` for descending order.
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+        - name: after
+          in: query
+          description: >
+            A cursor for use in pagination. `after` is an object ID that defines
+            your place in the list. For instance, if you make a list request and
+            receive 100 objects, ending with obj_foo, your subsequent call can
+            include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+        - name: before
+          in: query
+          description: >
+            A cursor for use in pagination. `before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, starting with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the
+            previous page of the list.
+          schema:
+            type: string
+        - name: filter
+          in: query
+          description: Filter by file status. One of `in_progress`, `completed`, `failed`,
+            `cancelled`.
+          schema:
+            type: string
+            enum:
+              - in_progress
+              - completed
+              - failed
+              - cancelled
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+      x-oaiMeta:
+        name: List vector store files
+        group: vector_stores
+        beta: true
+        returns: A list of [vector store
+          file](/docs/api-reference/vector-stores-files/file-object) objects.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/files \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store_files = client.beta.vector_stores.files.list(
+                vector_store_id="vs_abc123"
+              )
+              print(vector_store_files)
+            node.js: >
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const vectorStoreFiles = await openai.beta.vectorStores.files.list(
+                  "vs_abc123"
+                );
+                console.log(vectorStoreFiles);
+              }
+
+
+              main();
+          response: |
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "file-abc123",
+                  "object": "vector_store.file",
+                  "created_at": 1699061776,
+                  "vector_store_id": "vs_abc123"
+                },
+                {
+                  "id": "file-abc456",
+                  "object": "vector_store.file",
+                  "created_at": 1699061776,
+                  "vector_store_id": "vs_abc123"
+                }
+              ],
+              "first_id": "file-abc123",
+              "last_id": "file-abc456",
+              "has_more": false
+            }
+    post:
+      operationId: createVectorStoreFile
+      tags:
+        - Vector stores
+      summary: Create a vector store file by attaching a
+        [File](/docs/api-reference/files) to a [vector
+        store](/docs/api-reference/vector-stores/object).
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+            example: vs_abc123
+          description: |
+            The ID of the vector store for which to create a File.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateVectorStoreFileRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreFileObject"
+      x-oaiMeta:
+        name: Create vector store file
+        group: vector_stores
+        beta: true
+        returns: A [vector store
+          file](/docs/api-reference/vector-stores-files/file-object) object.
+        examples:
+          request:
+            curl: |
+              curl https://api.openai.com/v1/vector_stores/vs_abc123/files \
+                  -H "Authorization: Bearer $OPENAI_API_KEY" \
+                  -H "Content-Type: application/json" \
+                  -H "OpenAI-Beta: assistants=v2" \
+                  -d '{
+                    "file_id": "file-abc123"
+                  }'
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store_file = client.beta.vector_stores.files.create(
+                vector_store_id="vs_abc123",
+                file_id="file-abc123"
+              )
+              print(vector_store_file)
+            node.js: >
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const myVectorStoreFile = await openai.beta.vectorStores.files.create(
+                  "vs_abc123",
+                  {
+                    file_id: "file-abc123"
+                  }
+                );
+                console.log(myVectorStoreFile);
+              }
+
+
+              main();
+          response: |
+            {
+              "id": "file-abc123",
+              "object": "vector_store.file",
+              "created_at": 1699061776,
+              "usage_bytes": 1234,
+              "vector_store_id": "vs_abcd",
+              "status": "completed",
+              "last_error": null
+            }
+  /vector_stores/{vector_store_id}/files/{file_id}:
+    get:
+      operationId: getVectorStoreFile
+      tags:
+        - Vector stores
+      summary: Retrieves a vector store file.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+            example: vs_abc123
+          description: The ID of the vector store that the file belongs to.
+        - in: path
+          name: file_id
+          required: true
+          schema:
+            type: string
+            example: file-abc123
+          description: The ID of the file being retrieved.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VectorStoreFileObject"
+      x-oaiMeta:
+        name: Retrieve vector store file
+        group: vector_stores
+        beta: true
+        returns: The [vector store
+          file](/docs/api-reference/vector-stores-files/file-object) object.
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2"
+            python: |
+              from openai import OpenAI
+              client = OpenAI()
+
+              vector_store_file = client.beta.vector_stores.files.retrieve(
+                vector_store_id="vs_abc123",
+                file_id="file-abc123"
+              )
+              print(vector_store_file)
+            node.js: >
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const vectorStoreFile = await openai.beta.vectorStores.files.retrieve(
+                  "vs_abc123",
+                  "file-abc123"
+                );
+                console.log(vectorStoreFile);
+              }
+
+
+              main();
+          response: |
+            {
+              "id": "file-abc123",
+              "object": "vector_store.file",
+              "created_at": 1699061776,
+              "vector_store_id": "vs_abcd",
+              "status": "completed",
+              "last_error": null
+            }
+    delete:
+      operationId: deleteVectorStoreFile
+      tags:
+        - Vector stores
+      summary: Delete a vector store file. This will remove the file from the vector
+        store but the file itself will not be deleted. To delete the file, use
+        the [delete file](/docs/api-reference/files/delete) endpoint.
+      parameters:
+        - in: path
+          name: vector_store_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the vector store that the file belongs to.
+        - in: path
+          name: file_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the file to delete.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteVectorStoreFileResponse"
+      x-oaiMeta:
+        name: Delete vector store file
+        group: vector_stores
+        beta: true
+        returns: Deletion status
+        examples:
+          request:
+            curl: >
+              curl
+              https://api.openai.com/v1/vector_stores/vs_abc123/files/file-abc123
+              \
+                -H "Authorization: Bearer $OPENAI_API_KEY" \
+                -H "Content-Type: application/json" \
+                -H "OpenAI-Beta: assistants=v2" \
+                -X DELETE
+            python: >
+              from openai import OpenAI
+
+              client = OpenAI()
+
+
+              deleted_vector_store_file =
+              client.beta.vector_stores.files.delete(
+                  vector_store_id="vs_abc123",
+                  file_id="file-abc123"
+              )
+
+              print(deleted_vector_store_file)
+            node.js: >
+              import OpenAI from "openai";
+
+              const openai = new OpenAI();
+
+
+              async function main() {
+                const deletedVectorStoreFile = await openai.beta.vectorStores.files.del(
+                  "vs_abc123",
+                  "file-abc123"
+                );
+                console.log(deletedVectorStoreFile);
+              }
+
+
+              main();
+          response: |
+            {
+              id: "file-abc123",
+              object: "vector_store.file.deleted",
+              deleted: true
+            }
+components:
+  schemas:
+    AddUploadPartRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        data:
+          description: |
+            The chunk of bytes for this Part.
+          type: string
+          format: binary
+      required:
+        - data
+    AdminApiKey:
+      type: object
+      properties:
+        object:
+          type: string
+          example: organization.admin_api_key
+        id:
+          type: string
+          example: key_abc
+        name:
+          type: string
+          example: Administration Key
+        redacted_value:
+          type: string
+          example: sk-admin...def
+        value:
+          type: string
+          example: sk-admin-1234abcd
+        created_at:
+          type: integer
+          format: int64
+          example: 1711471533
+        owner:
+          type: object
+          properties:
+            type:
+              type: string
+              example: service_account
+            id:
+              type: string
+              example: sa_456
+            name:
+              type: string
+              example: My Service Account
+            created_at:
+              type: integer
+              format: int64
+              example: 1711471533
+            role:
+              type: string
+              example: member
+    ApiKeyList:
+      type: object
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminApiKey"
+        has_more:
+          type: boolean
+          example: false
+        first_id:
+          type: string
+          example: key_abc
+        last_id:
+          type: string
+          example: key_xyz
+    AssistantObject:
+      type: object
+      title: Assistant
+      description: Represents an `assistant` that can call the model and use tools.
+      properties:
+        id:
+          description: The identifier, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `assistant`.
+          type: string
+          enum:
+            - assistant
+          x-stainless-const: true
+        created_at:
+          description: The Unix timestamp (in seconds) for when the assistant was created.
+          type: integer
+        name:
+          description: |
+            The name of the assistant. The maximum length is 256 characters.
+          type: string
+          maxLength: 256
+          nullable: true
+        description:
+          description: >
+            The description of the assistant. The maximum length is 512
+            characters.
+          type: string
+          maxLength: 512
+          nullable: true
+        model:
+          description: >
+            ID of the model to use. You can use the [List
+            models](/docs/api-reference/models/list) API to see all of your
+            available models, or see our [Model overview](/docs/models) for
+            descriptions of them.
+          type: string
+        instructions:
+          description: >
+            The system instructions that the assistant uses. The maximum length
+            is 256,000 characters.
+          type: string
+          maxLength: 256000
+          nullable: true
+        tools:
+          description: >
+            A list of tool enabled on the assistant. There can be a maximum of
+            128 tools per assistant. Tools can be of types `code_interpreter`,
+            `file_search`, or `function`.
+          default: []
+          type: array
+          maxItems: 128
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/AssistantToolsCode"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
+              - $ref: "#/components/schemas/AssistantToolsFunction"
+            x-oaiExpandable: true
+        tool_resources:
+          type: object
+          description: >
+            A set of resources that are used by the assistant's tools. The
+            resources are specific to the type of tool. For example, the
+            `code_interpreter` tool requires a list of file IDs, while the
+            `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: >
+                    A list of [file](/docs/api-reference/files) IDs made
+                    available to the `code_interpreter`` tool. There can be a
+                    maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: >
+                    The ID of the [vector
+                    store](/docs/api-reference/vector-stores/object) attached to
+                    this assistant. There can be a maximum of 1 vector store
+                    attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          description: >
+            What sampling temperature to use, between 0 and 2. Higher values
+            like 0.8 will make the output more random, while lower values like
+            0.2 will make it more focused and deterministic.
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            An alternative to sampling with temperature, called nucleus
+            sampling, where the model considers the results of the tokens with
+            top_p probability mass. So 0.1 means only the tokens comprising the
+            top 10% probability mass are considered.
+
+
+            We generally recommend altering this or temperature but not both.
+        response_format:
+          allOf:
+            - $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+            - nullable: true
+      required:
+        - id
+        - object
+        - created_at
+        - name
+        - description
+        - model
+        - instructions
+        - tools
+        - metadata
+      x-oaiMeta:
+        name: The assistant object
+        beta: true
+        example: >
+          {
+            "id": "asst_abc123",
+            "object": "assistant",
+            "created_at": 1698984975,
+            "name": "Math Tutor",
+            "description": null,
+            "model": "gpt-4o",
+            "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
+            "tools": [
+              {
+                "type": "code_interpreter"
+              }
+            ],
+            "metadata": {},
+            "top_p": 1.0,
+            "temperature": 1.0,
+            "response_format": "auto"
+          }
+    AssistantStreamEvent:
+      description: >
+        Represents an event emitted when streaming a Run.
+
+
+        Each event in a server-sent events stream has an `event` and `data`
+        property:
+
+
+        ```
+
+        event: thread.created
+
+        data: {"id": "thread_123", "object": "thread", ...}
+
+        ```
+
+
+        We emit events whenever a new object is created, transitions to a new
+        state, or is being
+
+        streamed in parts (deltas). For example, we emit `thread.run.created`
+        when a new run
+
+        is created, `thread.run.completed` when a run completes, and so on. When
+        an Assistant chooses
+
+        to create a message during a run, we emit a `thread.message.created
+        event`, a
+
+        `thread.message.in_progress` event, many `thread.message.delta` events,
+        and finally a
+
+        `thread.message.completed` event.
+
+
+        We may add additional events over time, so we recommend handling unknown
+        events gracefully
+
+        in your code. See the [Assistants API
+        quickstart](/docs/assistants/overview) to learn how to
+
+        integrate the Assistants API with streaming.
+      oneOf:
+        - $ref: "#/components/schemas/ThreadStreamEvent"
+        - $ref: "#/components/schemas/RunStreamEvent"
+        - $ref: "#/components/schemas/RunStepStreamEvent"
+        - $ref: "#/components/schemas/MessageStreamEvent"
+        - $ref: "#/components/schemas/ErrorEvent"
+        - $ref: "#/components/schemas/DoneEvent"
+      x-oaiMeta:
+        name: Assistant stream events
+        beta: true
+    AssistantToolsCode:
+      type: object
+      title: Code interpreter tool
+      properties:
+        type:
+          type: string
+          description: "The type of tool being defined: `code_interpreter`"
+          enum:
+            - code_interpreter
+          x-stainless-const: true
+      required:
+        - type
+    AssistantToolsFileSearch:
+      type: object
+      title: FileSearch tool
+      properties:
+        type:
+          type: string
+          description: "The type of tool being defined: `file_search`"
+          enum:
+            - file_search
+          x-stainless-const: true
+        file_search:
+          type: object
+          description: Overrides for the file search tool.
+          properties:
+            max_num_results:
+              type: integer
+              minimum: 1
+              maximum: 50
+              description: >
+                The maximum number of results the file search tool should
+                output. The default is 20 for `gpt-4*` models and 5 for
+                `gpt-3.5-turbo`. This number should be between 1 and 50
+                inclusive.
+
+
+                Note that the file search tool may output fewer than
+                `max_num_results` results. See the [file search tool
+                documentation](/docs/assistants/tools/file-search#customizing-file-search-settings)
+                for more information.
+            ranking_options:
+              $ref: "#/components/schemas/FileSearchRankingOptions"
+      required:
+        - type
+    AssistantToolsFileSearchTypeOnly:
+      type: object
+      title: FileSearch tool
+      properties:
+        type:
+          type: string
+          description: "The type of tool being defined: `file_search`"
+          enum:
+            - file_search
+          x-stainless-const: true
+      required:
+        - type
+    AssistantToolsFunction:
+      type: object
+      title: Function tool
+      properties:
+        type:
+          type: string
+          description: "The type of tool being defined: `function`"
+          enum:
+            - function
+          x-stainless-const: true
+        function:
+          $ref: "#/components/schemas/FunctionObject"
+      required:
+        - type
+        - function
+    AssistantsApiResponseFormatOption:
+      description: >
+        Specifies the format that the model must output. Compatible with
+        [GPT-4o](/docs/models#gpt-4o), [GPT-4
+        Turbo](/docs/models#gpt-4-turbo-and-gpt-4), and all GPT-3.5 Turbo models
+        since `gpt-3.5-turbo-1106`.
+
+
+        Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
+        Structured Outputs which ensures the model will match your supplied JSON
+        schema. Learn more in the [Structured Outputs
+        guide](/docs/guides/structured-outputs).
+
+
+        Setting to `{ "type": "json_object" }` enables JSON mode, which ensures
+        the message the model generates is valid JSON.
+
+
+        **Important:** when using JSON mode, you **must** also instruct the
+        model to produce JSON yourself via a system or user message. Without
+        this, the model may generate an unending stream of whitespace until the
+        generation reaches the token limit, resulting in a long-running and
+        seemingly "stuck" request. Also note that the message content may be
+        partially cut off if `finish_reason="length"`, which indicates the
+        generation exceeded `max_tokens` or the conversation exceeded the max
+        context length.
+      oneOf:
+        - type: string
+          description: |
+            `auto` is the default value
+          enum:
+            - auto
+          x-stainless-const: true
+        - $ref: "#/components/schemas/ResponseFormatText"
+        - $ref: "#/components/schemas/ResponseFormatJsonObject"
+        - $ref: "#/components/schemas/ResponseFormatJsonSchema"
+      x-oaiExpandable: true
+    AssistantsApiToolChoiceOption:
+      description: >
+        Controls which (if any) tool is called by the model.
+
+        `none` means the model will not call any tools and instead generates a
+        message.
+
+        `auto` is the default value and means the model can pick between
+        generating a message or calling one or more tools.
+
+        `required` means the model must call one or more tools before responding
+        to the user.
+
+        Specifying a particular tool like `{"type": "file_search"}` or `{"type":
+        "function", "function": {"name": "my_function"}}` forces the model to
+        call that tool.
+      oneOf:
+        - type: string
+          description: >
+            `none` means the model will not call any tools and instead generates
+            a message. `auto` means the model can pick between generating a
+            message or calling one or more tools. `required` means the model
+            must call one or more tools before responding to the user.
+          enum:
+            - none
+            - auto
+            - required
+        - $ref: "#/components/schemas/AssistantsNamedToolChoice"
+      x-oaiExpandable: true
+    AssistantsNamedToolChoice:
+      type: object
+      description: Specifies a tool the model should use. Use to force the model to
+        call a specific tool.
+      properties:
+        type:
+          type: string
+          enum:
+            - function
+            - code_interpreter
+            - file_search
+          description: The type of the tool. If type is `function`, the function name must
+            be set
+        function:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the function to call.
+          required:
+            - name
+      required:
+        - type
+    AudioResponseFormat:
+      description: >
+        The format of the output, in one of these options: `json`, `text`,
+        `srt`, `verbose_json`, or `vtt`.
+      type: string
+      enum:
+        - json
+        - text
+        - srt
+        - verbose_json
+        - vtt
+      default: json
+    AuditLog:
+      type: object
+      description: A log of a user action or configuration change within this organization.
+      properties:
+        id:
+          type: string
+          description: The ID of this log.
+        type:
+          $ref: "#/components/schemas/AuditLogEventType"
+        effective_at:
+          type: integer
+          description: The Unix timestamp (in seconds) of the event.
+        project:
+          type: object
+          description: The project that the action was scoped to. Absent for actions not
+            scoped to projects.
+          properties:
+            id:
+              type: string
+              description: The project ID.
+            name:
+              type: string
+              description: The project title.
+        actor:
+          $ref: "#/components/schemas/AuditLogActor"
+        api_key.created:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The tracking ID of the API key.
+            data:
+              type: object
+              description: The payload used to create the API key.
+              properties:
+                scopes:
+                  type: array
+                  items:
+                    type: string
+                  description: A list of scopes allowed for the API key, e.g.
+                    `["api.model.request"]`
+        api_key.updated:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The tracking ID of the API key.
+            changes_requested:
+              type: object
+              description: The payload used to update the API key.
+              properties:
+                scopes:
+                  type: array
+                  items:
+                    type: string
+                  description: A list of scopes allowed for the API key, e.g.
+                    `["api.model.request"]`
+        api_key.deleted:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The tracking ID of the API key.
+        invite.sent:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The ID of the invite.
+            data:
+              type: object
+              description: The payload used to create the invite.
+              properties:
+                email:
+                  type: string
+                  description: The email invited to the organization.
+                role:
+                  type: string
+                  description: The role the email was invited to be. Is either `owner` or
+                    `member`.
+        invite.accepted:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The ID of the invite.
+        invite.deleted:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The ID of the invite.
+        login.failed:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            error_code:
+              type: string
+              description: The error code of the failure.
+            error_message:
+              type: string
+              description: The error message of the failure.
+        logout.failed:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            error_code:
+              type: string
+              description: The error code of the failure.
+            error_message:
+              type: string
+              description: The error message of the failure.
+        organization.updated:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The organization ID.
+            changes_requested:
+              type: object
+              description: The payload used to update the organization settings.
+              properties:
+                title:
+                  type: string
+                  description: The organization title.
+                description:
+                  type: string
+                  description: The organization description.
+                name:
+                  type: string
+                  description: The organization name.
+                settings:
+                  type: object
+                  properties:
+                    threads_ui_visibility:
+                      type: string
+                      description: Visibility of the threads page which shows messages created with
+                        the Assistants API and Playground. One of `ANY_ROLE`,
+                        `OWNERS`, or `NONE`.
+                    usage_dashboard_visibility:
+                      type: string
+                      description: Visibility of the usage dashboard which shows activity and costs
+                        for your organization. One of `ANY_ROLE` or `OWNERS`.
+        project.created:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The project ID.
+            data:
+              type: object
+              description: The payload used to create the project.
+              properties:
+                name:
+                  type: string
+                  description: The project name.
+                title:
+                  type: string
+                  description: The title of the project as seen on the dashboard.
+        project.updated:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The project ID.
+            changes_requested:
+              type: object
+              description: The payload used to update the project.
+              properties:
+                title:
+                  type: string
+                  description: The title of the project as seen on the dashboard.
+        project.archived:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The project ID.
+        rate_limit.updated:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The rate limit ID
+            changes_requested:
+              type: object
+              description: The payload used to update the rate limits.
+              properties:
+                max_requests_per_1_minute:
+                  type: integer
+                  description: The maximum requests per minute.
+                max_tokens_per_1_minute:
+                  type: integer
+                  description: The maximum tokens per minute.
+                max_images_per_1_minute:
+                  type: integer
+                  description: The maximum images per minute. Only relevant for certain models.
+                max_audio_megabytes_per_1_minute:
+                  type: integer
+                  description: The maximum audio megabytes per minute. Only relevant for certain
+                    models.
+                max_requests_per_1_day:
+                  type: integer
+                  description: The maximum requests per day. Only relevant for certain models.
+                batch_1_day_max_input_tokens:
+                  type: integer
+                  description: The maximum batch input tokens per day. Only relevant for certain
+                    models.
+        rate_limit.deleted:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The rate limit ID
+        service_account.created:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The service account ID.
+            data:
+              type: object
+              description: The payload used to create the service account.
+              properties:
+                role:
+                  type: string
+                  description: The role of the service account. Is either `owner` or `member`.
+        service_account.updated:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The service account ID.
+            changes_requested:
+              type: object
+              description: The payload used to updated the service account.
+              properties:
+                role:
+                  type: string
+                  description: The role of the service account. Is either `owner` or `member`.
+        service_account.deleted:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The service account ID.
+        user.added:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The user ID.
+            data:
+              type: object
+              description: The payload used to add the user to the project.
+              properties:
+                role:
+                  type: string
+                  description: The role of the user. Is either `owner` or `member`.
+        user.updated:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The project ID.
+            changes_requested:
+              type: object
+              description: The payload used to update the user.
+              properties:
+                role:
+                  type: string
+                  description: The role of the user. Is either `owner` or `member`.
+        user.deleted:
+          type: object
+          description: The details for events with this `type`.
+          properties:
+            id:
+              type: string
+              description: The user ID.
+      required:
+        - id
+        - type
+        - effective_at
+        - actor
+      x-oaiMeta:
+        name: The audit log object
+        example: >
+          {
+              "id": "req_xxx_20240101",
+              "type": "api_key.created",
+              "effective_at": 1720804090,
+              "actor": {
+                  "type": "session",
+                  "session": {
+                      "user": {
+                          "id": "user-xxx",
+                          "email": "user@example.com"
+                      },
+                      "ip_address": "127.0.0.1",
+                      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+                  }
+              },
+              "api_key.created": {
+                  "id": "key_xxxx",
+                  "data": {
+                      "scopes": ["resource.operation"]
+                  }
+              }
+          }
+    AuditLogActor:
+      type: object
+      description: The actor who performed the audit logged action.
+      properties:
+        type:
+          type: string
+          description: The type of actor. Is either `session` or `api_key`.
+          enum:
+            - session
+            - api_key
+        session:
+          $ref: "#/components/schemas/AuditLogActorSession"
+        api_key:
+          $ref: "#/components/schemas/AuditLogActorApiKey"
+    AuditLogActorApiKey:
+      type: object
+      description: The API Key used to perform the audit logged action.
+      properties:
+        id:
+          type: string
+          description: The tracking id of the API key.
+        type:
+          type: string
+          description: The type of API key. Can be either `user` or `service_account`.
+          enum:
+            - user
+            - service_account
+        user:
+          $ref: "#/components/schemas/AuditLogActorUser"
+        service_account:
+          $ref: "#/components/schemas/AuditLogActorServiceAccount"
+    AuditLogActorServiceAccount:
+      type: object
+      description: The service account that performed the audit logged action.
+      properties:
+        id:
+          type: string
+          description: The service account id.
+    AuditLogActorSession:
+      type: object
+      description: The session in which the audit logged action was performed.
+      properties:
+        user:
+          $ref: "#/components/schemas/AuditLogActorUser"
+        ip_address:
+          type: string
+          description: The IP address from which the action was performed.
+    AuditLogActorUser:
+      type: object
+      description: The user who performed the audit logged action.
+      properties:
+        id:
+          type: string
+          description: The user id.
+        email:
+          type: string
+          description: The user email.
+    AuditLogEventType:
+      type: string
+      description: The event type.
+      x-oaiExpandable: true
+      enum:
+        - api_key.created
+        - api_key.updated
+        - api_key.deleted
+        - invite.sent
+        - invite.accepted
+        - invite.deleted
+        - login.succeeded
+        - login.failed
+        - logout.succeeded
+        - logout.failed
+        - organization.updated
+        - project.created
+        - project.updated
+        - project.archived
+        - service_account.created
+        - service_account.updated
+        - service_account.deleted
+        - rate_limit.updated
+        - rate_limit.deleted
+        - user.added
+        - user.updated
+        - user.deleted
+    AutoChunkingStrategyRequestParam:
+      type: object
+      title: Auto Chunking Strategy
+      description: The default strategy. This strategy currently uses a
+        `max_chunk_size_tokens` of `800` and `chunk_overlap_tokens` of `400`.
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          description: Always `auto`.
+          enum:
+            - auto
+          x-stainless-const: true
+      required:
+        - type
+    Batch:
+      type: object
+      properties:
+        id:
+          type: string
+        object:
+          type: string
+          enum:
+            - batch
+          description: The object type, which is always `batch`.
+          x-stainless-const: true
+        endpoint:
+          type: string
+          description: The OpenAI API endpoint used by the batch.
+        errors:
+          type: object
+          properties:
+            object:
+              type: string
+              description: The object type, which is always `list`.
+            data:
+              type: array
+              items:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    description: An error code identifying the error type.
+                  message:
+                    type: string
+                    description: A human-readable message providing more details about the error.
+                  param:
+                    type: string
+                    description: The name of the parameter that caused the error, if applicable.
+                    nullable: true
+                  line:
+                    type: integer
+                    description: The line number of the input file where the error occurred, if
+                      applicable.
+                    nullable: true
+        input_file_id:
+          type: string
+          description: The ID of the input file for the batch.
+        completion_window:
+          type: string
+          description: The time frame within which the batch should be processed.
+        status:
+          type: string
+          description: The current status of the batch.
+          enum:
+            - validating
+            - failed
+            - in_progress
+            - finalizing
+            - completed
+            - expired
+            - cancelling
+            - cancelled
+        output_file_id:
+          type: string
+          description: The ID of the file containing the outputs of successfully executed
+            requests.
+        error_file_id:
+          type: string
+          description: The ID of the file containing the outputs of requests with errors.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch was created.
+        in_progress_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch started
+            processing.
+        expires_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch will expire.
+        finalizing_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch started
+            finalizing.
+        completed_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch was completed.
+        failed_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch failed.
+        expired_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch expired.
+        cancelling_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch started
+            cancelling.
+        cancelled_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the batch was cancelled.
+        request_counts:
+          type: object
+          properties:
+            total:
+              type: integer
+              description: Total number of requests in the batch.
+            completed:
+              type: integer
+              description: Number of requests that have been completed successfully.
+            failed:
+              type: integer
+              description: Number of requests that have failed.
+          required:
+            - total
+            - completed
+            - failed
+          description: The request counts for different statuses within the batch.
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+      required:
+        - id
+        - object
+        - endpoint
+        - input_file_id
+        - completion_window
+        - status
+        - created_at
+      x-oaiMeta:
+        name: The batch object
+        example: |
+          {
+            "id": "batch_abc123",
+            "object": "batch",
+            "endpoint": "/v1/completions",
+            "errors": null,
+            "input_file_id": "file-abc123",
+            "completion_window": "24h",
+            "status": "completed",
+            "output_file_id": "file-cvaTdG",
+            "error_file_id": "file-HOWS94",
+            "created_at": 1711471533,
+            "in_progress_at": 1711471538,
+            "expires_at": 1711557933,
+            "finalizing_at": 1711493133,
+            "completed_at": 1711493163,
+            "failed_at": null,
+            "expired_at": null,
+            "cancelling_at": null,
+            "cancelled_at": null,
+            "request_counts": {
+              "total": 100,
+              "completed": 95,
+              "failed": 5
+            },
+            "metadata": {
+              "customer_id": "user_123456789",
+              "batch_description": "Nightly eval job",
+            }
+          }
+    BatchRequestInput:
+      type: object
+      description: The per-line object of the batch input file
+      properties:
+        custom_id:
+          type: string
+          description: A developer-provided per-request id that will be used to match
+            outputs to inputs. Must be unique for each request in a batch.
+        method:
+          type: string
+          enum:
+            - POST
+          description: The HTTP method to be used for the request. Currently only `POST`
+            is supported.
+          x-stainless-const: true
+        url:
+          type: string
+          description: The OpenAI API relative URL to be used for the request. Currently
+            `/v1/chat/completions`, `/v1/embeddings`, and `/v1/completions` are
+            supported.
+      x-oaiMeta:
+        name: The request input object
+        example: >
+          {"custom_id": "request-1", "method": "POST", "url":
+          "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages":
+          [{"role": "system", "content": "You are a helpful assistant."},
+          {"role": "user", "content": "What is 2+2?"}]}}
+    BatchRequestOutput:
+      type: object
+      description: The per-line object of the batch output and error files
+      properties:
+        id:
+          type: string
+        custom_id:
+          type: string
+          description: A developer-provided per-request id that will be used to match
+            outputs to inputs.
+        response:
+          type: object
+          nullable: true
+          properties:
+            status_code:
+              type: integer
+              description: The HTTP status code of the response
+            request_id:
+              type: string
+              description: An unique identifier for the OpenAI API request. Please include
+                this request ID when contacting support.
+            body:
+              type: object
+              x-oaiTypeLabel: map
+              description: The JSON body of the response
+        error:
+          type: object
+          nullable: true
+          description: For requests that failed with a non-HTTP error, this will contain
+            more information on the cause of the failure.
+          properties:
+            code:
+              type: string
+              description: A machine-readable error code.
+            message:
+              type: string
+              description: A human-readable error message.
+      x-oaiMeta:
+        name: The request output object
+        example: >
+          {"id": "batch_req_wnaDys", "custom_id": "request-2", "response":
+          {"status_code": 200, "request_id": "req_c187b3", "body": {"id":
+          "chatcmpl-9758Iw", "object": "chat.completion", "created": 1711475054,
+          "model": "gpt-4o-mini", "choices": [{"index": 0, "message": {"role":
+          "assistant", "content": "2 + 2 equals 4."}, "finish_reason": "stop"}],
+          "usage": {"prompt_tokens": 24, "completion_tokens": 15,
+          "total_tokens": 39}, "system_fingerprint": null}}, "error": null}
+    CancelUploadRequest:
+      type: object
+      additionalProperties: false
+    ChatCompletionFunctionCallOption:
+      type: object
+      description: >
+        Specifying a particular function via `{"name": "my_function"}` forces
+        the model to call that function.
+      properties:
+        name:
+          type: string
+          description: The name of the function to call.
+      required:
+        - name
+    ChatCompletionFunctions:
+      type: object
+      deprecated: true
+      properties:
+        description:
+          type: string
+          description: A description of what the function does, used by the model to
+            choose when and how to call the function.
+        name:
+          type: string
+          description: The name of the function to be called. Must be a-z, A-Z, 0-9, or
+            contain underscores and dashes, with a maximum length of 64.
+        parameters:
+          $ref: "#/components/schemas/FunctionParameters"
+      required:
+        - name
+    ChatCompletionMessageToolCall:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the tool call.
+        type:
+          type: string
+          enum:
+            - function
+          description: The type of the tool. Currently, only `function` is supported.
+          x-stainless-const: true
+        function:
+          type: object
+          description: The function that the model called.
+          properties:
+            name:
+              type: string
+              description: The name of the function to call.
+            arguments:
+              type: string
+              description: The arguments to call the function with, as generated by the model
+                in JSON format. Note that the model does not always generate
+                valid JSON, and may hallucinate parameters not defined by your
+                function schema. Validate the arguments in your code before
+                calling your function.
+          required:
+            - name
+            - arguments
+      required:
+        - id
+        - type
+        - function
+    ChatCompletionMessageToolCallChunk:
+      type: object
+      properties:
+        index:
+          type: integer
+        id:
+          type: string
+          description: The ID of the tool call.
+        type:
+          type: string
+          enum:
+            - function
+          description: The type of the tool. Currently, only `function` is supported.
+          x-stainless-const: true
+        function:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the function to call.
+            arguments:
+              type: string
+              description: The arguments to call the function with, as generated by the model
+                in JSON format. Note that the model does not always generate
+                valid JSON, and may hallucinate parameters not defined by your
+                function schema. Validate the arguments in your code before
+                calling your function.
+      required:
+        - index
+    ChatCompletionMessageToolCalls:
+      type: array
+      description: The tool calls generated by the model, such as function calls.
+      items:
+        $ref: "#/components/schemas/ChatCompletionMessageToolCall"
+    ChatCompletionModalities:
+      type: array
+      nullable: true
+      description: >
+        Output types that you would like the model to generate for this request.
+
+        Most models are capable of generating text, which is the default:
+
+
+        `["text"]`
+
+
+        The `gpt-4o-audio-preview` model can also be used to [generate
+        audio](/docs/guides/audio). To
+
+        request that this model generate both text and audio responses, you can
+
+        use:
+
+
+        `["text", "audio"]`
+      items:
+        type: string
+        enum:
+          - text
+          - audio
+    ChatCompletionNamedToolChoice:
+      type: object
+      description: Specifies a tool the model should use. Use to force the model to
+        call a specific function.
+      properties:
+        type:
+          type: string
+          enum:
+            - function
+          description: The type of the tool. Currently, only `function` is supported.
+          x-stainless-const: true
+        function:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the function to call.
+          required:
+            - name
+      required:
+        - type
+        - function
+    ChatCompletionRequestAssistantMessage:
+      type: object
+      title: Assistant message
+      description: |
+        Messages sent by the model in response to user messages.
+      properties:
+        content:
+          x-oaiExpandable: true
+          nullable: true
+          oneOf:
+            - type: string
+              description: The contents of the assistant message.
+              title: Text content
+            - type: array
+              description: An array of content parts with a defined type. Can be one or more
+                of type `text`, or exactly one of type `refusal`.
+              title: Array of content parts
+              items:
+                $ref: "#/components/schemas/ChatCompletionRequestAssistantMessageContentPart"
+              minItems: 1
+          description: >
+            The contents of the assistant message. Required unless `tool_calls`
+            or `function_call` is specified.
+        refusal:
+          nullable: true
+          type: string
+          description: The refusal message by the assistant.
+        role:
+          type: string
+          enum:
+            - assistant
+          description: The role of the messages author, in this case `assistant`.
+          x-stainless-const: true
+        name:
+          type: string
+          description: An optional name for the participant. Provides the model
+            information to differentiate between participants of the same role.
+        audio:
+          type: object
+          nullable: true
+          x-oaiExpandable: true
+          description: |
+            Data about a previous audio response from the model. 
+            [Learn more](/docs/guides/audio).
+          required:
+            - id
+          properties:
+            id:
+              type: string
+              description: |
+                Unique identifier for a previous audio response from the model.
+        tool_calls:
+          $ref: "#/components/schemas/ChatCompletionMessageToolCalls"
+        function_call:
+          type: object
+          deprecated: true
+          description: Deprecated and replaced by `tool_calls`. The name and arguments of
+            a function that should be called, as generated by the model.
+          nullable: true
+          properties:
+            arguments:
+              type: string
+              description: The arguments to call the function with, as generated by the model
+                in JSON format. Note that the model does not always generate
+                valid JSON, and may hallucinate parameters not defined by your
+                function schema. Validate the arguments in your code before
+                calling your function.
+            name:
+              type: string
+              description: The name of the function to call.
+          required:
+            - arguments
+            - name
+      required:
+        - role
+    ChatCompletionRequestAssistantMessageContentPart:
+      oneOf:
+        - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+        - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartRefusal"
+      x-oaiExpandable: true
+    ChatCompletionRequestDeveloperMessage:
+      type: object
+      title: Developer message
+      description: >
+        Developer-provided instructions that the model should follow, regardless
+        of
+
+        messages sent by the user. With o1 models and newer, `developer`
+        messages
+
+        replace the previous `system` messages.
+      properties:
+        content:
+          description: The contents of the developer message.
+          oneOf:
+            - type: string
+              description: The contents of the developer message.
+              title: Text content
+            - type: array
+              description: An array of content parts with a defined type. For developer
+                messages, only type `text` is supported.
+              title: Array of content parts
+              items:
+                $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+              minItems: 1
+        role:
+          type: string
+          enum:
+            - developer
+          description: The role of the messages author, in this case `developer`.
+          x-stainless-const: true
+        name:
+          type: string
+          description: An optional name for the participant. Provides the model
+            information to differentiate between participants of the same role.
+      required:
+        - content
+        - role
+    ChatCompletionRequestFunctionMessage:
+      type: object
+      title: Function message
+      deprecated: true
+      properties:
+        role:
+          type: string
+          enum:
+            - function
+          description: The role of the messages author, in this case `function`.
+          x-stainless-const: true
+        content:
+          nullable: true
+          type: string
+          description: The contents of the function message.
+        name:
+          type: string
+          description: The name of the function to call.
+      required:
+        - role
+        - content
+        - name
+    ChatCompletionRequestMessage:
+      oneOf:
+        - $ref: "#/components/schemas/ChatCompletionRequestDeveloperMessage"
+        - $ref: "#/components/schemas/ChatCompletionRequestSystemMessage"
+        - $ref: "#/components/schemas/ChatCompletionRequestUserMessage"
+        - $ref: "#/components/schemas/ChatCompletionRequestAssistantMessage"
+        - $ref: "#/components/schemas/ChatCompletionRequestToolMessage"
+        - $ref: "#/components/schemas/ChatCompletionRequestFunctionMessage"
+      x-oaiExpandable: true
+    ChatCompletionRequestMessageContentPartAudio:
+      type: object
+      title: Audio content part
+      description: |
+        Learn about [audio inputs](/docs/guides/audio).
+      properties:
+        type:
+          type: string
+          enum:
+            - input_audio
+          description: The type of the content part. Always `input_audio`.
+          x-stainless-const: true
+        input_audio:
+          type: object
+          properties:
+            data:
+              type: string
+              description: Base64 encoded audio data.
+            format:
+              type: string
+              enum:
+                - wav
+                - mp3
+              description: >
+                The format of the encoded audio data. Currently supports "wav"
+                and "mp3".
+          required:
+            - data
+            - format
+      required:
+        - type
+        - input_audio
+    ChatCompletionRequestMessageContentPartImage:
+      type: object
+      title: Image content part
+      description: |
+        Learn about [image inputs](/docs/guides/vision).
+      properties:
+        type:
+          type: string
+          enum:
+            - image_url
+          description: The type of the content part.
+          x-stainless-const: true
+        image_url:
+          type: object
+          properties:
+            url:
+              type: string
+              description: Either a URL of the image or the base64 encoded image data.
+              format: uri
+            detail:
+              type: string
+              description: Specifies the detail level of the image. Learn more in the [Vision
+                guide](/docs/guides/vision#low-or-high-fidelity-image-understanding).
+              enum:
+                - auto
+                - low
+                - high
+              default: auto
+          required:
+            - url
+      required:
+        - type
+        - image_url
+    ChatCompletionRequestMessageContentPartRefusal:
+      type: object
+      title: Refusal content part
+      properties:
+        type:
+          type: string
+          enum:
+            - refusal
+          description: The type of the content part.
+          x-stainless-const: true
+        refusal:
+          type: string
+          description: The refusal message generated by the model.
+      required:
+        - type
+        - refusal
+    ChatCompletionRequestMessageContentPartText:
+      type: object
+      title: Text content part
+      description: |
+        Learn about [text inputs](/docs/guides/text-generation).
+      properties:
+        type:
+          type: string
+          enum:
+            - text
+          description: The type of the content part.
+          x-stainless-const: true
+        text:
+          type: string
+          description: The text content.
+      required:
+        - type
+        - text
+    ChatCompletionRequestSystemMessage:
+      type: object
+      title: System message
+      description: >
+        Developer-provided instructions that the model should follow, regardless
+        of
+
+        messages sent by the user. With o1 models and newer, use `developer`
+        messages
+
+        for this purpose instead.
+      properties:
+        content:
+          description: The contents of the system message.
+          oneOf:
+            - type: string
+              description: The contents of the system message.
+              title: Text content
+            - type: array
+              description: An array of content parts with a defined type. For system messages,
+                only type `text` is supported.
+              title: Array of content parts
+              items:
+                $ref: "#/components/schemas/ChatCompletionRequestSystemMessageContentPart"
+              minItems: 1
+        role:
+          type: string
+          enum:
+            - system
+          description: The role of the messages author, in this case `system`.
+          x-stainless-const: true
+        name:
+          type: string
+          description: An optional name for the participant. Provides the model
+            information to differentiate between participants of the same role.
+      required:
+        - content
+        - role
+    ChatCompletionRequestSystemMessageContentPart:
+      oneOf:
+        - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+      x-oaiExpandable: true
+    ChatCompletionRequestToolMessage:
+      type: object
+      title: Tool message
+      properties:
+        role:
+          type: string
+          enum:
+            - tool
+          description: The role of the messages author, in this case `tool`.
+          x-stainless-const: true
+        content:
+          oneOf:
+            - type: string
+              description: The contents of the tool message.
+              title: Text content
+            - type: array
+              description: An array of content parts with a defined type. For tool messages,
+                only type `text` is supported.
+              title: Array of content parts
+              items:
+                $ref: "#/components/schemas/ChatCompletionRequestToolMessageContentPart"
+              minItems: 1
+          description: The contents of the tool message.
+        tool_call_id:
+          type: string
+          description: Tool call that this message is responding to.
+      required:
+        - role
+        - content
+        - tool_call_id
+    ChatCompletionRequestToolMessageContentPart:
+      oneOf:
+        - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+      x-oaiExpandable: true
+    ChatCompletionRequestUserMessage:
+      type: object
+      title: User message
+      description: |
+        Messages sent by an end user, containing prompts or additional context
+        information.
+      properties:
+        content:
+          description: |
+            The contents of the user message.
+          oneOf:
+            - type: string
+              description: The text contents of the message.
+              title: Text content
+            - type: array
+              description: An array of content parts with a defined type. Supported options
+                differ based on the [model](/docs/models) being used to generate
+                the response. Can contain text, image, or audio inputs.
+              title: Array of content parts
+              items:
+                $ref: "#/components/schemas/ChatCompletionRequestUserMessageContentPart"
+              minItems: 1
+          x-oaiExpandable: true
+        role:
+          type: string
+          enum:
+            - user
+          description: The role of the messages author, in this case `user`.
+          x-stainless-const: true
+        name:
+          type: string
+          description: An optional name for the participant. Provides the model
+            information to differentiate between participants of the same role.
+      required:
+        - content
+        - role
+    ChatCompletionRequestUserMessageContentPart:
+      oneOf:
+        - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+        - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartImage"
+        - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartAudio"
+      x-oaiExpandable: true
+    ChatCompletionResponseMessage:
+      type: object
+      description: A chat completion message generated by the model.
+      properties:
+        content:
+          type: string
+          description: The contents of the message.
+          nullable: true
+        refusal:
+          type: string
+          description: The refusal message generated by the model.
+          nullable: true
+        tool_calls:
+          $ref: "#/components/schemas/ChatCompletionMessageToolCalls"
+        role:
+          type: string
+          enum:
+            - assistant
+          description: The role of the author of this message.
+          x-stainless-const: true
+        function_call:
+          type: object
+          deprecated: true
+          description: Deprecated and replaced by `tool_calls`. The name and arguments of
+            a function that should be called, as generated by the model.
+          properties:
+            arguments:
+              type: string
+              description: The arguments to call the function with, as generated by the model
+                in JSON format. Note that the model does not always generate
+                valid JSON, and may hallucinate parameters not defined by your
+                function schema. Validate the arguments in your code before
+                calling your function.
+            name:
+              type: string
+              description: The name of the function to call.
+          required:
+            - name
+            - arguments
+        audio:
+          type: object
+          nullable: true
+          description: >
+            If the audio output modality is requested, this object contains data
+
+            about the audio response from the model. [Learn
+            more](/docs/guides/audio).
+          x-oaiExpandable: true
+          required:
+            - id
+            - expires_at
+            - data
+            - transcript
+          properties:
+            id:
+              type: string
+              description: Unique identifier for this audio response.
+            expires_at:
+              type: integer
+              description: >
+                The Unix timestamp (in seconds) for when this audio response
+                will
+
+                no longer be accessible on the server for use in multi-turn
+
+                conversations.
+            data:
+              type: string
+              description: |
+                Base64 encoded audio bytes generated by the model, in the format
+                specified in the request.
+            transcript:
+              type: string
+              description: Transcript of the audio generated by the model.
+      required:
+        - role
+        - content
+        - refusal
+    ChatCompletionRole:
+      type: string
+      description: The role of the author of a message
+      enum:
+        - system
+        - user
+        - assistant
+        - tool
+        - function
+    ChatCompletionStreamOptions:
+      description: >
+        Options for streaming response. Only set this when you set `stream:
+        true`.
+      type: object
+      nullable: true
+      default: null
+      properties:
+        include_usage:
+          type: boolean
+          description: >
+            If set, an additional chunk will be streamed before the `data:
+            [DONE]` message. The `usage` field on this chunk shows the token
+            usage statistics for the entire request, and the `choices` field
+            will always be an empty array. All other chunks will also include a
+            `usage` field, but with a null value.
+    ChatCompletionStreamResponseDelta:
+      type: object
+      description: A chat completion delta generated by streamed model responses.
+      properties:
+        content:
+          type: string
+          description: The contents of the chunk message.
+          nullable: true
+        function_call:
+          deprecated: true
+          type: object
+          description: Deprecated and replaced by `tool_calls`. The name and arguments of
+            a function that should be called, as generated by the model.
+          properties:
+            arguments:
+              type: string
+              description: The arguments to call the function with, as generated by the model
+                in JSON format. Note that the model does not always generate
+                valid JSON, and may hallucinate parameters not defined by your
+                function schema. Validate the arguments in your code before
+                calling your function.
+            name:
+              type: string
+              description: The name of the function to call.
+        tool_calls:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChatCompletionMessageToolCallChunk"
+        role:
+          type: string
+          enum:
+            - system
+            - user
+            - assistant
+            - tool
+          description: The role of the author of this message.
+        refusal:
+          type: string
+          description: The refusal message generated by the model.
+          nullable: true
+    ChatCompletionTokenLogprob:
+      type: object
+      properties:
+        token: &a1
+          description: The token.
+          type: string
+        logprob: &a2
+          description: The log probability of this token, if it is within the top 20 most
+            likely tokens. Otherwise, the value `-9999.0` is used to signify
+            that the token is very unlikely.
+          type: number
+        bytes: &a3
+          description: A list of integers representing the UTF-8 bytes representation of
+            the token. Useful in instances where characters are represented by
+            multiple tokens and their byte representations must be combined to
+            generate the correct text representation. Can be `null` if there is
+            no bytes representation for the token.
+          type: array
+          items:
+            type: integer
+          nullable: true
+        top_logprobs:
+          description: List of the most likely tokens and their log probability, at this
+            token position. In rare cases, there may be fewer than the number of
+            requested `top_logprobs` returned.
+          type: array
+          items:
+            type: object
+            properties:
+              token: *a1
+              logprob: *a2
+              bytes: *a3
+            required:
+              - token
+              - logprob
+              - bytes
+      required:
+        - token
+        - logprob
+        - bytes
+        - top_logprobs
+    ChatCompletionTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - function
+          description: The type of the tool. Currently, only `function` is supported.
+          x-stainless-const: true
+        function:
+          $ref: "#/components/schemas/FunctionObject"
+      required:
+        - type
+        - function
+    ChatCompletionToolChoiceOption:
+      description: >
+        Controls which (if any) tool is called by the model.
+
+        `none` means the model will not call any tool and instead generates a
+        message.
+
+        `auto` means the model can pick between generating a message or calling
+        one or more tools.
+
+        `required` means the model must call one or more tools.
+
+        Specifying a particular tool via `{"type": "function", "function":
+        {"name": "my_function"}}` forces the model to call that tool.
+
+
+        `none` is the default when no tools are present. `auto` is the default
+        if tools are present.
+      oneOf:
+        - type: string
+          description: >
+            `none` means the model will not call any tool and instead generates
+            a message. `auto` means the model can pick between generating a
+            message or calling one or more tools. `required` means the model
+            must call one or more tools.
+          enum:
+            - none
+            - auto
+            - required
+        - $ref: "#/components/schemas/ChatCompletionNamedToolChoice"
+      x-oaiExpandable: true
+    ChunkingStrategyRequestParam:
+      type: object
+      description: The chunking strategy used to chunk the file(s). If not set, will
+        use the `auto` strategy.
+      oneOf:
+        - $ref: "#/components/schemas/AutoChunkingStrategyRequestParam"
+        - $ref: "#/components/schemas/StaticChunkingStrategyRequestParam"
+      x-oaiExpandable: true
+    CompleteUploadRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        part_ids:
+          type: array
+          description: |
+            The ordered list of Part IDs.
+          items:
+            type: string
+        md5:
+          description: >
+            The optional md5 checksum for the file contents to verify if the
+            bytes uploaded matches what you expect.
+          type: string
+      required:
+        - part_ids
+    CompletionUsage:
+      type: object
+      description: Usage statistics for the completion request.
+      properties:
+        completion_tokens:
+          type: integer
+          description: Number of tokens in the generated completion.
+        prompt_tokens:
+          type: integer
+          description: Number of tokens in the prompt.
+        total_tokens:
+          type: integer
+          description: Total number of tokens used in the request (prompt + completion).
+        completion_tokens_details:
+          type: object
+          description: Breakdown of tokens used in a completion.
+          properties:
+            accepted_prediction_tokens:
+              type: integer
+              description: |
+                When using Predicted Outputs, the number of tokens in the
+                prediction that appeared in the completion.
+            audio_tokens:
+              type: integer
+              description: Audio input tokens generated by the model.
+            reasoning_tokens:
+              type: integer
+              description: Tokens generated by the model for reasoning.
+            rejected_prediction_tokens:
+              type: integer
+              description: >
+                When using Predicted Outputs, the number of tokens in the
+
+                prediction that did not appear in the completion. However, like
+
+                reasoning tokens, these tokens are still counted in the total
+
+                completion tokens for purposes of billing, output, and context
+                window
+
+                limits.
+        prompt_tokens_details:
+          type: object
+          description: Breakdown of tokens used in the prompt.
+          properties:
+            audio_tokens:
+              type: integer
+              description: Audio input tokens present in the prompt.
+            cached_tokens:
+              type: integer
+              description: Cached tokens present in the prompt.
+      required:
+        - prompt_tokens
+        - completion_tokens
+        - total_tokens
+    CostsResult:
+      type: object
+      description: The aggregated costs details of the specific time bucket.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.costs.result
+          x-stainless-const: true
+        amount:
+          type: object
+          description: The monetary value in its associated currency.
+          properties:
+            value:
+              type: number
+              description: The numeric value of the cost.
+            currency:
+              type: string
+              description: Lowercase ISO-4217 currency e.g. "usd"
+        line_item:
+          type: string
+          nullable: true
+          description: When `group_by=line_item`, this field provides the line item of the
+            grouped costs result.
+        project_id:
+          type: string
+          nullable: true
+          description: When `group_by=project_id`, this field provides the project ID of
+            the grouped costs result.
+      required:
+        - object
+      x-oaiMeta:
+        name: Costs object
+        example: |
+          {
+              "object": "organization.costs.result",
+              "amount": {
+                "value": 0.06,
+                "currency": "usd"
+              },
+              "line_item": "Image models",
+              "project_id": "proj_abc"
+          }
+    CreateAssistantRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        model:
+          description: >
+            ID of the model to use. You can use the [List
+            models](/docs/api-reference/models/list) API to see all of your
+            available models, or see our [Model overview](/docs/models) for
+            descriptions of them.
+          example: gpt-4o
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - gpt-4o
+                - gpt-4o-2024-11-20
+                - gpt-4o-2024-08-06
+                - gpt-4o-2024-05-13
+                - gpt-4o-mini
+                - gpt-4o-mini-2024-07-18
+                - gpt-4-turbo
+                - gpt-4-turbo-2024-04-09
+                - gpt-4-0125-preview
+                - gpt-4-turbo-preview
+                - gpt-4-1106-preview
+                - gpt-4-vision-preview
+                - gpt-4
+                - gpt-4-0314
+                - gpt-4-0613
+                - gpt-4-32k
+                - gpt-4-32k-0314
+                - gpt-4-32k-0613
+                - gpt-3.5-turbo
+                - gpt-3.5-turbo-16k
+                - gpt-3.5-turbo-0613
+                - gpt-3.5-turbo-1106
+                - gpt-3.5-turbo-0125
+                - gpt-3.5-turbo-16k-0613
+          x-oaiTypeLabel: string
+        name:
+          description: |
+            The name of the assistant. The maximum length is 256 characters.
+          type: string
+          nullable: true
+          maxLength: 256
+        description:
+          description: >
+            The description of the assistant. The maximum length is 512
+            characters.
+          type: string
+          nullable: true
+          maxLength: 512
+        instructions:
+          description: >
+            The system instructions that the assistant uses. The maximum length
+            is 256,000 characters.
+          type: string
+          nullable: true
+          maxLength: 256000
+        tools:
+          description: >
+            A list of tool enabled on the assistant. There can be a maximum of
+            128 tools per assistant. Tools can be of types `code_interpreter`,
+            `file_search`, or `function`.
+          default: []
+          type: array
+          maxItems: 128
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/AssistantToolsCode"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
+              - $ref: "#/components/schemas/AssistantToolsFunction"
+            x-oaiExpandable: true
+        tool_resources:
+          type: object
+          description: >
+            A set of resources that are used by the assistant's tools. The
+            resources are specific to the type of tool. For example, the
+            `code_interpreter` tool requires a list of file IDs, while the
+            `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: >
+                    A list of [file](/docs/api-reference/files) IDs made
+                    available to the `code_interpreter` tool. There can be a
+                    maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: >
+                    The [vector store](/docs/api-reference/vector-stores/object)
+                    attached to this assistant. There can be a maximum of 1
+                    vector store attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: string
+                vector_stores:
+                  type: array
+                  description: >
+                    A helper to create a [vector
+                    store](/docs/api-reference/vector-stores/object) with
+                    file_ids and attach it to this assistant. There can be a
+                    maximum of 1 vector store attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: object
+                    properties:
+                      file_ids:
+                        type: array
+                        description: >
+                          A list of [file](/docs/api-reference/files) IDs to add
+                          to the vector store. There can be a maximum of 10000
+                          files in a vector store.
+                        maxItems: 10000
+                        items:
+                          type: string
+                      chunking_strategy:
+                        type: object
+                        description: The chunking strategy used to chunk the file(s). If not set, will
+                          use the `auto` strategy.
+                        oneOf:
+                          - type: object
+                            title: Auto Chunking Strategy
+                            description: The default strategy. This strategy currently uses a
+                              `max_chunk_size_tokens` of `800` and
+                              `chunk_overlap_tokens` of `400`.
+                            additionalProperties: false
+                            properties:
+                              type:
+                                type: string
+                                description: Always `auto`.
+                                enum:
+                                  - auto
+                                x-stainless-const: true
+                            required:
+                              - type
+                          - type: object
+                            title: Static Chunking Strategy
+                            additionalProperties: false
+                            properties:
+                              type:
+                                type: string
+                                description: Always `static`.
+                                enum:
+                                  - static
+                                x-stainless-const: true
+                              static:
+                                type: object
+                                additionalProperties: false
+                                properties:
+                                  max_chunk_size_tokens:
+                                    type: integer
+                                    minimum: 100
+                                    maximum: 4096
+                                    description: The maximum number of tokens in each chunk. The default value is
+                                      `800`. The minimum value is `100` and the
+                                      maximum value is `4096`.
+                                  chunk_overlap_tokens:
+                                    type: integer
+                                    description: >
+                                      The number of tokens that overlap between
+                                      chunks. The default value is `400`.
+
+
+                                      Note that the overlap must not exceed half
+                                      of `max_chunk_size_tokens`.
+                                required:
+                                  - max_chunk_size_tokens
+                                  - chunk_overlap_tokens
+                            required:
+                              - type
+                              - static
+                        x-oaiExpandable: true
+                      metadata:
+                        type: object
+                        description: >
+                          Set of 16 key-value pairs that can be attached to a
+                          vector store. This can be useful for storing
+                          additional information about the vector store in a
+                          structured format. Keys can be a maximum of 64
+                          characters long and values can be a maximum of 512
+                          characters long.
+                        x-oaiTypeLabel: map
+              oneOf:
+                - required:
+                    - vector_store_ids
+                - required:
+                    - vector_stores
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          description: >
+            What sampling temperature to use, between 0 and 2. Higher values
+            like 0.8 will make the output more random, while lower values like
+            0.2 will make it more focused and deterministic.
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            An alternative to sampling with temperature, called nucleus
+            sampling, where the model considers the results of the tokens with
+            top_p probability mass. So 0.1 means only the tokens comprising the
+            top 10% probability mass are considered.
+
+
+            We generally recommend altering this or temperature but not both.
+        response_format:
+          allOf:
+            - $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+            - nullable: true
+      required:
+        - model
+    CreateChatCompletionFunctionResponse:
+      type: object
+      description: Represents a chat completion response returned by model, based on
+        the provided input.
+      properties:
+        id:
+          type: string
+          description: A unique identifier for the chat completion.
+        choices:
+          type: array
+          description: A list of chat completion choices. Can be more than one if `n` is
+            greater than 1.
+          items:
+            type: object
+            required:
+              - finish_reason
+              - index
+              - message
+            properties:
+              finish_reason:
+                type: string
+                description: >
+                  The reason the model stopped generating tokens. This will be
+                  `stop` if the model hit a natural stop point or a provided
+                  stop sequence, `length` if the maximum number of tokens
+                  specified in the request was reached, `content_filter` if
+                  content was omitted due to a flag from our content filters, or
+                  `function_call` if the model called a function.
+                enum:
+                  - stop
+                  - length
+                  - function_call
+                  - content_filter
+              index:
+                type: integer
+                description: The index of the choice in the list of choices.
+              message:
+                $ref: "#/components/schemas/ChatCompletionResponseMessage"
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the chat completion was
+            created.
+        model:
+          type: string
+          description: The model used for the chat completion.
+        system_fingerprint:
+          type: string
+          description: >
+            This fingerprint represents the backend configuration that the model
+            runs with.
+
+
+            Can be used in conjunction with the `seed` request parameter to
+            understand when backend changes have been made that might impact
+            determinism.
+        object:
+          type: string
+          description: The object type, which is always `chat.completion`.
+          enum:
+            - chat.completion
+          x-stainless-const: true
+        usage:
+          $ref: "#/components/schemas/CompletionUsage"
+      required:
+        - choices
+        - created
+        - id
+        - model
+        - object
+      x-oaiMeta:
+        name: The chat completion object
+        group: chat
+        example: |
+          {
+            "id": "chatcmpl-abc123",
+            "object": "chat.completion",
+            "created": 1699896916,
+            "model": "gpt-4o-mini",
+            "choices": [
+              {
+                "index": 0,
+                "message": {
+                  "role": "assistant",
+                  "content": null,
+                  "tool_calls": [
+                    {
+                      "id": "call_abc123",
+                      "type": "function",
+                      "function": {
+                        "name": "get_current_weather",
+                        "arguments": "{\n\"location\": \"Boston, MA\"\n}"
+                      }
+                    }
+                  ]
+                },
+                "logprobs": null,
+                "finish_reason": "tool_calls"
+              }
+            ],
+            "usage": {
+              "prompt_tokens": 82,
+              "completion_tokens": 17,
+              "total_tokens": 99,
+              "completion_tokens_details": {
+                "reasoning_tokens": 0,
+                "accepted_prediction_tokens": 0,
+                "rejected_prediction_tokens": 0
+              }
+            }
+          }
+    CreateChatCompletionImageResponse:
+      type: object
+      description: Represents a streamed chunk of a chat completion response returned
+        by model, based on the provided input.
+      x-oaiMeta:
+        name: The chat completion chunk object
+        group: chat
+        example: >
+          {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "model": "gpt-4o-mini",
+            "system_fingerprint": "fp_44709d6fcb",
+            "choices": [{
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "\n\nThis image shows a wooden boardwalk extending through a lush green marshland.",
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }],
+            "usage": {
+              "prompt_tokens": 9,
+              "completion_tokens": 12,
+              "total_tokens": 21,
+              "completion_tokens_details": {
+                "reasoning_tokens": 0,
+                "accepted_prediction_tokens": 0,
+                "rejected_prediction_tokens": 0
+              }
+            }
+          }
+    CreateChatCompletionRequest:
+      type: object
+      properties:
+        messages:
+          description: >
+            A list of messages comprising the conversation so far. Depending on
+            the
+
+            [model](/docs/models) you use, different message types (modalities)
+            are
+
+            supported, like [text](/docs/guides/text-generation),
+
+            [images](/docs/guides/vision), and [audio](/docs/guides/audio).
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/ChatCompletionRequestMessage"
+        model:
+          description: ID of the model to use. See the [model endpoint
+            compatibility](/docs/models#model-endpoint-compatibility) table for
+            details on which models work with the Chat API.
+          example: gpt-4o
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - o1
+                - o1-2024-12-17
+                - o1-preview
+                - o1-preview-2024-09-12
+                - o1-mini
+                - o1-mini-2024-09-12
+                - gpt-4o
+                - gpt-4o-2024-11-20
+                - gpt-4o-2024-08-06
+                - gpt-4o-2024-05-13
+                - gpt-4o-audio-preview
+                - gpt-4o-audio-preview-2024-10-01
+                - gpt-4o-audio-preview-2024-12-17
+                - gpt-4o-mini-audio-preview
+                - gpt-4o-mini-audio-preview-2024-12-17
+                - chatgpt-4o-latest
+                - gpt-4o-mini
+                - gpt-4o-mini-2024-07-18
+                - gpt-4-turbo
+                - gpt-4-turbo-2024-04-09
+                - gpt-4-0125-preview
+                - gpt-4-turbo-preview
+                - gpt-4-1106-preview
+                - gpt-4-vision-preview
+                - gpt-4
+                - gpt-4-0314
+                - gpt-4-0613
+                - gpt-4-32k
+                - gpt-4-32k-0314
+                - gpt-4-32k-0613
+                - gpt-3.5-turbo
+                - gpt-3.5-turbo-16k
+                - gpt-3.5-turbo-0301
+                - gpt-3.5-turbo-0613
+                - gpt-3.5-turbo-1106
+                - gpt-3.5-turbo-0125
+                - gpt-3.5-turbo-16k-0613
+          x-oaiTypeLabel: string
+        store:
+          type: boolean
+          default: false
+          nullable: true
+          description: >
+            Whether or not to store the output of this chat completion request
+            for 
+
+            use in our [model distillation](/docs/guides/distillation) or
+
+            [evals](/docs/guides/evals) products.
+        reasoning_effort:
+          type: string
+          enum:
+            - low
+            - medium
+            - high
+          default: medium
+          description: >
+            **o1 models only** 
+
+
+            Constrains effort on reasoning for 
+
+            [reasoning
+            models](https://platform.openai.com/docs/guides/reasoning).
+
+            Currently supported values are `low`, `medium`, and `high`. Reducing
+
+            reasoning effort can result in faster responses and fewer tokens
+            used
+
+            on reasoning in a response.
+        metadata:
+          type: object
+          nullable: true
+          description: |
+            Developer-defined tags and values used for filtering completions
+            in the [dashboard](https://platform.openai.com/chat-completions).
+          additionalProperties:
+            type: string
+        frequency_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: >
+            Number between -2.0 and 2.0. Positive values penalize new tokens
+            based on
+
+            their existing frequency in the text so far, decreasing the model's
+
+            likelihood to repeat the same line verbatim.
+        logit_bias:
+          type: object
+          x-oaiTypeLabel: map
+          default: null
+          nullable: true
+          additionalProperties:
+            type: integer
+          description: >
+            Modify the likelihood of specified tokens appearing in the
+            completion.
+
+
+            Accepts a JSON object that maps tokens (specified by their token ID
+            in the
+
+            tokenizer) to an associated bias value from -100 to 100.
+            Mathematically,
+
+            the bias is added to the logits generated by the model prior to
+            sampling.
+
+            The exact effect will vary per model, but values between -1 and 1
+            should
+
+            decrease or increase likelihood of selection; values like -100 or
+            100
+
+            should result in a ban or exclusive selection of the relevant token.
+        logprobs:
+          description: >
+            Whether to return log probabilities of the output tokens or not. If
+            true,
+
+            returns the log probabilities of each output token returned in the
+
+            `content` of `message`.
+          type: boolean
+          default: false
+          nullable: true
+        top_logprobs:
+          description: >
+            An integer between 0 and 20 specifying the number of most likely
+            tokens to
+
+            return at each token position, each with an associated log
+            probability.
+
+            `logprobs` must be set to `true` if this parameter is used.
+          type: integer
+          minimum: 0
+          maximum: 20
+          nullable: true
+        max_tokens:
+          description: >
+            The maximum number of [tokens](/tokenizer) that can be generated in
+            the
+
+            chat completion. This value can be used to control
+
+            [costs](https://openai.com/api/pricing/) for text generated via API.
+
+
+            This value is now deprecated in favor of `max_completion_tokens`,
+            and is
+
+            not compatible with [o1 series models](/docs/guides/reasoning).
+          type: integer
+          nullable: true
+          deprecated: true
+        max_completion_tokens:
+          description: >
+            An upper bound for the number of tokens that can be generated for a
+            completion, including visible output tokens and [reasoning
+            tokens](/docs/guides/reasoning).
+          type: integer
+          nullable: true
+        n:
+          type: integer
+          minimum: 1
+          maximum: 128
+          default: 1
+          example: 1
+          nullable: true
+          description: How many chat completion choices to generate for each input
+            message. Note that you will be charged based on the number of
+            generated tokens across all of the choices. Keep `n` as `1` to
+            minimize costs.
+        modalities:
+          $ref: "#/components/schemas/ChatCompletionModalities"
+        prediction:
+          nullable: true
+          x-oaiExpandable: true
+          description: >
+            Configuration for a [Predicted
+            Output](/docs/guides/predicted-outputs),
+
+            which can greatly improve response times when large parts of the
+            model
+
+            response are known ahead of time. This is most common when you are
+
+            regenerating a file with only minor changes to most of the content.
+          oneOf:
+            - $ref: "#/components/schemas/PredictionContent"
+        audio:
+          type: object
+          nullable: true
+          description: >
+            Parameters for audio output. Required when audio output is requested
+            with
+
+            `modalities: ["audio"]`. [Learn more](/docs/guides/audio).
+          required:
+            - voice
+            - format
+          x-oaiExpandable: true
+          properties:
+            voice:
+              type: string
+              enum:
+                - alloy
+                - ash
+                - ballad
+                - coral
+                - echo
+                - sage
+                - shimmer
+                - verse
+              description: >
+                The voice the model uses to respond. Supported voices are `ash`,
+                `ballad`, `coral`, `sage`, and `verse` (also supported but not
+                recommended are `alloy`, `echo`, and `shimmer`; these voices are
+                less expressive).
+            format:
+              type: string
+              enum:
+                - wav
+                - mp3
+                - flac
+                - opus
+                - pcm16
+              description: >
+                Specifies the output audio format. Must be one of `wav`, `mp3`,
+                `flac`,
+
+                `opus`, or `pcm16`.
+        presence_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: >
+            Number between -2.0 and 2.0. Positive values penalize new tokens
+            based on
+
+            whether they appear in the text so far, increasing the model's
+            likelihood
+
+            to talk about new topics.
+        response_format:
+          description: >
+            An object specifying the format that the model must output.
+
+
+            Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
+
+            Structured Outputs which ensures the model will match your supplied
+            JSON
+
+            schema. Learn more in the [Structured Outputs
+
+            guide](/docs/guides/structured-outputs).
+
+
+            Setting to `{ "type": "json_object" }` enables JSON mode, which
+            ensures
+
+            the message the model generates is valid JSON.
+
+
+            **Important:** when using JSON mode, you **must** also instruct the
+            model
+
+            to produce JSON yourself via a system or user message. Without this,
+            the
+
+            model may generate an unending stream of whitespace until the
+            generation
+
+            reaches the token limit, resulting in a long-running and seemingly
+            "stuck"
+
+            request. Also note that the message content may be partially cut off
+            if
+
+            `finish_reason="length"`, which indicates the generation exceeded
+
+            `max_tokens` or the conversation exceeded the max context length.
+          oneOf:
+            - $ref: "#/components/schemas/ResponseFormatText"
+            - $ref: "#/components/schemas/ResponseFormatJsonObject"
+            - $ref: "#/components/schemas/ResponseFormatJsonSchema"
+          x-oaiExpandable: true
+        seed:
+          type: integer
+          format: int64
+          nullable: true
+          description: >
+            This feature is in Beta.
+
+            If specified, our system will make a best effort to sample
+            deterministically, such that repeated requests with the same `seed`
+            and parameters should return the same result.
+
+            Determinism is not guaranteed, and you should refer to the
+            `system_fingerprint` response parameter to monitor changes in the
+            backend.
+          x-oaiMeta:
+            beta: true
+        service_tier:
+          description: >
+            Specifies the latency tier to use for processing the request. This
+            parameter is relevant for customers subscribed to the scale tier
+            service:
+              - If set to 'auto', and the Project is Scale tier enabled, the system will utilize scale tier credits until they are exhausted.
+              - If set to 'auto', and the Project is not Scale tier enabled, the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.
+              - If set to 'default', the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.
+              - When not set, the default behavior is 'auto'.
+          type: string
+          enum:
+            - auto
+            - default
+          nullable: true
+          default: auto
+        stop:
+          description: |
+            Up to 4 sequences where the API will stop generating further tokens.
+          default: null
+          oneOf:
+            - type: string
+              nullable: true
+            - type: array
+              minItems: 1
+              maxItems: 4
+              items:
+                type: string
+        stream:
+          description: >
+            If set, partial message deltas will be sent, like in ChatGPT. Tokens
+            will be sent as data-only [server-sent
+            events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+            as they become available, with the stream terminated by a `data:
+            [DONE]` message. [Example Python
+            code](https://cookbook.openai.com/examples/how_to_stream_completions).
+          type: boolean
+          nullable: true
+          default: false
+        stream_options:
+          $ref: "#/components/schemas/ChatCompletionStreamOptions"
+        temperature:
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            What sampling temperature to use, between 0 and 2. Higher values
+            like 0.8 will make the output more random, while lower values like
+            0.2 will make it more focused and deterministic.
+
+            We generally recommend altering this or `top_p` but not both.
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            An alternative to sampling with temperature, called nucleus
+            sampling,
+
+            where the model considers the results of the tokens with top_p
+            probability
+
+            mass. So 0.1 means only the tokens comprising the top 10%
+            probability mass
+
+            are considered.
+
+
+            We generally recommend altering this or `temperature` but not both.
+        tools:
+          type: array
+          description: >
+            A list of tools the model may call. Currently, only functions are
+            supported as a tool. Use this to provide a list of functions the
+            model may generate JSON inputs for. A max of 128 functions are
+            supported.
+          items:
+            $ref: "#/components/schemas/ChatCompletionTool"
+        tool_choice:
+          $ref: "#/components/schemas/ChatCompletionToolChoiceOption"
+        parallel_tool_calls:
+          $ref: "#/components/schemas/ParallelToolCalls"
+        user:
+          type: string
+          example: user-1234
+          description: >
+            A unique identifier representing your end-user, which can help
+            OpenAI to monitor and detect abuse. [Learn
+            more](/docs/guides/safety-best-practices#end-user-ids).
+        function_call:
+          deprecated: true
+          description: >
+            Deprecated in favor of `tool_choice`.
+
+
+            Controls which (if any) function is called by the model.
+
+
+            `none` means the model will not call a function and instead
+            generates a
+
+            message.
+
+
+            `auto` means the model can pick between generating a message or
+            calling a
+
+            function.
+
+
+            Specifying a particular function via `{"name": "my_function"}`
+            forces the
+
+            model to call that function.
+
+
+            `none` is the default when no functions are present. `auto` is the
+            default
+
+            if functions are present.
+          oneOf:
+            - type: string
+              description: >
+                `none` means the model will not call a function and instead
+                generates a message. `auto` means the model can pick between
+                generating a message or calling a function.
+              enum:
+                - none
+                - auto
+            - $ref: "#/components/schemas/ChatCompletionFunctionCallOption"
+          x-oaiExpandable: true
+        functions:
+          deprecated: true
+          description: |
+            Deprecated in favor of `tools`.
+
+            A list of functions the model may generate JSON inputs for.
+          type: array
+          minItems: 1
+          maxItems: 128
+          items:
+            $ref: "#/components/schemas/ChatCompletionFunctions"
+      required:
+        - model
+        - messages
+    CreateChatCompletionResponse:
+      type: object
+      description: Represents a chat completion response returned by model, based on
+        the provided input.
+      properties:
+        id:
+          type: string
+          description: A unique identifier for the chat completion.
+        choices:
+          type: array
+          description: A list of chat completion choices. Can be more than one if `n` is
+            greater than 1.
+          items:
+            type: object
+            required:
+              - finish_reason
+              - index
+              - message
+              - logprobs
+            properties:
+              finish_reason:
+                type: string
+                description: >
+                  The reason the model stopped generating tokens. This will be
+                  `stop` if the model hit a natural stop point or a provided
+                  stop sequence,
+
+                  `length` if the maximum number of tokens specified in the
+                  request was reached,
+
+                  `content_filter` if content was omitted due to a flag from our
+                  content filters,
+
+                  `tool_calls` if the model called a tool, or `function_call`
+                  (deprecated) if the model called a function.
+                enum:
+                  - stop
+                  - length
+                  - tool_calls
+                  - content_filter
+                  - function_call
+              index:
+                type: integer
+                description: The index of the choice in the list of choices.
+              message:
+                $ref: "#/components/schemas/ChatCompletionResponseMessage"
+              logprobs:
+                description: Log probability information for the choice.
+                type: object
+                nullable: true
+                properties:
+                  content:
+                    description: A list of message content tokens with log probability information.
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ChatCompletionTokenLogprob"
+                    nullable: true
+                  refusal:
+                    description: A list of message refusal tokens with log probability information.
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ChatCompletionTokenLogprob"
+                    nullable: true
+                required:
+                  - content
+                  - refusal
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the chat completion was
+            created.
+        model:
+          type: string
+          description: The model used for the chat completion.
+        service_tier:
+          description: The service tier used for processing the request.
+          type: string
+          enum:
+            - scale
+            - default
+          example: scale
+          nullable: true
+        system_fingerprint:
+          type: string
+          description: >
+            This fingerprint represents the backend configuration that the model
+            runs with.
+
+
+            Can be used in conjunction with the `seed` request parameter to
+            understand when backend changes have been made that might impact
+            determinism.
+        object:
+          type: string
+          description: The object type, which is always `chat.completion`.
+          enum:
+            - chat.completion
+          x-stainless-const: true
+        usage:
+          $ref: "#/components/schemas/CompletionUsage"
+      required:
+        - choices
+        - created
+        - id
+        - model
+        - object
+      x-oaiMeta:
+        name: The chat completion object
+        group: chat
+        example: |
+          {
+            "id": "chatcmpl-123456",
+            "object": "chat.completion",
+            "created": 1728933352,
+            "model": "gpt-4o-2024-08-06",
+            "choices": [
+              {
+                "index": 0,
+                "message": {
+                  "role": "assistant",
+                  "content": "Hi there! How can I assist you today?",
+                  "refusal": null
+                },
+                "logprobs": null,
+                "finish_reason": "stop"
+              }
+            ],
+            "usage": {
+              "prompt_tokens": 19,
+              "completion_tokens": 10,
+              "total_tokens": 29,
+              "prompt_tokens_details": {
+                "cached_tokens": 0
+              },
+              "completion_tokens_details": {
+                "reasoning_tokens": 0,
+                "accepted_prediction_tokens": 0,
+                "rejected_prediction_tokens": 0
+              }
+            },
+            "system_fingerprint": "fp_6b68a8204b"
+          }
+    CreateChatCompletionStreamResponse:
+      type: object
+      description: Represents a streamed chunk of a chat completion response returned
+        by model, based on the provided input.
+      properties:
+        id:
+          type: string
+          description: A unique identifier for the chat completion. Each chunk has the
+            same ID.
+        choices:
+          type: array
+          description: >
+            A list of chat completion choices. Can contain more than one
+            elements if `n` is greater than 1. Can also be empty for the
+
+            last chunk if you set `stream_options: {"include_usage": true}`.
+          items:
+            type: object
+            required:
+              - delta
+              - finish_reason
+              - index
+            properties:
+              delta:
+                $ref: "#/components/schemas/ChatCompletionStreamResponseDelta"
+              logprobs:
+                description: Log probability information for the choice.
+                type: object
+                nullable: true
+                properties:
+                  content:
+                    description: A list of message content tokens with log probability information.
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ChatCompletionTokenLogprob"
+                    nullable: true
+                  refusal:
+                    description: A list of message refusal tokens with log probability information.
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ChatCompletionTokenLogprob"
+                    nullable: true
+                required:
+                  - content
+                  - refusal
+              finish_reason:
+                type: string
+                description: >
+                  The reason the model stopped generating tokens. This will be
+                  `stop` if the model hit a natural stop point or a provided
+                  stop sequence,
+
+                  `length` if the maximum number of tokens specified in the
+                  request was reached,
+
+                  `content_filter` if content was omitted due to a flag from our
+                  content filters,
+
+                  `tool_calls` if the model called a tool, or `function_call`
+                  (deprecated) if the model called a function.
+                enum:
+                  - stop
+                  - length
+                  - tool_calls
+                  - content_filter
+                  - function_call
+                nullable: true
+              index:
+                type: integer
+                description: The index of the choice in the list of choices.
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the chat completion was
+            created. Each chunk has the same timestamp.
+        model:
+          type: string
+          description: The model to generate the completion.
+        service_tier:
+          description: The service tier used for processing the request.
+          type: string
+          enum:
+            - scale
+            - default
+          example: scale
+          nullable: true
+        system_fingerprint:
+          type: string
+          description: >
+            This fingerprint represents the backend configuration that the model
+            runs with.
+
+            Can be used in conjunction with the `seed` request parameter to
+            understand when backend changes have been made that might impact
+            determinism.
+        object:
+          type: string
+          description: The object type, which is always `chat.completion.chunk`.
+          enum:
+            - chat.completion.chunk
+          x-stainless-const: true
+        usage:
+          type: object
+          nullable: true
+          description: >
+            An optional field that will only be present when you set
+            `stream_options: {"include_usage": true}` in your request.
+
+            When present, it contains a null value except for the last chunk
+            which contains the token usage statistics for the entire request.
+          properties:
+            completion_tokens:
+              type: integer
+              description: Number of tokens in the generated completion.
+            prompt_tokens:
+              type: integer
+              description: Number of tokens in the prompt.
+            total_tokens:
+              type: integer
+              description: Total number of tokens used in the request (prompt + completion).
+          required:
+            - prompt_tokens
+            - completion_tokens
+            - total_tokens
+      required:
+        - choices
+        - created
+        - id
+        - model
+        - object
+      x-oaiMeta:
+        name: The chat completion chunk object
+        group: chat
+        example: >
+          {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini",
+          "system_fingerprint": "fp_44709d6fcb",
+          "choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+
+          {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini",
+          "system_fingerprint": "fp_44709d6fcb",
+          "choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}
+
+
+          ....
+
+
+          {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4o-mini",
+          "system_fingerprint": "fp_44709d6fcb",
+          "choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+    CreateCompletionRequest:
+      type: object
+      properties:
+        model:
+          description: >
+            ID of the model to use. You can use the [List
+            models](/docs/api-reference/models/list) API to see all of your
+            available models, or see our [Model overview](/docs/models) for
+            descriptions of them.
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - gpt-3.5-turbo-instruct
+                - davinci-002
+                - babbage-002
+          x-oaiTypeLabel: string
+        prompt:
+          description: >
+            The prompt(s) to generate completions for, encoded as a string,
+            array of strings, array of tokens, or array of token arrays.
+
+
+            Note that <|endoftext|> is the document separator that the model
+            sees during training, so if a prompt is not specified the model will
+            generate as if from the beginning of a new document.
+          default: <|endoftext|>
+          nullable: true
+          oneOf:
+            - type: string
+              default: ""
+              example: This is a test.
+            - type: array
+              items:
+                type: string
+                default: ""
+                example: This is a test.
+            - type: array
+              minItems: 1
+              items:
+                type: integer
+              example: "[1212, 318, 257, 1332, 13]"
+            - type: array
+              minItems: 1
+              items:
+                type: array
+                minItems: 1
+                items:
+                  type: integer
+              example: "[[1212, 318, 257, 1332, 13]]"
+        best_of:
+          type: integer
+          default: 1
+          minimum: 0
+          maximum: 20
+          nullable: true
+          description: >
+            Generates `best_of` completions server-side and returns the "best"
+            (the one with the highest log probability per token). Results cannot
+            be streamed.
+
+
+            When used with `n`, `best_of` controls the number of candidate
+            completions and `n` specifies how many to return – `best_of` must be
+            greater than `n`.
+
+
+            **Note:** Because this parameter generates many completions, it can
+            quickly consume your token quota. Use carefully and ensure that you
+            have reasonable settings for `max_tokens` and `stop`.
+        echo:
+          type: boolean
+          default: false
+          nullable: true
+          description: |
+            Echo back the prompt in addition to the completion
+        frequency_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: >
+            Number between -2.0 and 2.0. Positive values penalize new tokens
+            based on their existing frequency in the text so far, decreasing the
+            model's likelihood to repeat the same line verbatim.
+
+
+            [See more information about frequency and presence
+            penalties.](/docs/guides/text-generation)
+        logit_bias:
+          type: object
+          x-oaiTypeLabel: map
+          default: null
+          nullable: true
+          additionalProperties:
+            type: integer
+          description: >
+            Modify the likelihood of specified tokens appearing in the
+            completion.
+
+
+            Accepts a JSON object that maps tokens (specified by their token ID
+            in the GPT tokenizer) to an associated bias value from -100 to 100.
+            You can use this [tokenizer tool](/tokenizer?view=bpe) to convert
+            text to token IDs. Mathematically, the bias is added to the logits
+            generated by the model prior to sampling. The exact effect will vary
+            per model, but values between -1 and 1 should decrease or increase
+            likelihood of selection; values like -100 or 100 should result in a
+            ban or exclusive selection of the relevant token.
+
+
+            As an example, you can pass `{"50256": -100}` to prevent the
+            <|endoftext|> token from being generated.
+        logprobs:
+          type: integer
+          minimum: 0
+          maximum: 5
+          default: null
+          nullable: true
+          description: >
+            Include the log probabilities on the `logprobs` most likely output
+            tokens, as well the chosen tokens. For example, if `logprobs` is 5,
+            the API will return a list of the 5 most likely tokens. The API will
+            always return the `logprob` of the sampled token, so there may be up
+            to `logprobs+1` elements in the response.
+
+
+            The maximum value for `logprobs` is 5.
+        max_tokens:
+          type: integer
+          minimum: 0
+          default: 16
+          example: 16
+          nullable: true
+          description: >
+            The maximum number of [tokens](/tokenizer) that can be generated in
+            the completion.
+
+
+            The token count of your prompt plus `max_tokens` cannot exceed the
+            model's context length. [Example Python
+            code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken)
+            for counting tokens.
+        n:
+          type: integer
+          minimum: 1
+          maximum: 128
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            How many completions to generate for each prompt.
+
+
+            **Note:** Because this parameter generates many completions, it can
+            quickly consume your token quota. Use carefully and ensure that you
+            have reasonable settings for `max_tokens` and `stop`.
+        presence_penalty:
+          type: number
+          default: 0
+          minimum: -2
+          maximum: 2
+          nullable: true
+          description: >
+            Number between -2.0 and 2.0. Positive values penalize new tokens
+            based on whether they appear in the text so far, increasing the
+            model's likelihood to talk about new topics.
+
+
+            [See more information about frequency and presence
+            penalties.](/docs/guides/text-generation)
+        seed:
+          type: integer
+          format: int64
+          nullable: true
+          description: >
+            If specified, our system will make a best effort to sample
+            deterministically, such that repeated requests with the same `seed`
+            and parameters should return the same result.
+
+
+            Determinism is not guaranteed, and you should refer to the
+            `system_fingerprint` response parameter to monitor changes in the
+            backend.
+        stop:
+          description: >
+            Up to 4 sequences where the API will stop generating further tokens.
+            The returned text will not contain the stop sequence.
+          default: null
+          nullable: true
+          oneOf:
+            - type: string
+              default: <|endoftext|>
+              example: "\n"
+              nullable: true
+            - type: array
+              minItems: 1
+              maxItems: 4
+              items:
+                type: string
+                example: '["\n"]'
+        stream:
+          description: >
+            Whether to stream back partial progress. If set, tokens will be sent
+            as data-only [server-sent
+            events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format)
+            as they become available, with the stream terminated by a `data:
+            [DONE]` message. [Example Python
+            code](https://cookbook.openai.com/examples/how_to_stream_completions).
+          type: boolean
+          nullable: true
+          default: false
+        stream_options:
+          $ref: "#/components/schemas/ChatCompletionStreamOptions"
+        suffix:
+          description: |
+            The suffix that comes after a completion of inserted text.
+
+            This parameter is only supported for `gpt-3.5-turbo-instruct`.
+          default: null
+          nullable: true
+          type: string
+          example: test.
+        temperature:
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            What sampling temperature to use, between 0 and 2. Higher values
+            like 0.8 will make the output more random, while lower values like
+            0.2 will make it more focused and deterministic.
+
+
+            We generally recommend altering this or `top_p` but not both.
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            An alternative to sampling with temperature, called nucleus
+            sampling, where the model considers the results of the tokens with
+            top_p probability mass. So 0.1 means only the tokens comprising the
+            top 10% probability mass are considered.
+
+
+            We generally recommend altering this or `temperature` but not both.
+        user:
+          type: string
+          example: user-1234
+          description: >
+            A unique identifier representing your end-user, which can help
+            OpenAI to monitor and detect abuse. [Learn
+            more](/docs/guides/safety-best-practices#end-user-ids).
+      required:
+        - model
+        - prompt
+    CreateCompletionResponse:
+      type: object
+      description: >
+        Represents a completion response from the API. Note: both the streamed
+        and non-streamed response objects share the same shape (unlike the chat
+        endpoint).
+      properties:
+        id:
+          type: string
+          description: A unique identifier for the completion.
+        choices:
+          type: array
+          description: The list of completion choices the model generated for the input
+            prompt.
+          items:
+            type: object
+            required:
+              - finish_reason
+              - index
+              - logprobs
+              - text
+            properties:
+              finish_reason:
+                type: string
+                description: >
+                  The reason the model stopped generating tokens. This will be
+                  `stop` if the model hit a natural stop point or a provided
+                  stop sequence,
+
+                  `length` if the maximum number of tokens specified in the
+                  request was reached,
+
+                  or `content_filter` if content was omitted due to a flag from
+                  our content filters.
+                enum:
+                  - stop
+                  - length
+                  - content_filter
+              index:
+                type: integer
+              logprobs:
+                type: object
+                nullable: true
+                properties:
+                  text_offset:
+                    type: array
+                    items:
+                      type: integer
+                  token_logprobs:
+                    type: array
+                    items:
+                      type: number
+                  tokens:
+                    type: array
+                    items:
+                      type: string
+                  top_logprobs:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties:
+                        type: number
+              text:
+                type: string
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the completion was created.
+        model:
+          type: string
+          description: The model used for completion.
+        system_fingerprint:
+          type: string
+          description: >
+            This fingerprint represents the backend configuration that the model
+            runs with.
+
+
+            Can be used in conjunction with the `seed` request parameter to
+            understand when backend changes have been made that might impact
+            determinism.
+        object:
+          type: string
+          description: The object type, which is always "text_completion"
+          enum:
+            - text_completion
+          x-stainless-const: true
+        usage:
+          $ref: "#/components/schemas/CompletionUsage"
+      required:
+        - id
+        - object
+        - created
+        - model
+        - choices
+      x-oaiMeta:
+        name: The completion object
+        legacy: true
+        example: |
+          {
+            "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+            "object": "text_completion",
+            "created": 1589478378,
+            "model": "gpt-4-turbo",
+            "choices": [
+              {
+                "text": "\n\nThis is indeed a test",
+                "index": 0,
+                "logprobs": null,
+                "finish_reason": "length"
+              }
+            ],
+            "usage": {
+              "prompt_tokens": 5,
+              "completion_tokens": 7,
+              "total_tokens": 12
+            }
+          }
+    CreateEmbeddingRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        input:
+          description: >
+            Input text to embed, encoded as a string or array of tokens. To
+            embed multiple inputs in a single request, pass an array of strings
+            or array of token arrays. The input must not exceed the max input
+            tokens for the model (8192 tokens for `text-embedding-ada-002`),
+            cannot be an empty string, and any array must be 2048 dimensions or
+            less. [Example Python
+            code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken)
+            for counting tokens. Some models may also impose a limit on total
+            number of tokens summed across inputs.
+          example: The quick brown fox jumped over the lazy dog
+          oneOf:
+            - type: string
+              title: string
+              description: The string that will be turned into an embedding.
+              default: ""
+              example: This is a test.
+            - type: array
+              title: array
+              description: The array of strings that will be turned into an embedding.
+              minItems: 1
+              maxItems: 2048
+              items:
+                type: string
+                default: ""
+                example: "['This is a test.']"
+            - type: array
+              title: array
+              description: The array of integers that will be turned into an embedding.
+              minItems: 1
+              maxItems: 2048
+              items:
+                type: integer
+              example: "[1212, 318, 257, 1332, 13]"
+            - type: array
+              title: array
+              description: The array of arrays containing integers that will be turned into an
+                embedding.
+              minItems: 1
+              maxItems: 2048
+              items:
+                type: array
+                minItems: 1
+                items:
+                  type: integer
+              example: "[[1212, 318, 257, 1332, 13]]"
+          x-oaiExpandable: true
+        model:
+          description: >
+            ID of the model to use. You can use the [List
+            models](/docs/api-reference/models/list) API to see all of your
+            available models, or see our [Model overview](/docs/models) for
+            descriptions of them.
+          example: text-embedding-3-small
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - text-embedding-ada-002
+                - text-embedding-3-small
+                - text-embedding-3-large
+          x-oaiTypeLabel: string
+        encoding_format:
+          description: The format to return the embeddings in. Can be either `float` or
+            [`base64`](https://pypi.org/project/pybase64/).
+          example: float
+          default: float
+          type: string
+          enum:
+            - float
+            - base64
+        dimensions:
+          description: >
+            The number of dimensions the resulting output embeddings should
+            have. Only supported in `text-embedding-3` and later models.
+          type: integer
+          minimum: 1
+        user:
+          type: string
+          example: user-1234
+          description: >
+            A unique identifier representing your end-user, which can help
+            OpenAI to monitor and detect abuse. [Learn
+            more](/docs/guides/safety-best-practices#end-user-ids).
+      required:
+        - model
+        - input
+    CreateEmbeddingResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          description: The list of embeddings generated by the model.
+          items:
+            $ref: "#/components/schemas/Embedding"
+        model:
+          type: string
+          description: The name of the model used to generate the embedding.
+        object:
+          type: string
+          description: The object type, which is always "list".
+          enum:
+            - list
+          x-stainless-const: true
+        usage:
+          type: object
+          description: The usage information for the request.
+          properties:
+            prompt_tokens:
+              type: integer
+              description: The number of tokens used by the prompt.
+            total_tokens:
+              type: integer
+              description: The total number of tokens used by the request.
+          required:
+            - prompt_tokens
+            - total_tokens
+      required:
+        - object
+        - model
+        - data
+        - usage
+    CreateFileRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        file:
+          description: |
+            The File object (not file name) to be uploaded.
+          type: string
+          format: binary
+        purpose:
+          description: >
+            The intended purpose of the uploaded file.
+
+
+            Use "assistants" for [Assistants](/docs/api-reference/assistants)
+            and [Message](/docs/api-reference/messages) files, "vision" for
+            Assistants image file inputs, "batch" for [Batch
+            API](/docs/guides/batch), and "fine-tune" for
+            [Fine-tuning](/docs/api-reference/fine-tuning).
+          type: string
+          enum:
+            - assistants
+            - batch
+            - fine-tune
+            - vision
+      required:
+        - file
+        - purpose
+    CreateFineTuningJobRequest:
+      type: object
+      properties:
+        model:
+          description: >
+            The name of the model to fine-tune. You can select one of the
+
+            [supported
+            models](/docs/guides/fine-tuning#which-models-can-be-fine-tuned).
+          example: gpt-4o-mini
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - babbage-002
+                - davinci-002
+                - gpt-3.5-turbo
+                - gpt-4o-mini
+          x-oaiTypeLabel: string
+        training_file:
+          description: >
+            The ID of an uploaded file that contains training data.
+
+
+            See [upload file](/docs/api-reference/files/create) for how to
+            upload a file.
+
+
+            Your dataset must be formatted as a JSONL file. Additionally, you
+            must upload your file with the purpose `fine-tune`.
+
+
+            The contents of the file should differ depending on if the model
+            uses the [chat](/docs/api-reference/fine-tuning/chat-input),
+            [completions](/docs/api-reference/fine-tuning/completions-input)
+            format, or if the fine-tuning method uses the
+            [preference](/docs/api-reference/fine-tuning/preference-input)
+            format.
+
+
+            See the [fine-tuning guide](/docs/guides/fine-tuning) for more
+            details.
+          type: string
+          example: file-abc123
+        hyperparameters:
+          type: object
+          description: >
+            The hyperparameters used for the fine-tuning job.
+
+            This value is now deprecated in favor of `method`, and should be
+            passed in under the `method` parameter.
+          properties:
+            batch_size:
+              description: >
+                Number of examples in each batch. A larger batch size means that
+                model parameters
+
+                are updated less frequently, but with lower variance.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: integer
+                  minimum: 1
+                  maximum: 256
+              default: auto
+            learning_rate_multiplier:
+              description: >
+                Scaling factor for the learning rate. A smaller learning rate
+                may be useful to avoid
+
+                overfitting.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: number
+                  minimum: 0
+                  exclusiveMinimum: true
+              default: auto
+            n_epochs:
+              description: >
+                The number of epochs to train the model for. An epoch refers to
+                one full cycle
+
+                through the training dataset.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: integer
+                  minimum: 1
+                  maximum: 50
+              default: auto
+          deprecated: true
+        suffix:
+          description: >
+            A string of up to 64 characters that will be added to your
+            fine-tuned model name.
+
+
+            For example, a `suffix` of "custom-model-name" would produce a model
+            name like `ft:gpt-4o-mini:openai:custom-model-name:7p4lURel`.
+          type: string
+          minLength: 1
+          maxLength: 64
+          default: null
+          nullable: true
+        validation_file:
+          description: >
+            The ID of an uploaded file that contains validation data.
+
+
+            If you provide this file, the data is used to generate validation
+
+            metrics periodically during fine-tuning. These metrics can be viewed
+            in
+
+            the fine-tuning results file.
+
+            The same data should not be present in both train and validation
+            files.
+
+
+            Your dataset must be formatted as a JSONL file. You must upload your
+            file with the purpose `fine-tune`.
+
+
+            See the [fine-tuning guide](/docs/guides/fine-tuning) for more
+            details.
+          type: string
+          nullable: true
+          example: file-abc123
+        integrations:
+          type: array
+          description: A list of integrations to enable for your fine-tuning job.
+          nullable: true
+          items:
+            type: object
+            required:
+              - type
+              - wandb
+            properties:
+              type:
+                description: >
+                  The type of integration to enable. Currently, only "wandb"
+                  (Weights and Biases) is supported.
+                oneOf:
+                  - type: string
+                    enum:
+                      - wandb
+                    x-stainless-const: true
+              wandb:
+                type: object
+                description: >
+                  The settings for your integration with Weights and Biases.
+                  This payload specifies the project that
+
+                  metrics will be sent to. Optionally, you can set an explicit
+                  display name for your run, add tags
+
+                  to your run, and set a default entity (team, username, etc) to
+                  be associated with your run.
+                required:
+                  - project
+                properties:
+                  project:
+                    description: >
+                      The name of the project that the new run will be created
+                      under.
+                    type: string
+                    example: my-wandb-project
+                  name:
+                    description: >
+                      A display name to set for the run. If not set, we will use
+                      the Job ID as the name.
+                    nullable: true
+                    type: string
+                  entity:
+                    description: >
+                      The entity to use for the run. This allows you to set the
+                      team or username of the WandB user that you would
+
+                      like associated with the run. If not set, the default
+                      entity for the registered WandB API key is used.
+                    nullable: true
+                    type: string
+                  tags:
+                    description: >
+                      A list of tags to be attached to the newly created run.
+                      These tags are passed through directly to WandB. Some
+
+                      default tags are generated by OpenAI: "openai/finetune",
+                      "openai/{base-model}", "openai/{ftjob-abcdef}".
+                    type: array
+                    items:
+                      type: string
+                      example: custom-tag
+        seed:
+          description: >
+            The seed controls the reproducibility of the job. Passing in the
+            same seed and job parameters should produce the same results, but
+            may differ in rare cases.
+
+            If a seed is not specified, one will be generated for you.
+          type: integer
+          nullable: true
+          minimum: 0
+          maximum: 2147483647
+          example: 42
+        method:
+          $ref: "#/components/schemas/FineTuneMethod"
+      required:
+        - model
+        - training_file
+    CreateImageEditRequest:
+      type: object
+      properties:
+        image:
+          description: The image to edit. Must be a valid PNG file, less than 4MB, and
+            square. If mask is not provided, image must have transparency, which
+            will be used as the mask.
+          type: string
+          format: binary
+        prompt:
+          description: A text description of the desired image(s). The maximum length is
+            1000 characters.
+          type: string
+          example: A cute baby sea otter wearing a beret
+        mask:
+          description: An additional image whose fully transparent areas (e.g. where alpha
+            is zero) indicate where `image` should be edited. Must be a valid
+            PNG file, less than 4MB, and have the same dimensions as `image`.
+          type: string
+          format: binary
+        model:
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - dall-e-2
+              x-stainless-const: true
+          x-oaiTypeLabel: string
+          default: dall-e-2
+          example: dall-e-2
+          nullable: true
+          description: The model to use for image generation. Only `dall-e-2` is supported
+            at this time.
+        n:
+          type: integer
+          minimum: 1
+          maximum: 10
+          default: 1
+          example: 1
+          nullable: true
+          description: The number of images to generate. Must be between 1 and 10.
+        size:
+          type: string
+          enum:
+            - 256x256
+            - 512x512
+            - 1024x1024
+          default: 1024x1024
+          example: 1024x1024
+          nullable: true
+          description: The size of the generated images. Must be one of `256x256`,
+            `512x512`, or `1024x1024`.
+        response_format:
+          type: string
+          enum:
+            - url
+            - b64_json
+          default: url
+          example: url
+          nullable: true
+          description: The format in which the generated images are returned. Must be one
+            of `url` or `b64_json`. URLs are only valid for 60 minutes after the
+            image has been generated.
+        user:
+          type: string
+          example: user-1234
+          description: >
+            A unique identifier representing your end-user, which can help
+            OpenAI to monitor and detect abuse. [Learn
+            more](/docs/guides/safety-best-practices#end-user-ids).
+      required:
+        - prompt
+        - image
+    CreateImageRequest:
+      type: object
+      properties:
+        prompt:
+          description: A text description of the desired image(s). The maximum length is
+            1000 characters for `dall-e-2` and 4000 characters for `dall-e-3`.
+          type: string
+          example: A cute baby sea otter
+        model:
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - dall-e-2
+                - dall-e-3
+          x-oaiTypeLabel: string
+          default: dall-e-2
+          example: dall-e-3
+          nullable: true
+          description: The model to use for image generation.
+        n:
+          type: integer
+          minimum: 1
+          maximum: 10
+          default: 1
+          example: 1
+          nullable: true
+          description: The number of images to generate. Must be between 1 and 10. For
+            `dall-e-3`, only `n=1` is supported.
+        quality:
+          type: string
+          enum:
+            - standard
+            - hd
+          default: standard
+          example: standard
+          description: The quality of the image that will be generated. `hd` creates
+            images with finer details and greater consistency across the image.
+            This param is only supported for `dall-e-3`.
+        response_format:
+          type: string
+          enum:
+            - url
+            - b64_json
+          default: url
+          example: url
+          nullable: true
+          description: The format in which the generated images are returned. Must be one
+            of `url` or `b64_json`. URLs are only valid for 60 minutes after the
+            image has been generated.
+        size:
+          type: string
+          enum:
+            - 256x256
+            - 512x512
+            - 1024x1024
+            - 1792x1024
+            - 1024x1792
+          default: 1024x1024
+          example: 1024x1024
+          nullable: true
+          description: The size of the generated images. Must be one of `256x256`,
+            `512x512`, or `1024x1024` for `dall-e-2`. Must be one of
+            `1024x1024`, `1792x1024`, or `1024x1792` for `dall-e-3` models.
+        style:
+          type: string
+          enum:
+            - vivid
+            - natural
+          default: vivid
+          example: vivid
+          nullable: true
+          description: The style of the generated images. Must be one of `vivid` or
+            `natural`. Vivid causes the model to lean towards generating
+            hyper-real and dramatic images. Natural causes the model to produce
+            more natural, less hyper-real looking images. This param is only
+            supported for `dall-e-3`.
+        user:
+          type: string
+          example: user-1234
+          description: >
+            A unique identifier representing your end-user, which can help
+            OpenAI to monitor and detect abuse. [Learn
+            more](/docs/guides/safety-best-practices#end-user-ids).
+      required:
+        - prompt
+    CreateImageVariationRequest:
+      type: object
+      properties:
+        image:
+          description: The image to use as the basis for the variation(s). Must be a valid
+            PNG file, less than 4MB, and square.
+          type: string
+          format: binary
+        model:
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - dall-e-2
+              x-stainless-const: true
+          x-oaiTypeLabel: string
+          default: dall-e-2
+          example: dall-e-2
+          nullable: true
+          description: The model to use for image generation. Only `dall-e-2` is supported
+            at this time.
+        n:
+          type: integer
+          minimum: 1
+          maximum: 10
+          default: 1
+          example: 1
+          nullable: true
+          description: The number of images to generate. Must be between 1 and 10. For
+            `dall-e-3`, only `n=1` is supported.
+        response_format:
+          type: string
+          enum:
+            - url
+            - b64_json
+          default: url
+          example: url
+          nullable: true
+          description: The format in which the generated images are returned. Must be one
+            of `url` or `b64_json`. URLs are only valid for 60 minutes after the
+            image has been generated.
+        size:
+          type: string
+          enum:
+            - 256x256
+            - 512x512
+            - 1024x1024
+          default: 1024x1024
+          example: 1024x1024
+          nullable: true
+          description: The size of the generated images. Must be one of `256x256`,
+            `512x512`, or `1024x1024`.
+        user:
+          type: string
+          example: user-1234
+          description: >
+            A unique identifier representing your end-user, which can help
+            OpenAI to monitor and detect abuse. [Learn
+            more](/docs/guides/safety-best-practices#end-user-ids).
+      required:
+        - image
+    CreateMessageRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - role
+        - content
+      properties:
+        role:
+          type: string
+          enum:
+            - user
+            - assistant
+          description: >
+            The role of the entity that is creating the message. Allowed values
+            include:
+
+            - `user`: Indicates the message is sent by an actual user and should
+            be used in most cases to represent user-generated messages.
+
+            - `assistant`: Indicates the message is generated by the assistant.
+            Use this value to insert messages from the assistant into the
+            conversation.
+        content:
+          oneOf:
+            - type: string
+              description: The text contents of the message.
+              title: Text content
+            - type: array
+              description: An array of content parts with a defined type, each can be of type
+                `text` or images can be passed with `image_url` or `image_file`.
+                Image types are only supported on [Vision-compatible
+                models](/docs/models).
+              title: Array of content parts
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/MessageContentImageFileObject"
+                  - $ref: "#/components/schemas/MessageContentImageUrlObject"
+                  - $ref: "#/components/schemas/MessageRequestContentTextObject"
+                x-oaiExpandable: true
+              minItems: 1
+          x-oaiExpandable: true
+        attachments:
+          type: array
+          items:
+            type: object
+            properties:
+              file_id:
+                type: string
+                description: The ID of the file to attach to the message.
+              tools:
+                description: The tools to add this file to.
+                type: array
+                items:
+                  oneOf:
+                    - $ref: "#/components/schemas/AssistantToolsCode"
+                    - $ref: "#/components/schemas/AssistantToolsFileSearchTypeOnly"
+                  x-oaiExpandable: true
+          description: A list of files attached to the message, and the tools they should
+            be added to.
+          required:
+            - file_id
+            - tools
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+    CreateModerationRequest:
+      type: object
+      properties:
+        input:
+          description: >
+            Input (or inputs) to classify. Can be a single string, an array of
+            strings, or
+
+            an array of multi-modal input objects similar to other models.
+          oneOf:
+            - type: string
+              description: A string of text to classify for moderation.
+              default: ""
+              example: I want to kill them.
+            - type: array
+              description: An array of strings to classify for moderation.
+              items:
+                type: string
+                default: ""
+                example: I want to kill them.
+            - type: array
+              description: An array of multi-modal inputs to the moderation model.
+              items:
+                x-oaiExpandable: true
+                oneOf:
+                  - type: object
+                    description: An object describing an image to classify.
+                    properties:
+                      type:
+                        description: Always `image_url`.
+                        type: string
+                        enum:
+                          - image_url
+                        x-stainless-const: true
+                      image_url:
+                        type: object
+                        description: Contains either an image URL or a data URL for a base64 encoded
+                          image.
+                        properties:
+                          url:
+                            type: string
+                            description: Either a URL of the image or the base64 encoded image data.
+                            format: uri
+                            example: https://example.com/image.jpg
+                        required:
+                          - url
+                    required:
+                      - type
+                      - image_url
+                  - type: object
+                    description: An object describing text to classify.
+                    properties:
+                      type:
+                        description: Always `text`.
+                        type: string
+                        enum:
+                          - text
+                        x-stainless-const: true
+                      text:
+                        description: A string of text to classify.
+                        type: string
+                        example: I want to kill them
+                    required:
+                      - type
+                      - text
+          x-oaiExpandable: true
+        model:
+          description: |
+            The content moderation model you would like to use. Learn more in
+            [the moderation guide](/docs/guides/moderation), and learn about
+            available models [here](/docs/models#moderation).
+          nullable: false
+          default: omni-moderation-latest
+          example: omni-moderation-2024-09-26
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - omni-moderation-latest
+                - omni-moderation-2024-09-26
+                - text-moderation-latest
+                - text-moderation-stable
+          x-oaiTypeLabel: string
+      required:
+        - input
+    CreateModerationResponse:
+      type: object
+      description: Represents if a given text input is potentially harmful.
+      properties:
+        id:
+          type: string
+          description: The unique identifier for the moderation request.
+        model:
+          type: string
+          description: The model used to generate the moderation results.
+        results:
+          type: array
+          description: A list of moderation objects.
+          items:
+            type: object
+            properties:
+              flagged:
+                type: boolean
+                description: Whether any of the below categories are flagged.
+              categories:
+                type: object
+                description: A list of the categories, and whether they are flagged or not.
+                properties:
+                  hate:
+                    type: boolean
+                    description: Content that expresses, incites, or promotes hate based on race,
+                      gender, ethnicity, religion, nationality, sexual
+                      orientation, disability status, or caste. Hateful content
+                      aimed at non-protected groups (e.g., chess players) is
+                      harassment.
+                  hate/threatening:
+                    type: boolean
+                    description: Hateful content that also includes violence or serious harm towards
+                      the targeted group based on race, gender, ethnicity,
+                      religion, nationality, sexual orientation, disability
+                      status, or caste.
+                  harassment:
+                    type: boolean
+                    description: Content that expresses, incites, or promotes harassing language
+                      towards any target.
+                  harassment/threatening:
+                    type: boolean
+                    description: Harassment content that also includes violence or serious harm
+                      towards any target.
+                  illicit:
+                    type: boolean
+                    description: Content that includes instructions or advice that facilitate the
+                      planning or execution of wrongdoing, or that gives advice
+                      or instruction on how to commit illicit acts. For example,
+                      "how to shoplift" would fit this category.
+                  illicit/violent:
+                    type: boolean
+                    description: Content that includes instructions or advice that facilitate the
+                      planning or execution of wrongdoing that also includes
+                      violence, or that gives advice or instruction on the
+                      procurement of any weapon.
+                  self-harm:
+                    type: boolean
+                    description: Content that promotes, encourages, or depicts acts of self-harm,
+                      such as suicide, cutting, and eating disorders.
+                  self-harm/intent:
+                    type: boolean
+                    description: Content where the speaker expresses that they are engaging or
+                      intend to engage in acts of self-harm, such as suicide,
+                      cutting, and eating disorders.
+                  self-harm/instructions:
+                    type: boolean
+                    description: Content that encourages performing acts of self-harm, such as
+                      suicide, cutting, and eating disorders, or that gives
+                      instructions or advice on how to commit such acts.
+                  sexual:
+                    type: boolean
+                    description: Content meant to arouse sexual excitement, such as the description
+                      of sexual activity, or that promotes sexual services
+                      (excluding sex education and wellness).
+                  sexual/minors:
+                    type: boolean
+                    description: Sexual content that includes an individual who is under 18 years
+                      old.
+                  violence:
+                    type: boolean
+                    description: Content that depicts death, violence, or physical injury.
+                  violence/graphic:
+                    type: boolean
+                    description: Content that depicts death, violence, or physical injury in graphic
+                      detail.
+                required:
+                  - hate
+                  - hate/threatening
+                  - harassment
+                  - harassment/threatening
+                  - illicit
+                  - illicit/violent
+                  - self-harm
+                  - self-harm/intent
+                  - self-harm/instructions
+                  - sexual
+                  - sexual/minors
+                  - violence
+                  - violence/graphic
+              category_scores:
+                type: object
+                description: A list of the categories along with their scores as predicted by
+                  model.
+                properties:
+                  hate:
+                    type: number
+                    description: The score for the category 'hate'.
+                  hate/threatening:
+                    type: number
+                    description: The score for the category 'hate/threatening'.
+                  harassment:
+                    type: number
+                    description: The score for the category 'harassment'.
+                  harassment/threatening:
+                    type: number
+                    description: The score for the category 'harassment/threatening'.
+                  illicit:
+                    type: number
+                    description: The score for the category 'illicit'.
+                  illicit/violent:
+                    type: number
+                    description: The score for the category 'illicit/violent'.
+                  self-harm:
+                    type: number
+                    description: The score for the category 'self-harm'.
+                  self-harm/intent:
+                    type: number
+                    description: The score for the category 'self-harm/intent'.
+                  self-harm/instructions:
+                    type: number
+                    description: The score for the category 'self-harm/instructions'.
+                  sexual:
+                    type: number
+                    description: The score for the category 'sexual'.
+                  sexual/minors:
+                    type: number
+                    description: The score for the category 'sexual/minors'.
+                  violence:
+                    type: number
+                    description: The score for the category 'violence'.
+                  violence/graphic:
+                    type: number
+                    description: The score for the category 'violence/graphic'.
+                required:
+                  - hate
+                  - hate/threatening
+                  - harassment
+                  - harassment/threatening
+                  - illicit
+                  - illicit/violent
+                  - self-harm
+                  - self-harm/intent
+                  - self-harm/instructions
+                  - sexual
+                  - sexual/minors
+                  - violence
+                  - violence/graphic
+              category_applied_input_types:
+                type: object
+                description: A list of the categories along with the input type(s) that the
+                  score applies to.
+                properties:
+                  hate:
+                    type: array
+                    description: The applied input type(s) for the category 'hate'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                      x-stainless-const: true
+                  hate/threatening:
+                    type: array
+                    description: The applied input type(s) for the category 'hate/threatening'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                      x-stainless-const: true
+                  harassment:
+                    type: array
+                    description: The applied input type(s) for the category 'harassment'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                      x-stainless-const: true
+                  harassment/threatening:
+                    type: array
+                    description: The applied input type(s) for the category
+                      'harassment/threatening'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                      x-stainless-const: true
+                  illicit:
+                    type: array
+                    description: The applied input type(s) for the category 'illicit'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                      x-stainless-const: true
+                  illicit/violent:
+                    type: array
+                    description: The applied input type(s) for the category 'illicit/violent'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                      x-stainless-const: true
+                  self-harm:
+                    type: array
+                    description: The applied input type(s) for the category 'self-harm'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                        - image
+                  self-harm/intent:
+                    type: array
+                    description: The applied input type(s) for the category 'self-harm/intent'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                        - image
+                  self-harm/instructions:
+                    type: array
+                    description: The applied input type(s) for the category
+                      'self-harm/instructions'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                        - image
+                  sexual:
+                    type: array
+                    description: The applied input type(s) for the category 'sexual'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                        - image
+                  sexual/minors:
+                    type: array
+                    description: The applied input type(s) for the category 'sexual/minors'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                      x-stainless-const: true
+                  violence:
+                    type: array
+                    description: The applied input type(s) for the category 'violence'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                        - image
+                  violence/graphic:
+                    type: array
+                    description: The applied input type(s) for the category 'violence/graphic'.
+                    items:
+                      type: string
+                      enum:
+                        - text
+                        - image
+                required:
+                  - hate
+                  - hate/threatening
+                  - harassment
+                  - harassment/threatening
+                  - illicit
+                  - illicit/violent
+                  - self-harm
+                  - self-harm/intent
+                  - self-harm/instructions
+                  - sexual
+                  - sexual/minors
+                  - violence
+                  - violence/graphic
+            required:
+              - flagged
+              - categories
+              - category_scores
+              - category_applied_input_types
+      required:
+        - id
+        - model
+        - results
+      x-oaiMeta:
+        name: The moderation object
+        example: |
+          {
+            "id": "modr-0d9740456c391e43c445bf0f010940c7",
+            "model": "omni-moderation-latest",
+            "results": [
+              {
+                "flagged": true,
+                "categories": {
+                  "harassment": true,
+                  "harassment/threatening": true,
+                  "sexual": false,
+                  "hate": false,
+                  "hate/threatening": false,
+                  "illicit": false,
+                  "illicit/violent": false,
+                  "self-harm/intent": false,
+                  "self-harm/instructions": false,
+                  "self-harm": false,
+                  "sexual/minors": false,
+                  "violence": true,
+                  "violence/graphic": true
+                },
+                "category_scores": {
+                  "harassment": 0.8189693396524255,
+                  "harassment/threatening": 0.804985420696006,
+                  "sexual": 1.573112165348997e-6,
+                  "hate": 0.007562942636942845,
+                  "hate/threatening": 0.004208854591835476,
+                  "illicit": 0.030535955153511665,
+                  "illicit/violent": 0.008925306722380033,
+                  "self-harm/intent": 0.00023023930975076432,
+                  "self-harm/instructions": 0.0002293869201073356,
+                  "self-harm": 0.012598046106750154,
+                  "sexual/minors": 2.212566909570261e-8,
+                  "violence": 0.9999992735124786,
+                  "violence/graphic": 0.843064871157054
+                },
+                "category_applied_input_types": {
+                  "harassment": [
+                    "text"
+                  ],
+                  "harassment/threatening": [
+                    "text"
+                  ],
+                  "sexual": [
+                    "text",
+                    "image"
+                  ],
+                  "hate": [
+                    "text"
+                  ],
+                  "hate/threatening": [
+                    "text"
+                  ],
+                  "illicit": [
+                    "text"
+                  ],
+                  "illicit/violent": [
+                    "text"
+                  ],
+                  "self-harm/intent": [
+                    "text",
+                    "image"
+                  ],
+                  "self-harm/instructions": [
+                    "text",
+                    "image"
+                  ],
+                  "self-harm": [
+                    "text",
+                    "image"
+                  ],
+                  "sexual/minors": [
+                    "text"
+                  ],
+                  "violence": [
+                    "text",
+                    "image"
+                  ],
+                  "violence/graphic": [
+                    "text",
+                    "image"
+                  ]
+                }
+              }
+            ]
+          }
+    CreateRunRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        assistant_id:
+          description: The ID of the [assistant](/docs/api-reference/assistants) to use to
+            execute this run.
+          type: string
+        model:
+          description: The ID of the [Model](/docs/api-reference/models) to be used to
+            execute this run. If a value is provided here, it will override the
+            model associated with the assistant. If not, the model associated
+            with the assistant will be used.
+          example: gpt-4o
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - gpt-4o
+                - gpt-4o-2024-11-20
+                - gpt-4o-2024-08-06
+                - gpt-4o-2024-05-13
+                - gpt-4o-mini
+                - gpt-4o-mini-2024-07-18
+                - gpt-4-turbo
+                - gpt-4-turbo-2024-04-09
+                - gpt-4-0125-preview
+                - gpt-4-turbo-preview
+                - gpt-4-1106-preview
+                - gpt-4-vision-preview
+                - gpt-4
+                - gpt-4-0314
+                - gpt-4-0613
+                - gpt-4-32k
+                - gpt-4-32k-0314
+                - gpt-4-32k-0613
+                - gpt-3.5-turbo
+                - gpt-3.5-turbo-16k
+                - gpt-3.5-turbo-0613
+                - gpt-3.5-turbo-1106
+                - gpt-3.5-turbo-0125
+                - gpt-3.5-turbo-16k-0613
+          x-oaiTypeLabel: string
+          nullable: true
+        instructions:
+          description: Overrides the
+            [instructions](/docs/api-reference/assistants/createAssistant) of
+            the assistant. This is useful for modifying the behavior on a
+            per-run basis.
+          type: string
+          nullable: true
+        additional_instructions:
+          description: Appends additional instructions at the end of the instructions for
+            the run. This is useful for modifying the behavior on a per-run
+            basis without overriding other instructions.
+          type: string
+          nullable: true
+        additional_messages:
+          description: Adds additional messages to the thread before creating the run.
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateMessageRequest"
+          nullable: true
+        tools:
+          description: Override the tools the assistant can use for this run. This is
+            useful for modifying the behavior on a per-run basis.
+          nullable: true
+          type: array
+          maxItems: 20
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/AssistantToolsCode"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
+              - $ref: "#/components/schemas/AssistantToolsFunction"
+            x-oaiExpandable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            What sampling temperature to use, between 0 and 2. Higher values
+            like 0.8 will make the output more random, while lower values like
+            0.2 will make it more focused and deterministic.
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            An alternative to sampling with temperature, called nucleus
+            sampling, where the model considers the results of the tokens with
+            top_p probability mass. So 0.1 means only the tokens comprising the
+            top 10% probability mass are considered.
+
+
+            We generally recommend altering this or temperature but not both.
+        stream:
+          type: boolean
+          nullable: true
+          description: >
+            If `true`, returns a stream of events that happen during the Run as
+            server-sent events, terminating when the Run enters a terminal state
+            with a `data: [DONE]` message.
+        max_prompt_tokens:
+          type: integer
+          nullable: true
+          description: >
+            The maximum number of prompt tokens that may be used over the course
+            of the run. The run will make a best effort to use only the number
+            of prompt tokens specified, across multiple turns of the run. If the
+            run exceeds the number of prompt tokens specified, the run will end
+            with status `incomplete`. See `incomplete_details` for more info.
+          minimum: 256
+        max_completion_tokens:
+          type: integer
+          nullable: true
+          description: >
+            The maximum number of completion tokens that may be used over the
+            course of the run. The run will make a best effort to use only the
+            number of completion tokens specified, across multiple turns of the
+            run. If the run exceeds the number of completion tokens specified,
+            the run will end with status `incomplete`. See `incomplete_details`
+            for more info.
+          minimum: 256
+        truncation_strategy:
+          allOf:
+            - $ref: "#/components/schemas/TruncationObject"
+            - nullable: true
+        tool_choice:
+          allOf:
+            - $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+            - nullable: true
+        parallel_tool_calls:
+          $ref: "#/components/schemas/ParallelToolCalls"
+        response_format:
+          allOf:
+            - $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+            - nullable: true
+      required:
+        - assistant_id
+    CreateSpeechRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        model:
+          description: >
+            One of the available [TTS models](/docs/models#tts): `tts-1` or
+            `tts-1-hd`
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - tts-1
+                - tts-1-hd
+          x-oaiTypeLabel: string
+        input:
+          type: string
+          description: The text to generate audio for. The maximum length is 4096
+            characters.
+          maxLength: 4096
+        voice:
+          description: The voice to use when generating the audio. Supported voices are
+            `alloy`, `ash`, `coral`, `echo`, `fable`, `onyx`, `nova`, `sage` and
+            `shimmer`. Previews of the voices are available in the [Text to
+            speech guide](/docs/guides/text-to-speech#voice-options).
+          type: string
+          enum:
+            - alloy
+            - ash
+            - coral
+            - echo
+            - fable
+            - onyx
+            - nova
+            - sage
+            - shimmer
+        response_format:
+          description: The format to audio in. Supported formats are `mp3`, `opus`, `aac`,
+            `flac`, `wav`, and `pcm`.
+          default: mp3
+          type: string
+          enum:
+            - mp3
+            - opus
+            - aac
+            - flac
+            - wav
+            - pcm
+        speed:
+          description: The speed of the generated audio. Select a value from `0.25` to
+            `4.0`. `1.0` is the default.
+          type: number
+          default: 1
+          minimum: 0.25
+          maximum: 4
+      required:
+        - model
+        - input
+        - voice
+    CreateThreadAndRunRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        assistant_id:
+          description: The ID of the [assistant](/docs/api-reference/assistants) to use to
+            execute this run.
+          type: string
+        thread:
+          $ref: "#/components/schemas/CreateThreadRequest"
+        model:
+          description: The ID of the [Model](/docs/api-reference/models) to be used to
+            execute this run. If a value is provided here, it will override the
+            model associated with the assistant. If not, the model associated
+            with the assistant will be used.
+          example: gpt-4o
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - gpt-4o
+                - gpt-4o-2024-11-20
+                - gpt-4o-2024-08-06
+                - gpt-4o-2024-05-13
+                - gpt-4o-mini
+                - gpt-4o-mini-2024-07-18
+                - gpt-4-turbo
+                - gpt-4-turbo-2024-04-09
+                - gpt-4-0125-preview
+                - gpt-4-turbo-preview
+                - gpt-4-1106-preview
+                - gpt-4-vision-preview
+                - gpt-4
+                - gpt-4-0314
+                - gpt-4-0613
+                - gpt-4-32k
+                - gpt-4-32k-0314
+                - gpt-4-32k-0613
+                - gpt-3.5-turbo
+                - gpt-3.5-turbo-16k
+                - gpt-3.5-turbo-0613
+                - gpt-3.5-turbo-1106
+                - gpt-3.5-turbo-0125
+                - gpt-3.5-turbo-16k-0613
+          x-oaiTypeLabel: string
+          nullable: true
+        instructions:
+          description: Override the default system message of the assistant. This is
+            useful for modifying the behavior on a per-run basis.
+          type: string
+          nullable: true
+        tools:
+          description: Override the tools the assistant can use for this run. This is
+            useful for modifying the behavior on a per-run basis.
+          nullable: true
+          type: array
+          maxItems: 20
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/AssistantToolsCode"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
+              - $ref: "#/components/schemas/AssistantToolsFunction"
+        tool_resources:
+          type: object
+          description: >
+            A set of resources that are used by the assistant's tools. The
+            resources are specific to the type of tool. For example, the
+            `code_interpreter` tool requires a list of file IDs, while the
+            `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: >
+                    A list of [file](/docs/api-reference/files) IDs made
+                    available to the `code_interpreter` tool. There can be a
+                    maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: >
+                    The ID of the [vector
+                    store](/docs/api-reference/vector-stores/object) attached to
+                    this assistant. There can be a maximum of 1 vector store
+                    attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            What sampling temperature to use, between 0 and 2. Higher values
+            like 0.8 will make the output more random, while lower values like
+            0.2 will make it more focused and deterministic.
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            An alternative to sampling with temperature, called nucleus
+            sampling, where the model considers the results of the tokens with
+            top_p probability mass. So 0.1 means only the tokens comprising the
+            top 10% probability mass are considered.
+
+
+            We generally recommend altering this or temperature but not both.
+        stream:
+          type: boolean
+          nullable: true
+          description: >
+            If `true`, returns a stream of events that happen during the Run as
+            server-sent events, terminating when the Run enters a terminal state
+            with a `data: [DONE]` message.
+        max_prompt_tokens:
+          type: integer
+          nullable: true
+          description: >
+            The maximum number of prompt tokens that may be used over the course
+            of the run. The run will make a best effort to use only the number
+            of prompt tokens specified, across multiple turns of the run. If the
+            run exceeds the number of prompt tokens specified, the run will end
+            with status `incomplete`. See `incomplete_details` for more info.
+          minimum: 256
+        max_completion_tokens:
+          type: integer
+          nullable: true
+          description: >
+            The maximum number of completion tokens that may be used over the
+            course of the run. The run will make a best effort to use only the
+            number of completion tokens specified, across multiple turns of the
+            run. If the run exceeds the number of completion tokens specified,
+            the run will end with status `incomplete`. See `incomplete_details`
+            for more info.
+          minimum: 256
+        truncation_strategy:
+          allOf:
+            - $ref: "#/components/schemas/TruncationObject"
+            - nullable: true
+        tool_choice:
+          allOf:
+            - $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+            - nullable: true
+        parallel_tool_calls:
+          $ref: "#/components/schemas/ParallelToolCalls"
+        response_format:
+          allOf:
+            - $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+            - nullable: true
+      required:
+        - assistant_id
+    CreateThreadRequest:
+      type: object
+      description: |
+        Options to create a new thread. If no thread is provided when running a 
+        request, an empty thread will be created.
+      additionalProperties: false
+      properties:
+        messages:
+          description: A list of [messages](/docs/api-reference/messages) to start the
+            thread with.
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateMessageRequest"
+        tool_resources:
+          type: object
+          description: >
+            A set of resources that are made available to the assistant's tools
+            in this thread. The resources are specific to the type of tool. For
+            example, the `code_interpreter` tool requires a list of file IDs,
+            while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: >
+                    A list of [file](/docs/api-reference/files) IDs made
+                    available to the `code_interpreter` tool. There can be a
+                    maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: >
+                    The [vector store](/docs/api-reference/vector-stores/object)
+                    attached to this thread. There can be a maximum of 1 vector
+                    store attached to the thread.
+                  maxItems: 1
+                  items:
+                    type: string
+                vector_stores:
+                  type: array
+                  description: >
+                    A helper to create a [vector
+                    store](/docs/api-reference/vector-stores/object) with
+                    file_ids and attach it to this thread. There can be a
+                    maximum of 1 vector store attached to the thread.
+                  maxItems: 1
+                  items:
+                    type: object
+                    properties:
+                      file_ids:
+                        type: array
+                        description: >
+                          A list of [file](/docs/api-reference/files) IDs to add
+                          to the vector store. There can be a maximum of 10000
+                          files in a vector store.
+                        maxItems: 10000
+                        items:
+                          type: string
+                      chunking_strategy:
+                        type: object
+                        description: The chunking strategy used to chunk the file(s). If not set, will
+                          use the `auto` strategy.
+                        oneOf:
+                          - type: object
+                            title: Auto Chunking Strategy
+                            description: The default strategy. This strategy currently uses a
+                              `max_chunk_size_tokens` of `800` and
+                              `chunk_overlap_tokens` of `400`.
+                            additionalProperties: false
+                            properties:
+                              type:
+                                type: string
+                                description: Always `auto`.
+                                enum:
+                                  - auto
+                                x-stainless-const: true
+                            required:
+                              - type
+                          - type: object
+                            title: Static Chunking Strategy
+                            additionalProperties: false
+                            properties:
+                              type:
+                                type: string
+                                description: Always `static`.
+                                enum:
+                                  - static
+                                x-stainless-const: true
+                              static:
+                                type: object
+                                additionalProperties: false
+                                properties:
+                                  max_chunk_size_tokens:
+                                    type: integer
+                                    minimum: 100
+                                    maximum: 4096
+                                    description: The maximum number of tokens in each chunk. The default value is
+                                      `800`. The minimum value is `100` and the
+                                      maximum value is `4096`.
+                                  chunk_overlap_tokens:
+                                    type: integer
+                                    description: >
+                                      The number of tokens that overlap between
+                                      chunks. The default value is `400`.
+
+
+                                      Note that the overlap must not exceed half
+                                      of `max_chunk_size_tokens`.
+                                required:
+                                  - max_chunk_size_tokens
+                                  - chunk_overlap_tokens
+                            required:
+                              - type
+                              - static
+                        x-oaiExpandable: true
+                      metadata:
+                        type: object
+                        description: >
+                          Set of 16 key-value pairs that can be attached to a
+                          vector store. This can be useful for storing
+                          additional information about the vector store in a
+                          structured format. Keys can be a maximum of 64
+                          characters long and values can be a maximum of 512
+                          characters long.
+                        x-oaiTypeLabel: map
+                    x-oaiExpandable: true
+              oneOf:
+                - required:
+                    - vector_store_ids
+                - required:
+                    - vector_stores
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+    CreateTranscriptionRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        file:
+          description: >
+            The audio file object (not file name) to transcribe, in one of these
+            formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+          type: string
+          x-oaiTypeLabel: file
+          format: binary
+        model:
+          description: >
+            ID of the model to use. Only `whisper-1` (which is powered by our
+            open source Whisper V2 model) is currently available.
+          example: whisper-1
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - whisper-1
+              x-stainless-const: true
+          x-oaiTypeLabel: string
+        language:
+          description: >
+            The language of the input audio. Supplying the input language in
+            [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+            format will improve accuracy and latency.
+          type: string
+        prompt:
+          description: >
+            An optional text to guide the model's style or continue a previous
+            audio segment. The [prompt](/docs/guides/speech-to-text#prompting)
+            should match the audio language.
+          type: string
+        response_format:
+          $ref: "#/components/schemas/AudioResponseFormat"
+        temperature:
+          description: >
+            The sampling temperature, between 0 and 1. Higher values like 0.8
+            will make the output more random, while lower values like 0.2 will
+            make it more focused and deterministic. If set to 0, the model will
+            use [log probability](https://en.wikipedia.org/wiki/Log_probability)
+            to automatically increase the temperature until certain thresholds
+            are hit.
+          type: number
+          default: 0
+        timestamp_granularities[]:
+          description: >
+            The timestamp granularities to populate for this transcription.
+            `response_format` must be set `verbose_json` to use timestamp
+            granularities. Either or both of these options are supported:
+            `word`, or `segment`. Note: There is no additional latency for
+            segment timestamps, but generating word timestamps incurs additional
+            latency.
+          type: array
+          items:
+            type: string
+            enum:
+              - word
+              - segment
+          default:
+            - segment
+      required:
+        - file
+        - model
+    CreateTranscriptionResponseJson:
+      type: object
+      description: Represents a transcription response returned by model, based on the
+        provided input.
+      properties:
+        text:
+          type: string
+          description: The transcribed text.
+      required:
+        - text
+      x-oaiMeta:
+        name: The transcription object (JSON)
+        group: audio
+        example: >
+          {
+            "text": "Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that."
+          }
+    CreateTranscriptionResponseVerboseJson:
+      type: object
+      description: Represents a verbose json transcription response returned by model,
+        based on the provided input.
+      properties:
+        language:
+          type: string
+          description: The language of the input audio.
+        duration:
+          type: string
+          description: The duration of the input audio.
+        text:
+          type: string
+          description: The transcribed text.
+        words:
+          type: array
+          description: Extracted words and their corresponding timestamps.
+          items:
+            $ref: "#/components/schemas/TranscriptionWord"
+        segments:
+          type: array
+          description: Segments of the transcribed text and their corresponding details.
+          items:
+            $ref: "#/components/schemas/TranscriptionSegment"
+      required:
+        - language
+        - duration
+        - text
+      x-oaiMeta:
+        name: The transcription object (Verbose JSON)
+        group: audio
+        example: >
+          {
+            "task": "transcribe",
+            "language": "english",
+            "duration": 8.470000267028809,
+            "text": "The beach was a popular spot on a hot summer day. People were swimming in the ocean, building sandcastles, and playing beach volleyball.",
+            "segments": [
+              {
+                "id": 0,
+                "seek": 0,
+                "start": 0.0,
+                "end": 3.319999933242798,
+                "text": " The beach was a popular spot on a hot summer day.",
+                "tokens": [
+                  50364, 440, 7534, 390, 257, 3743, 4008, 322, 257, 2368, 4266, 786, 13, 50530
+                ],
+                "temperature": 0.0,
+                "avg_logprob": -0.2860786020755768,
+                "compression_ratio": 1.2363636493682861,
+                "no_speech_prob": 0.00985979475080967
+              },
+              ...
+            ]
+          }
+    CreateTranslationRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        file:
+          description: >
+            The audio file object (not file name) translate, in one of these
+            formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+          type: string
+          x-oaiTypeLabel: file
+          format: binary
+        model:
+          description: >
+            ID of the model to use. Only `whisper-1` (which is powered by our
+            open source Whisper V2 model) is currently available.
+          example: whisper-1
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - whisper-1
+              x-stainless-const: true
+          x-oaiTypeLabel: string
+        prompt:
+          description: >
+            An optional text to guide the model's style or continue a previous
+            audio segment. The [prompt](/docs/guides/speech-to-text#prompting)
+            should be in English.
+          type: string
+        response_format:
+          $ref: "#/components/schemas/AudioResponseFormat"
+        temperature:
+          description: >
+            The sampling temperature, between 0 and 1. Higher values like 0.8
+            will make the output more random, while lower values like 0.2 will
+            make it more focused and deterministic. If set to 0, the model will
+            use [log probability](https://en.wikipedia.org/wiki/Log_probability)
+            to automatically increase the temperature until certain thresholds
+            are hit.
+          type: number
+          default: 0
+      required:
+        - file
+        - model
+    CreateTranslationResponseJson:
+      type: object
+      properties:
+        text:
+          type: string
+      required:
+        - text
+    CreateTranslationResponseVerboseJson:
+      type: object
+      properties:
+        language:
+          type: string
+          description: The language of the output translation (always `english`).
+        duration:
+          type: string
+          description: The duration of the input audio.
+        text:
+          type: string
+          description: The translated text.
+        segments:
+          type: array
+          description: Segments of the translated text and their corresponding details.
+          items:
+            $ref: "#/components/schemas/TranscriptionSegment"
+      required:
+        - language
+        - duration
+        - text
+    CreateUploadRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        filename:
+          description: |
+            The name of the file to upload.
+          type: string
+        purpose:
+          description: >
+            The intended purpose of the uploaded file.
+
+
+            See the [documentation on File
+            purposes](/docs/api-reference/files/create#files-create-purpose).
+          type: string
+          enum:
+            - assistants
+            - batch
+            - fine-tune
+            - vision
+        bytes:
+          description: |
+            The number of bytes in the file you are uploading.
+          type: integer
+        mime_type:
+          description: >
+            The MIME type of the file.
+
+
+            This must fall within the supported MIME types for your file
+            purpose. See the supported MIME types for assistants and vision.
+          type: string
+      required:
+        - filename
+        - purpose
+        - bytes
+        - mime_type
+    CreateVectorStoreFileBatchRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        file_ids:
+          description: A list of [File](/docs/api-reference/files) IDs that the vector
+            store should use. Useful for tools like `file_search` that can
+            access files.
+          type: array
+          minItems: 1
+          maxItems: 500
+          items:
+            type: string
+        chunking_strategy:
+          $ref: "#/components/schemas/ChunkingStrategyRequestParam"
+      required:
+        - file_ids
+    CreateVectorStoreFileRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        file_id:
+          description: A [File](/docs/api-reference/files) ID that the vector store should
+            use. Useful for tools like `file_search` that can access files.
+          type: string
+        chunking_strategy:
+          $ref: "#/components/schemas/ChunkingStrategyRequestParam"
+      required:
+        - file_id
+    CreateVectorStoreRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        file_ids:
+          description: A list of [File](/docs/api-reference/files) IDs that the vector
+            store should use. Useful for tools like `file_search` that can
+            access files.
+          type: array
+          maxItems: 500
+          items:
+            type: string
+        name:
+          description: The name of the vector store.
+          type: string
+        expires_after:
+          $ref: "#/components/schemas/VectorStoreExpirationAfter"
+        chunking_strategy:
+          type: object
+          description: The chunking strategy used to chunk the file(s). If not set, will
+            use the `auto` strategy. Only applicable if `file_ids` is non-empty.
+          oneOf:
+            - $ref: "#/components/schemas/AutoChunkingStrategyRequestParam"
+            - $ref: "#/components/schemas/StaticChunkingStrategyRequestParam"
+          x-oaiExpandable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+    DefaultProjectErrorResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+      required:
+        - code
+        - message
+    DeleteAssistantResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        deleted:
+          type: boolean
+        object:
+          type: string
+          enum:
+            - assistant.deleted
+          x-stainless-const: true
+      required:
+        - id
+        - object
+        - deleted
+    DeleteFileResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        object:
+          type: string
+          enum:
+            - file
+          x-stainless-const: true
+        deleted:
+          type: boolean
+      required:
+        - id
+        - object
+        - deleted
+    DeleteMessageResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        deleted:
+          type: boolean
+        object:
+          type: string
+          enum:
+            - thread.message.deleted
+          x-stainless-const: true
+      required:
+        - id
+        - object
+        - deleted
+    DeleteModelResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        deleted:
+          type: boolean
+        object:
+          type: string
+      required:
+        - id
+        - object
+        - deleted
+    DeleteThreadResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        deleted:
+          type: boolean
+        object:
+          type: string
+          enum:
+            - thread.deleted
+          x-stainless-const: true
+      required:
+        - id
+        - object
+        - deleted
+    DeleteVectorStoreFileResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        deleted:
+          type: boolean
+        object:
+          type: string
+          enum:
+            - vector_store.file.deleted
+          x-stainless-const: true
+      required:
+        - id
+        - object
+        - deleted
+    DeleteVectorStoreResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        deleted:
+          type: boolean
+        object:
+          type: string
+          enum:
+            - vector_store.deleted
+          x-stainless-const: true
+      required:
+        - id
+        - object
+        - deleted
+    DoneEvent:
+      type: object
+      properties:
+        event:
+          type: string
+          enum:
+            - done
+          x-stainless-const: true
+        data:
+          type: string
+          enum:
+            - "[DONE]"
+          x-stainless-const: true
+      required:
+        - event
+        - data
+      description: Occurs when a stream ends.
+      x-oaiMeta:
+        dataDescription: "`data` is `[DONE]`"
+    Embedding:
+      type: object
+      description: |
+        Represents an embedding vector returned by embedding endpoint.
+      properties:
+        index:
+          type: integer
+          description: The index of the embedding in the list of embeddings.
+        embedding:
+          type: array
+          description: >
+            The embedding vector, which is a list of floats. The length of
+            vector depends on the model as listed in the [embedding
+            guide](/docs/guides/embeddings).
+          items:
+            type: number
+        object:
+          type: string
+          description: The object type, which is always "embedding".
+          enum:
+            - embedding
+          x-stainless-const: true
+      required:
+        - index
+        - object
+        - embedding
+      x-oaiMeta:
+        name: The embedding object
+        example: |
+          {
+            "object": "embedding",
+            "embedding": [
+              0.0023064255,
+              -0.009327292,
+              .... (1536 floats total for ada-002)
+              -0.0028842222,
+            ],
+            "index": 0
+          }
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+          nullable: true
+        message:
+          type: string
+          nullable: false
+        param:
+          type: string
+          nullable: true
+        type:
+          type: string
+          nullable: false
+      required:
+        - type
+        - message
+        - param
+        - code
+    ErrorEvent:
+      type: object
+      properties:
+        event:
+          type: string
+          enum:
+            - error
+          x-stainless-const: true
+        data:
+          $ref: "#/components/schemas/Error"
+      required:
+        - event
+        - data
+      description: Occurs when an [error](/docs/guides/error-codes#api-errors) occurs.
+        This can happen due to an internal server error or a timeout.
+      x-oaiMeta:
+        dataDescription: "`data` is an [error](/docs/guides/error-codes#api-errors)"
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          $ref: "#/components/schemas/Error"
+      required:
+        - error
+    FileSearchRankingOptions:
+      title: File search tool call ranking options
+      type: object
+      description: >
+        The ranking options for the file search. If not specified, the file
+        search tool will use the `auto` ranker and a score_threshold of 0.
+
+
+        See the [file search tool
+        documentation](/docs/assistants/tools/file-search#customizing-file-search-settings)
+        for more information.
+      properties:
+        ranker:
+          type: string
+          description: The ranker to use for the file search. If not specified will use
+            the `auto` ranker.
+          enum:
+            - auto
+            - default_2024_08_21
+        score_threshold:
+          type: number
+          description: The score threshold for the file search. All values must be a
+            floating point number between 0 and 1.
+          minimum: 0
+          maximum: 1
+      required:
+        - score_threshold
+    FineTuneChatCompletionRequestAssistantMessage:
+      allOf:
+        - type: object
+          title: Assistant message
+          deprecated: false
+          properties:
+            weight:
+              type: integer
+              enum:
+                - 0
+                - 1
+              description: Controls whether the assistant message is trained against (0 or 1)
+        - $ref: "#/components/schemas/ChatCompletionRequestAssistantMessage"
+      required:
+        - role
+    FineTuneChatRequestInput:
+      type: object
+      description: The per-line training example of a fine-tuning input file for chat
+        models using the supervised method.
+      properties:
+        messages:
+          type: array
+          minItems: 1
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/ChatCompletionRequestSystemMessage"
+              - $ref: "#/components/schemas/ChatCompletionRequestUserMessage"
+              - $ref: "#/components/schemas/FineTuneChatCompletionRequestAssistantMessage"
+              - $ref: "#/components/schemas/ChatCompletionRequestToolMessage"
+              - $ref: "#/components/schemas/ChatCompletionRequestFunctionMessage"
+            x-oaiExpandable: true
+        tools:
+          type: array
+          description: A list of tools the model may generate JSON inputs for.
+          items:
+            $ref: "#/components/schemas/ChatCompletionTool"
+        parallel_tool_calls:
+          $ref: "#/components/schemas/ParallelToolCalls"
+        functions:
+          deprecated: true
+          description: A list of functions the model may generate JSON inputs for.
+          type: array
+          minItems: 1
+          maxItems: 128
+          items:
+            $ref: "#/components/schemas/ChatCompletionFunctions"
+      x-oaiMeta:
+        name: Training format for chat models using the supervised method
+        example: >
+          {
+            "messages": [
+              { "role": "user", "content": "What is the weather in San Francisco?" },
+              {
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "id": "call_id",
+                    "type": "function",
+                    "function": {
+                      "name": "get_current_weather",
+                      "arguments": "{\"location\": \"San Francisco, USA\", \"format\": \"celsius\"}"
+                    }
+                  }
+                ]
+              }
+            ],
+            "parallel_tool_calls": false,
+            "tools": [
+              {
+                "type": "function",
+                "function": {
+                  "name": "get_current_weather",
+                  "description": "Get the current weather",
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "location": {
+                          "type": "string",
+                          "description": "The city and country, eg. San Francisco, USA"
+                      },
+                      "format": { "type": "string", "enum": ["celsius", "fahrenheit"] }
+                    },
+                    "required": ["location", "format"]
+                  }
+                }
+              }
+            ]
+          }
+    FineTuneCompletionRequestInput:
+      type: object
+      description: The per-line training example of a fine-tuning input file for
+        completions models
+      properties:
+        prompt:
+          type: string
+          description: The input prompt for this training example.
+        completion:
+          type: string
+          description: The desired completion for this training example.
+      x-oaiMeta:
+        name: Training format for completions models
+        example: |
+          {
+            "prompt": "What is the answer to 2+2",
+            "completion": "4"
+          }
+    FineTuneDPOMethod:
+      type: object
+      description: Configuration for the DPO fine-tuning method.
+      properties:
+        hyperparameters:
+          type: object
+          description: The hyperparameters used for the fine-tuning job.
+          properties:
+            beta:
+              description: >
+                The beta value for the DPO method. A higher beta value will
+                increase the weight of the penalty between the policy and
+                reference model.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: number
+                  minimum: 0
+                  maximum: 2
+                  exclusiveMinimum: true
+              default: auto
+            batch_size:
+              description: >
+                Number of examples in each batch. A larger batch size means that
+                model parameters are updated less frequently, but with lower
+                variance.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: integer
+                  minimum: 1
+                  maximum: 256
+              default: auto
+            learning_rate_multiplier:
+              description: >
+                Scaling factor for the learning rate. A smaller learning rate
+                may be useful to avoid overfitting.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: number
+                  minimum: 0
+                  exclusiveMinimum: true
+              default: auto
+            n_epochs:
+              description: >
+                The number of epochs to train the model for. An epoch refers to
+                one full cycle through the training dataset.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: integer
+                  minimum: 1
+                  maximum: 50
+              default: auto
+    FineTuneMethod:
+      type: object
+      description: The method used for fine-tuning.
+      properties:
+        type:
+          type: string
+          description: The type of method. Is either `supervised` or `dpo`.
+          enum:
+            - supervised
+            - dpo
+        supervised:
+          $ref: "#/components/schemas/FineTuneSupervisedMethod"
+        dpo:
+          $ref: "#/components/schemas/FineTuneDPOMethod"
+    FineTunePreferenceRequestInput:
+      type: object
+      description: The per-line training example of a fine-tuning input file for chat
+        models using the dpo method.
+      properties:
+        input:
+          type: object
+          properties:
+            messages:
+              type: array
+              minItems: 1
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/ChatCompletionRequestSystemMessage"
+                  - $ref: "#/components/schemas/ChatCompletionRequestUserMessage"
+                  - $ref: "#/components/schemas/FineTuneChatCompletionRequestAssistantMessage"
+                  - $ref: "#/components/schemas/ChatCompletionRequestToolMessage"
+                  - $ref: "#/components/schemas/ChatCompletionRequestFunctionMessage"
+                x-oaiExpandable: true
+            tools:
+              type: array
+              description: A list of tools the model may generate JSON inputs for.
+              items:
+                $ref: "#/components/schemas/ChatCompletionTool"
+            parallel_tool_calls:
+              $ref: "#/components/schemas/ParallelToolCalls"
+        preferred_completion:
+          type: array
+          description: The preferred completion message for the output.
+          maxItems: 1
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/ChatCompletionRequestAssistantMessage"
+            x-oaiExpandable: true
+        non_preferred_completion:
+          type: array
+          description: The non-preferred completion message for the output.
+          maxItems: 1
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/ChatCompletionRequestAssistantMessage"
+            x-oaiExpandable: true
+      x-oaiMeta:
+        name: Training format for chat models using the preference method
+        example: >
+          {
+            "input": {
+              "messages": [
+                { "role": "user", "content": "What is the weather in San Francisco?" }
+              ]
+            },
+            "preferred_completion": [
+              {
+                "role": "assistant",
+                "content": "The weather in San Francisco is 70 degrees Fahrenheit."
+              }
+            ],
+            "non_preferred_completion": [
+              {
+                "role": "assistant",
+                "content": "The weather in San Francisco is 21 degrees Celsius."
+              }
+            ]
+          }
+    FineTuneSupervisedMethod:
+      type: object
+      description: Configuration for the supervised fine-tuning method.
+      properties:
+        hyperparameters:
+          type: object
+          description: The hyperparameters used for the fine-tuning job.
+          properties:
+            batch_size:
+              description: >
+                Number of examples in each batch. A larger batch size means that
+                model parameters are updated less frequently, but with lower
+                variance.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: integer
+                  minimum: 1
+                  maximum: 256
+              default: auto
+            learning_rate_multiplier:
+              description: >
+                Scaling factor for the learning rate. A smaller learning rate
+                may be useful to avoid overfitting.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: number
+                  minimum: 0
+                  exclusiveMinimum: true
+              default: auto
+            n_epochs:
+              description: >
+                The number of epochs to train the model for. An epoch refers to
+                one full cycle through the training dataset.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: integer
+                  minimum: 1
+                  maximum: 50
+              default: auto
+    FineTuningIntegration:
+      type: object
+      title: Fine-Tuning Job Integration
+      required:
+        - type
+        - wandb
+      properties:
+        type:
+          type: string
+          description: The type of the integration being enabled for the fine-tuning job
+          enum:
+            - wandb
+          x-stainless-const: true
+        wandb:
+          type: object
+          description: >
+            The settings for your integration with Weights and Biases. This
+            payload specifies the project that
+
+            metrics will be sent to. Optionally, you can set an explicit display
+            name for your run, add tags
+
+            to your run, and set a default entity (team, username, etc) to be
+            associated with your run.
+          required:
+            - project
+          properties:
+            project:
+              description: |
+                The name of the project that the new run will be created under.
+              type: string
+              example: my-wandb-project
+            name:
+              description: >
+                A display name to set for the run. If not set, we will use the
+                Job ID as the name.
+              nullable: true
+              type: string
+            entity:
+              description: >
+                The entity to use for the run. This allows you to set the team
+                or username of the WandB user that you would
+
+                like associated with the run. If not set, the default entity for
+                the registered WandB API key is used.
+              nullable: true
+              type: string
+            tags:
+              description: >
+                A list of tags to be attached to the newly created run. These
+                tags are passed through directly to WandB. Some
+
+                default tags are generated by OpenAI: "openai/finetune",
+                "openai/{base-model}", "openai/{ftjob-abcdef}".
+              type: array
+              items:
+                type: string
+                example: custom-tag
+    FineTuningJob:
+      type: object
+      title: FineTuningJob
+      description: >
+        The `fine_tuning.job` object represents a fine-tuning job that has been
+        created through the API.
+      properties:
+        id:
+          type: string
+          description: The object identifier, which can be referenced in the API endpoints.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the fine-tuning job was
+            created.
+        error:
+          type: object
+          nullable: true
+          description: For fine-tuning jobs that have `failed`, this will contain more
+            information on the cause of the failure.
+          properties:
+            code:
+              type: string
+              description: A machine-readable error code.
+            message:
+              type: string
+              description: A human-readable error message.
+            param:
+              type: string
+              description: The parameter that was invalid, usually `training_file` or
+                `validation_file`. This field will be null if the failure was
+                not parameter-specific.
+              nullable: true
+          required:
+            - code
+            - message
+            - param
+        fine_tuned_model:
+          type: string
+          nullable: true
+          description: The name of the fine-tuned model that is being created. The value
+            will be null if the fine-tuning job is still running.
+        finished_at:
+          type: integer
+          nullable: true
+          description: The Unix timestamp (in seconds) for when the fine-tuning job was
+            finished. The value will be null if the fine-tuning job is still
+            running.
+        hyperparameters:
+          type: object
+          description: The hyperparameters used for the fine-tuning job. This value will
+            only be returned when running `supervised` jobs.
+          properties:
+            batch_size:
+              description: >
+                Number of examples in each batch. A larger batch size means that
+                model parameters
+
+                are updated less frequently, but with lower variance.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: integer
+                  minimum: 1
+                  maximum: 256
+              default: auto
+            learning_rate_multiplier:
+              description: >
+                Scaling factor for the learning rate. A smaller learning rate
+                may be useful to avoid
+
+                overfitting.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: number
+                  minimum: 0
+                  exclusiveMinimum: true
+              default: auto
+            n_epochs:
+              description: >
+                The number of epochs to train the model for. An epoch refers to
+                one full cycle
+
+                through the training dataset.
+              oneOf:
+                - type: string
+                  enum:
+                    - auto
+                  x-stainless-const: true
+                - type: integer
+                  minimum: 1
+                  maximum: 50
+              default: auto
+        model:
+          type: string
+          description: The base model that is being fine-tuned.
+        object:
+          type: string
+          description: The object type, which is always "fine_tuning.job".
+          enum:
+            - fine_tuning.job
+          x-stainless-const: true
+        organization_id:
+          type: string
+          description: The organization that owns the fine-tuning job.
+        result_files:
+          type: array
+          description: The compiled results file ID(s) for the fine-tuning job. You can
+            retrieve the results with the [Files
+            API](/docs/api-reference/files/retrieve-contents).
+          items:
+            type: string
+            example: file-abc123
+        status:
+          type: string
+          description: The current status of the fine-tuning job, which can be either
+            `validating_files`, `queued`, `running`, `succeeded`, `failed`, or
+            `cancelled`.
+          enum:
+            - validating_files
+            - queued
+            - running
+            - succeeded
+            - failed
+            - cancelled
+        trained_tokens:
+          type: integer
+          nullable: true
+          description: The total number of billable tokens processed by this fine-tuning
+            job. The value will be null if the fine-tuning job is still running.
+        training_file:
+          type: string
+          description: The file ID used for training. You can retrieve the training data
+            with the [Files API](/docs/api-reference/files/retrieve-contents).
+        validation_file:
+          type: string
+          nullable: true
+          description: The file ID used for validation. You can retrieve the validation
+            results with the [Files
+            API](/docs/api-reference/files/retrieve-contents).
+        integrations:
+          type: array
+          nullable: true
+          description: A list of integrations to enable for this fine-tuning job.
+          maxItems: 5
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/FineTuningIntegration"
+            x-oaiExpandable: true
+        seed:
+          type: integer
+          description: The seed used for the fine-tuning job.
+        estimated_finish:
+          type: integer
+          nullable: true
+          description: The Unix timestamp (in seconds) for when the fine-tuning job is
+            estimated to finish. The value will be null if the fine-tuning job
+            is not running.
+        method:
+          $ref: "#/components/schemas/FineTuneMethod"
+      required:
+        - created_at
+        - error
+        - finished_at
+        - fine_tuned_model
+        - hyperparameters
+        - id
+        - model
+        - object
+        - organization_id
+        - result_files
+        - status
+        - trained_tokens
+        - training_file
+        - validation_file
+        - seed
+      x-oaiMeta:
+        name: The fine-tuning job object
+        example: |
+          {
+            "object": "fine_tuning.job",
+            "id": "ftjob-abc123",
+            "model": "davinci-002",
+            "created_at": 1692661014,
+            "finished_at": 1692661190,
+            "fine_tuned_model": "ft:davinci-002:my-org:custom_suffix:7q8mpxmy",
+            "organization_id": "org-123",
+            "result_files": [
+                "file-abc123"
+            ],
+            "status": "succeeded",
+            "validation_file": null,
+            "training_file": "file-abc123",
+            "hyperparameters": {
+                "n_epochs": 4,
+                "batch_size": 1,
+                "learning_rate_multiplier": 1.0
+            },
+            "trained_tokens": 5768,
+            "integrations": [],
+            "seed": 0,
+            "estimated_finish": 0,
+            "method": {
+              "type": "supervised",
+              "supervised": {
+                "hyperparameters": {
+                  "n_epochs": 4,
+                  "batch_size": 1,
+                  "learning_rate_multiplier": 1.0
+                }
+              }
+            }
+          }
+    FineTuningJobCheckpoint:
+      type: object
+      title: FineTuningJobCheckpoint
+      description: >
+        The `fine_tuning.job.checkpoint` object represents a model checkpoint
+        for a fine-tuning job that is ready to use.
+      properties:
+        id:
+          type: string
+          description: The checkpoint identifier, which can be referenced in the API
+            endpoints.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the checkpoint was created.
+        fine_tuned_model_checkpoint:
+          type: string
+          description: The name of the fine-tuned checkpoint model that is created.
+        step_number:
+          type: integer
+          description: The step number that the checkpoint was created at.
+        metrics:
+          type: object
+          description: Metrics at the step number during the fine-tuning job.
+          properties:
+            step:
+              type: number
+            train_loss:
+              type: number
+            train_mean_token_accuracy:
+              type: number
+            valid_loss:
+              type: number
+            valid_mean_token_accuracy:
+              type: number
+            full_valid_loss:
+              type: number
+            full_valid_mean_token_accuracy:
+              type: number
+        fine_tuning_job_id:
+          type: string
+          description: The name of the fine-tuning job that this checkpoint was created
+            from.
+        object:
+          type: string
+          description: The object type, which is always "fine_tuning.job.checkpoint".
+          enum:
+            - fine_tuning.job.checkpoint
+          x-stainless-const: true
+      required:
+        - created_at
+        - fine_tuning_job_id
+        - fine_tuned_model_checkpoint
+        - id
+        - metrics
+        - object
+        - step_number
+      x-oaiMeta:
+        name: The fine-tuning job checkpoint object
+        example: >
+          {
+            "object": "fine_tuning.job.checkpoint",
+            "id": "ftckpt_qtZ5Gyk4BLq1SfLFWp3RtO3P",
+            "created_at": 1712211699,
+            "fine_tuned_model_checkpoint": "ft:gpt-4o-mini-2024-07-18:my-org:custom_suffix:9ABel2dg:ckpt-step-88",
+            "fine_tuning_job_id": "ftjob-fpbNQ3H1GrMehXRf8cO97xTN",
+            "metrics": {
+              "step": 88,
+              "train_loss": 0.478,
+              "train_mean_token_accuracy": 0.924,
+              "valid_loss": 10.112,
+              "valid_mean_token_accuracy": 0.145,
+              "full_valid_loss": 0.567,
+              "full_valid_mean_token_accuracy": 0.944
+            },
+            "step_number": 88
+          }
+    FineTuningJobEvent:
+      type: object
+      description: Fine-tuning job event object
+      properties:
+        object:
+          type: string
+          description: The object type, which is always "fine_tuning.job.event".
+          enum:
+            - fine_tuning.job.event
+          x-stainless-const: true
+        id:
+          type: string
+          description: The object identifier.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the fine-tuning job was
+            created.
+        level:
+          type: string
+          description: The log level of the event.
+          enum:
+            - info
+            - warn
+            - error
+        message:
+          type: string
+          description: The message of the event.
+        type:
+          type: string
+          description: The type of event.
+          enum:
+            - message
+            - metrics
+        data:
+          type: object
+          description: The data associated with the event.
+      required:
+        - id
+        - object
+        - created_at
+        - level
+        - message
+      x-oaiMeta:
+        name: The fine-tuning job event object
+        example: |
+          {
+            "object": "fine_tuning.job.event",
+            "id": "ftevent-abc123"
+            "created_at": 1677610602,
+            "level": "info",
+            "message": "Created fine-tuning job",
+            "data": {},
+            "type": "message"
+          }
+    FunctionObject:
+      type: object
+      properties:
+        description:
+          type: string
+          description: A description of what the function does, used by the model to
+            choose when and how to call the function.
+        name:
+          type: string
+          description: The name of the function to be called. Must be a-z, A-Z, 0-9, or
+            contain underscores and dashes, with a maximum length of 64.
+        parameters:
+          $ref: "#/components/schemas/FunctionParameters"
+        strict:
+          type: boolean
+          nullable: true
+          default: false
+          description: Whether to enable strict schema adherence when generating the
+            function call. If set to true, the model will follow the exact
+            schema defined in the `parameters` field. Only a subset of JSON
+            Schema is supported when `strict` is `true`. Learn more about
+            Structured Outputs in the [function calling
+            guide](docs/guides/function-calling).
+      required:
+        - name
+    FunctionParameters:
+      type: object
+      description: >-
+        The parameters the functions accepts, described as a JSON Schema object.
+        See the [guide](/docs/guides/function-calling) for examples, and the
+        [JSON Schema
+        reference](https://json-schema.org/understanding-json-schema/) for
+        documentation about the format. 
+
+
+        Omitting `parameters` defines a function with an empty parameter list.
+      additionalProperties: true
+    Image:
+      type: object
+      description: Represents the url or the content of an image generated by the
+        OpenAI API.
+      properties:
+        b64_json:
+          type: string
+          description: The base64-encoded JSON of the generated image, if
+            `response_format` is `b64_json`.
+        url:
+          type: string
+          description: The URL of the generated image, if `response_format` is `url`
+            (default).
+        revised_prompt:
+          type: string
+          description: The prompt that was used to generate the image, if there was any
+            revision to the prompt.
+      x-oaiMeta:
+        name: The image object
+        example: |
+          {
+            "url": "...",
+            "revised_prompt": "..."
+          }
+    ImagesResponse:
+      properties:
+        created:
+          type: integer
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Image"
+      required:
+        - created
+        - data
+    Invite:
+      type: object
+      description: Represents an individual `invite` to the organization.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.invite
+          description: The object type, which is always `organization.invite`
+          x-stainless-const: true
+        id:
+          type: string
+          description: The identifier, which can be referenced in API endpoints
+        email:
+          type: string
+          description: The email address of the individual to whom the invite was sent
+        role:
+          type: string
+          enum:
+            - owner
+            - reader
+          description: "`owner` or `reader`"
+        status:
+          type: string
+          enum:
+            - accepted
+            - expired
+            - pending
+          description: "`accepted`,`expired`, or `pending`"
+        invited_at:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the invite was sent.
+        expires_at:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the invite expires.
+        accepted_at:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the invite was accepted.
+        projects:
+          type: array
+          description: The projects that were granted membership upon acceptance of the
+            invite.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Project's public ID
+              role:
+                type: string
+                enum:
+                  - member
+                  - owner
+                description: Project membership role
+      required:
+        - object
+        - id
+        - email
+        - role
+        - status
+        - invited_at
+        - expires_at
+      x-oaiMeta:
+        name: The invite object
+        example: |
+          {
+            "object": "organization.invite",
+            "id": "invite-abc",
+            "email": "user@example.com",
+            "role": "owner",
+            "status": "accepted",
+            "invited_at": 1711471533,
+            "expires_at": 1711471533,
+            "accepted_at": 1711471533,
+            "projects": [
+              {
+                "id": "project-xyz",
+                "role": "member"
+              }
+            ]
+          }
+    InviteDeleteResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.invite.deleted
+          description: The object type, which is always `organization.invite.deleted`
+          x-stainless-const: true
+        id:
+          type: string
+        deleted:
+          type: boolean
+      required:
+        - object
+        - id
+        - deleted
+    InviteListResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          description: The object type, which is always `list`
+          x-stainless-const: true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Invite"
+        first_id:
+          type: string
+          description: The first `invite_id` in the retrieved `list`
+        last_id:
+          type: string
+          description: The last `invite_id` in the retrieved `list`
+        has_more:
+          type: boolean
+          description: The `has_more` property is used for pagination to indicate there
+            are additional results.
+      required:
+        - object
+        - data
+    InviteRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          description: Send an email to this address
+        role:
+          type: string
+          enum:
+            - reader
+            - owner
+          description: "`owner` or `reader`"
+        projects:
+          type: array
+          description: An array of projects to which membership is granted at the same
+            time the org invite is accepted. If omitted, the user will be
+            invited to the default project for compatibility with legacy
+            behavior.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Project's public ID
+              role:
+                type: string
+                enum:
+                  - member
+                  - owner
+                description: Project membership role
+            required:
+              - id
+              - role
+      required:
+        - email
+        - role
+    ListAssistantsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantObject"
+        first_id:
+          type: string
+          example: asst_abc123
+        last_id:
+          type: string
+          example: asst_abc456
+        has_more:
+          type: boolean
+          example: false
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+      x-oaiMeta:
+        name: List assistants response object
+        group: chat
+        example: >
+          {
+            "object": "list",
+            "data": [
+              {
+                "id": "asst_abc123",
+                "object": "assistant",
+                "created_at": 1698982736,
+                "name": "Coding Tutor",
+                "description": null,
+                "model": "gpt-4o",
+                "instructions": "You are a helpful assistant designed to make me better at coding!",
+                "tools": [],
+                "tool_resources": {},
+                "metadata": {},
+                "top_p": 1.0,
+                "temperature": 1.0,
+                "response_format": "auto"
+              },
+              {
+                "id": "asst_abc456",
+                "object": "assistant",
+                "created_at": 1698982718,
+                "name": "My Assistant",
+                "description": null,
+                "model": "gpt-4o",
+                "instructions": "You are a helpful assistant designed to make me better at coding!",
+                "tools": [],
+                "tool_resources": {},
+                "metadata": {},
+                "top_p": 1.0,
+                "temperature": 1.0,
+                "response_format": "auto"
+              },
+              {
+                "id": "asst_abc789",
+                "object": "assistant",
+                "created_at": 1698982643,
+                "name": null,
+                "description": null,
+                "model": "gpt-4o",
+                "instructions": null,
+                "tools": [],
+                "tool_resources": {},
+                "metadata": {},
+                "top_p": 1.0,
+                "temperature": 1.0,
+                "response_format": "auto"
+              }
+            ],
+            "first_id": "asst_abc123",
+            "last_id": "asst_abc789",
+            "has_more": false
+          }
+    ListAuditLogsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuditLog"
+        first_id:
+          type: string
+          example: audit_log-defb456h8dks
+        last_id:
+          type: string
+          example: audit_log-hnbkd8s93s
+        has_more:
+          type: boolean
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ListBatchesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Batch"
+        first_id:
+          type: string
+          example: batch_abc123
+        last_id:
+          type: string
+          example: batch_abc456
+        has_more:
+          type: boolean
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+      required:
+        - object
+        - data
+        - has_more
+    ListFilesResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpenAIFile"
+        first_id:
+          type: string
+          example: file-abc123
+        last_id:
+          type: string
+          example: file-abc456
+        has_more:
+          type: boolean
+          example: false
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ListFineTuningJobCheckpointsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/FineTuningJobCheckpoint"
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+        first_id:
+          type: string
+          nullable: true
+        last_id:
+          type: string
+          nullable: true
+        has_more:
+          type: boolean
+      required:
+        - object
+        - data
+        - has_more
+    ListFineTuningJobEventsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/FineTuningJobEvent"
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+      required:
+        - object
+        - data
+    ListMessagesResponse:
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageObject"
+        first_id:
+          type: string
+          example: msg_abc123
+        last_id:
+          type: string
+          example: msg_abc123
+        has_more:
+          type: boolean
+          example: false
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ListModelsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Model"
+      required:
+        - object
+        - data
+    ListPaginatedFineTuningJobsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/FineTuningJob"
+        has_more:
+          type: boolean
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+      required:
+        - object
+        - data
+        - has_more
+    ListRunStepsResponse:
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/RunStepObject"
+        first_id:
+          type: string
+          example: step_abc123
+        last_id:
+          type: string
+          example: step_abc456
+        has_more:
+          type: boolean
+          example: false
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ListRunsResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/RunObject"
+        first_id:
+          type: string
+          example: run_abc123
+        last_id:
+          type: string
+          example: run_abc456
+        has_more:
+          type: boolean
+          example: false
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ListThreadsResponse:
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ThreadObject"
+        first_id:
+          type: string
+          example: asst_abc123
+        last_id:
+          type: string
+          example: asst_abc456
+        has_more:
+          type: boolean
+          example: false
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ListVectorStoreFilesResponse:
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/VectorStoreFileObject"
+        first_id:
+          type: string
+          example: file-abc123
+        last_id:
+          type: string
+          example: file-abc456
+        has_more:
+          type: boolean
+          example: false
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ListVectorStoresResponse:
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/VectorStoreObject"
+        first_id:
+          type: string
+          example: vs_abc123
+        last_id:
+          type: string
+          example: vs_abc456
+        has_more:
+          type: boolean
+          example: false
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    MessageContentImageFileObject:
+      title: Image file
+      type: object
+      description: References an image [File](/docs/api-reference/files) in the
+        content of a message.
+      properties:
+        type:
+          description: Always `image_file`.
+          type: string
+          enum:
+            - image_file
+          x-stainless-const: true
+        image_file:
+          type: object
+          properties:
+            file_id:
+              description: The [File](/docs/api-reference/files) ID of the image in the
+                message content. Set `purpose="vision"` when uploading the File
+                if you need to later display the file content.
+              type: string
+            detail:
+              type: string
+              description: Specifies the detail level of the image if specified by the user.
+                `low` uses fewer tokens, you can opt in to high resolution using
+                `high`.
+              enum:
+                - auto
+                - low
+                - high
+              default: auto
+          required:
+            - file_id
+      required:
+        - type
+        - image_file
+    MessageContentImageUrlObject:
+      title: Image URL
+      type: object
+      description: References an image URL in the content of a message.
+      properties:
+        type:
+          type: string
+          enum:
+            - image_url
+          description: The type of the content part.
+          x-stainless-const: true
+        image_url:
+          type: object
+          properties:
+            url:
+              type: string
+              description: "The external URL of the image, must be a supported image types:
+                jpeg, jpg, png, gif, webp."
+              format: uri
+            detail:
+              type: string
+              description: Specifies the detail level of the image. `low` uses fewer tokens,
+                you can opt in to high resolution using `high`. Default value is
+                `auto`
+              enum:
+                - auto
+                - low
+                - high
+              default: auto
+          required:
+            - url
+      required:
+        - type
+        - image_url
+    MessageContentRefusalObject:
+      title: Refusal
+      type: object
+      description: The refusal content generated by the assistant.
+      properties:
+        type:
+          description: Always `refusal`.
+          type: string
+          enum:
+            - refusal
+          x-stainless-const: true
+        refusal:
+          type: string
+          nullable: false
+      required:
+        - type
+        - refusal
+    MessageContentTextAnnotationsFileCitationObject:
+      title: File citation
+      type: object
+      description: A citation within the message that points to a specific quote from
+        a specific File associated with the assistant or the message. Generated
+        when the assistant uses the "file_search" tool to search files.
+      properties:
+        type:
+          description: Always `file_citation`.
+          type: string
+          enum:
+            - file_citation
+          x-stainless-const: true
+        text:
+          description: The text in the message content that needs to be replaced.
+          type: string
+        file_citation:
+          type: object
+          properties:
+            file_id:
+              description: The ID of the specific File the citation is from.
+              type: string
+          required:
+            - file_id
+        start_index:
+          type: integer
+          minimum: 0
+        end_index:
+          type: integer
+          minimum: 0
+      required:
+        - type
+        - text
+        - file_citation
+        - start_index
+        - end_index
+    MessageContentTextAnnotationsFilePathObject:
+      title: File path
+      type: object
+      description: A URL for the file that's generated when the assistant used the
+        `code_interpreter` tool to generate a file.
+      properties:
+        type:
+          description: Always `file_path`.
+          type: string
+          enum:
+            - file_path
+          x-stainless-const: true
+        text:
+          description: The text in the message content that needs to be replaced.
+          type: string
+        file_path:
+          type: object
+          properties:
+            file_id:
+              description: The ID of the file that was generated.
+              type: string
+          required:
+            - file_id
+        start_index:
+          type: integer
+          minimum: 0
+        end_index:
+          type: integer
+          minimum: 0
+      required:
+        - type
+        - text
+        - file_path
+        - start_index
+        - end_index
+    MessageContentTextObject:
+      title: Text
+      type: object
+      description: The text content that is part of a message.
+      properties:
+        type:
+          description: Always `text`.
+          type: string
+          enum:
+            - text
+          x-stainless-const: true
+        text:
+          type: object
+          properties:
+            value:
+              description: The data that makes up the text.
+              type: string
+            annotations:
+              type: array
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/MessageContentTextAnnotationsFileCitationObject"
+                  - $ref: "#/components/schemas/MessageContentTextAnnotationsFilePathObject"
+                x-oaiExpandable: true
+          required:
+            - value
+            - annotations
+      required:
+        - type
+        - text
+    MessageDeltaContentImageFileObject:
+      title: Image file
+      type: object
+      description: References an image [File](/docs/api-reference/files) in the
+        content of a message.
+      properties:
+        index:
+          type: integer
+          description: The index of the content part in the message.
+        type:
+          description: Always `image_file`.
+          type: string
+          enum:
+            - image_file
+          x-stainless-const: true
+        image_file:
+          type: object
+          properties:
+            file_id:
+              description: The [File](/docs/api-reference/files) ID of the image in the
+                message content. Set `purpose="vision"` when uploading the File
+                if you need to later display the file content.
+              type: string
+            detail:
+              type: string
+              description: Specifies the detail level of the image if specified by the user.
+                `low` uses fewer tokens, you can opt in to high resolution using
+                `high`.
+              enum:
+                - auto
+                - low
+                - high
+              default: auto
+      required:
+        - index
+        - type
+    MessageDeltaContentImageUrlObject:
+      title: Image URL
+      type: object
+      description: References an image URL in the content of a message.
+      properties:
+        index:
+          type: integer
+          description: The index of the content part in the message.
+        type:
+          description: Always `image_url`.
+          type: string
+          enum:
+            - image_url
+          x-stainless-const: true
+        image_url:
+          type: object
+          properties:
+            url:
+              description: "The URL of the image, must be a supported image types: jpeg, jpg,
+                png, gif, webp."
+              type: string
+            detail:
+              type: string
+              description: Specifies the detail level of the image. `low` uses fewer tokens,
+                you can opt in to high resolution using `high`.
+              enum:
+                - auto
+                - low
+                - high
+              default: auto
+      required:
+        - index
+        - type
+    MessageDeltaContentRefusalObject:
+      title: Refusal
+      type: object
+      description: The refusal content that is part of a message.
+      properties:
+        index:
+          type: integer
+          description: The index of the refusal part in the message.
+        type:
+          description: Always `refusal`.
+          type: string
+          enum:
+            - refusal
+          x-stainless-const: true
+        refusal:
+          type: string
+      required:
+        - index
+        - type
+    MessageDeltaContentTextAnnotationsFileCitationObject:
+      title: File citation
+      type: object
+      description: A citation within the message that points to a specific quote from
+        a specific File associated with the assistant or the message. Generated
+        when the assistant uses the "file_search" tool to search files.
+      properties:
+        index:
+          type: integer
+          description: The index of the annotation in the text content part.
+        type:
+          description: Always `file_citation`.
+          type: string
+          enum:
+            - file_citation
+          x-stainless-const: true
+        text:
+          description: The text in the message content that needs to be replaced.
+          type: string
+        file_citation:
+          type: object
+          properties:
+            file_id:
+              description: The ID of the specific File the citation is from.
+              type: string
+            quote:
+              description: The specific quote in the file.
+              type: string
+        start_index:
+          type: integer
+          minimum: 0
+        end_index:
+          type: integer
+          minimum: 0
+      required:
+        - index
+        - type
+    MessageDeltaContentTextAnnotationsFilePathObject:
+      title: File path
+      type: object
+      description: A URL for the file that's generated when the assistant used the
+        `code_interpreter` tool to generate a file.
+      properties:
+        index:
+          type: integer
+          description: The index of the annotation in the text content part.
+        type:
+          description: Always `file_path`.
+          type: string
+          enum:
+            - file_path
+          x-stainless-const: true
+        text:
+          description: The text in the message content that needs to be replaced.
+          type: string
+        file_path:
+          type: object
+          properties:
+            file_id:
+              description: The ID of the file that was generated.
+              type: string
+        start_index:
+          type: integer
+          minimum: 0
+        end_index:
+          type: integer
+          minimum: 0
+      required:
+        - index
+        - type
+    MessageDeltaContentTextObject:
+      title: Text
+      type: object
+      description: The text content that is part of a message.
+      properties:
+        index:
+          type: integer
+          description: The index of the content part in the message.
+        type:
+          description: Always `text`.
+          type: string
+          enum:
+            - text
+          x-stainless-const: true
+        text:
+          type: object
+          properties:
+            value:
+              description: The data that makes up the text.
+              type: string
+            annotations:
+              type: array
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/MessageDeltaContentTextAnnotationsFileCitationObjec\
+                      t"
+                  - $ref: "#/components/schemas/MessageDeltaContentTextAnnotationsFilePathObject"
+                x-oaiExpandable: true
+      required:
+        - index
+        - type
+    MessageDeltaObject:
+      type: object
+      title: Message delta object
+      description: >
+        Represents a message delta i.e. any changed fields on a message during
+        streaming.
+      properties:
+        id:
+          description: The identifier of the message, which can be referenced in API
+            endpoints.
+          type: string
+        object:
+          description: The object type, which is always `thread.message.delta`.
+          type: string
+          enum:
+            - thread.message.delta
+          x-stainless-const: true
+        delta:
+          description: The delta containing the fields that have changed on the Message.
+          type: object
+          properties:
+            role:
+              description: The entity that produced the message. One of `user` or `assistant`.
+              type: string
+              enum:
+                - user
+                - assistant
+            content:
+              description: The content of the message in array of text and/or images.
+              type: array
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/MessageDeltaContentImageFileObject"
+                  - $ref: "#/components/schemas/MessageDeltaContentTextObject"
+                  - $ref: "#/components/schemas/MessageDeltaContentRefusalObject"
+                  - $ref: "#/components/schemas/MessageDeltaContentImageUrlObject"
+                x-oaiExpandable: true
+      required:
+        - id
+        - object
+        - delta
+      x-oaiMeta:
+        name: The message delta object
+        beta: true
+        example: |
+          {
+            "id": "msg_123",
+            "object": "thread.message.delta",
+            "delta": {
+              "content": [
+                {
+                  "index": 0,
+                  "type": "text",
+                  "text": { "value": "Hello", "annotations": [] }
+                }
+              ]
+            }
+          }
+    MessageObject:
+      type: object
+      title: The message object
+      description: Represents a message within a [thread](/docs/api-reference/threads).
+      properties:
+        id:
+          description: The identifier, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `thread.message`.
+          type: string
+          enum:
+            - thread.message
+          x-stainless-const: true
+        created_at:
+          description: The Unix timestamp (in seconds) for when the message was created.
+          type: integer
+        thread_id:
+          description: The [thread](/docs/api-reference/threads) ID that this message
+            belongs to.
+          type: string
+        status:
+          description: The status of the message, which can be either `in_progress`,
+            `incomplete`, or `completed`.
+          type: string
+          enum:
+            - in_progress
+            - incomplete
+            - completed
+        incomplete_details:
+          description: On an incomplete message, details about why the message is
+            incomplete.
+          type: object
+          properties:
+            reason:
+              type: string
+              description: The reason the message is incomplete.
+              enum:
+                - content_filter
+                - max_tokens
+                - run_cancelled
+                - run_expired
+                - run_failed
+          nullable: true
+          required:
+            - reason
+        completed_at:
+          description: The Unix timestamp (in seconds) for when the message was completed.
+          type: integer
+          nullable: true
+        incomplete_at:
+          description: The Unix timestamp (in seconds) for when the message was marked as
+            incomplete.
+          type: integer
+          nullable: true
+        role:
+          description: The entity that produced the message. One of `user` or `assistant`.
+          type: string
+          enum:
+            - user
+            - assistant
+        content:
+          description: The content of the message in array of text and/or images.
+          type: array
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/MessageContentImageFileObject"
+              - $ref: "#/components/schemas/MessageContentImageUrlObject"
+              - $ref: "#/components/schemas/MessageContentTextObject"
+              - $ref: "#/components/schemas/MessageContentRefusalObject"
+            x-oaiExpandable: true
+        assistant_id:
+          description: If applicable, the ID of the
+            [assistant](/docs/api-reference/assistants) that authored this
+            message.
+          type: string
+          nullable: true
+        run_id:
+          description: The ID of the [run](/docs/api-reference/runs) associated with the
+            creation of this message. Value is `null` when messages are created
+            manually using the create message or create thread endpoints.
+          type: string
+          nullable: true
+        attachments:
+          type: array
+          items:
+            type: object
+            properties:
+              file_id:
+                type: string
+                description: The ID of the file to attach to the message.
+              tools:
+                description: The tools to add this file to.
+                type: array
+                items:
+                  oneOf:
+                    - $ref: "#/components/schemas/AssistantToolsCode"
+                    - $ref: "#/components/schemas/AssistantToolsFileSearchTypeOnly"
+                  x-oaiExpandable: true
+          description: A list of files attached to the message, and the tools they were
+            added to.
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+      required:
+        - id
+        - object
+        - created_at
+        - thread_id
+        - status
+        - incomplete_details
+        - completed_at
+        - incomplete_at
+        - role
+        - content
+        - assistant_id
+        - run_id
+        - attachments
+        - metadata
+      x-oaiMeta:
+        name: The message object
+        beta: true
+        example: |
+          {
+            "id": "msg_abc123",
+            "object": "thread.message",
+            "created_at": 1698983503,
+            "thread_id": "thread_abc123",
+            "role": "assistant",
+            "content": [
+              {
+                "type": "text",
+                "text": {
+                  "value": "Hi! How can I help you today?",
+                  "annotations": []
+                }
+              }
+            ],
+            "assistant_id": "asst_abc123",
+            "run_id": "run_abc123",
+            "attachments": [],
+            "metadata": {}
+          }
+    MessageRequestContentTextObject:
+      title: Text
+      type: object
+      description: The text content that is part of a message.
+      properties:
+        type:
+          description: Always `text`.
+          type: string
+          enum:
+            - text
+          x-stainless-const: true
+        text:
+          type: string
+          description: Text content to be sent to the model
+      required:
+        - type
+        - text
+    MessageStreamEvent:
+      oneOf:
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.message.created
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/MessageObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [message](/docs/api-reference/messages/object) is
+            created.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.message.in_progress
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/MessageObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [message](/docs/api-reference/messages/object) moves
+            to an `in_progress` state.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.message.delta
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/MessageDeltaObject"
+          required:
+            - event
+            - data
+          description: Occurs when parts of a
+            [Message](/docs/api-reference/messages/object) are being streamed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message
+              delta](/docs/api-reference/assistants-streaming/message-delta-obj\
+              ect)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.message.completed
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/MessageObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [message](/docs/api-reference/messages/object) is
+            completed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.message.incomplete
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/MessageObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [message](/docs/api-reference/messages/object) ends
+            before it is completed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [message](/docs/api-reference/messages/object)"
+    Model:
+      title: Model
+      description: Describes an OpenAI model offering that can be used with the API.
+      properties:
+        id:
+          type: string
+          description: The model identifier, which can be referenced in the API endpoints.
+        created:
+          type: integer
+          description: The Unix timestamp (in seconds) when the model was created.
+        object:
+          type: string
+          description: The object type, which is always "model".
+          enum:
+            - model
+          x-stainless-const: true
+        owned_by:
+          type: string
+          description: The organization that owns the model.
+      required:
+        - id
+        - object
+        - created
+        - owned_by
+      x-oaiMeta:
+        name: The model object
+        example: |
+          {
+            "id": "VAR_chat_model_id",
+            "object": "model",
+            "created": 1686935002,
+            "owned_by": "openai"
+          }
+    ModifyAssistantRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        model:
+          description: >
+            ID of the model to use. You can use the [List
+            models](/docs/api-reference/models/list) API to see all of your
+            available models, or see our [Model overview](/docs/models) for
+            descriptions of them.
+          anyOf:
+            - type: string
+        name:
+          description: |
+            The name of the assistant. The maximum length is 256 characters.
+          type: string
+          nullable: true
+          maxLength: 256
+        description:
+          description: >
+            The description of the assistant. The maximum length is 512
+            characters.
+          type: string
+          nullable: true
+          maxLength: 512
+        instructions:
+          description: >
+            The system instructions that the assistant uses. The maximum length
+            is 256,000 characters.
+          type: string
+          nullable: true
+          maxLength: 256000
+        tools:
+          description: >
+            A list of tool enabled on the assistant. There can be a maximum of
+            128 tools per assistant. Tools can be of types `code_interpreter`,
+            `file_search`, or `function`.
+          default: []
+          type: array
+          maxItems: 128
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/AssistantToolsCode"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
+              - $ref: "#/components/schemas/AssistantToolsFunction"
+            x-oaiExpandable: true
+        tool_resources:
+          type: object
+          description: >
+            A set of resources that are used by the assistant's tools. The
+            resources are specific to the type of tool. For example, the
+            `code_interpreter` tool requires a list of file IDs, while the
+            `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: >
+                    Overrides the list of [file](/docs/api-reference/files) IDs
+                    made available to the `code_interpreter` tool. There can be
+                    a maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: >
+                    Overrides the [vector
+                    store](/docs/api-reference/vector-stores/object) attached to
+                    this assistant. There can be a maximum of 1 vector store
+                    attached to the assistant.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+        temperature:
+          description: >
+            What sampling temperature to use, between 0 and 2. Higher values
+            like 0.8 will make the output more random, while lower values like
+            0.2 will make it more focused and deterministic.
+          type: number
+          minimum: 0
+          maximum: 2
+          default: 1
+          example: 1
+          nullable: true
+        top_p:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 1
+          example: 1
+          nullable: true
+          description: >
+            An alternative to sampling with temperature, called nucleus
+            sampling, where the model considers the results of the tokens with
+            top_p probability mass. So 0.1 means only the tokens comprising the
+            top 10% probability mass are considered.
+
+
+            We generally recommend altering this or temperature but not both.
+        response_format:
+          allOf:
+            - $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+            - nullable: true
+    ModifyMessageRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+    ModifyRunRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+    ModifyThreadRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        tool_resources:
+          type: object
+          description: >
+            A set of resources that are made available to the assistant's tools
+            in this thread. The resources are specific to the type of tool. For
+            example, the `code_interpreter` tool requires a list of file IDs,
+            while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: >
+                    A list of [file](/docs/api-reference/files) IDs made
+                    available to the `code_interpreter` tool. There can be a
+                    maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: >
+                    The [vector store](/docs/api-reference/vector-stores/object)
+                    attached to this thread. There can be a maximum of 1 vector
+                    store attached to the thread.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+    OpenAIFile:
+      title: OpenAIFile
+      description: The `File` object represents a document that has been uploaded to OpenAI.
+      properties:
+        id:
+          type: string
+          description: The file identifier, which can be referenced in the API endpoints.
+        bytes:
+          type: integer
+          description: The size of the file, in bytes.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the file was created.
+        filename:
+          type: string
+          description: The name of the file.
+        object:
+          type: string
+          description: The object type, which is always `file`.
+          enum:
+            - file
+          x-stainless-const: true
+        purpose:
+          type: string
+          description: The intended purpose of the file. Supported values are
+            `assistants`, `assistants_output`, `batch`, `batch_output`,
+            `fine-tune`, `fine-tune-results` and `vision`.
+          enum:
+            - assistants
+            - assistants_output
+            - batch
+            - batch_output
+            - fine-tune
+            - fine-tune-results
+            - vision
+        status:
+          type: string
+          deprecated: true
+          description: Deprecated. The current status of the file, which can be either
+            `uploaded`, `processed`, or `error`.
+          enum:
+            - uploaded
+            - processed
+            - error
+        status_details:
+          type: string
+          deprecated: true
+          description: Deprecated. For details on why a fine-tuning training file failed
+            validation, see the `error` field on `fine_tuning.job`.
+      required:
+        - id
+        - object
+        - bytes
+        - created_at
+        - filename
+        - purpose
+        - status
+      x-oaiMeta:
+        name: The file object
+        example: |
+          {
+            "id": "file-abc123",
+            "object": "file",
+            "bytes": 120000,
+            "created_at": 1677610602,
+            "filename": "salesOverview.pdf",
+            "purpose": "assistants",
+          }
+    OtherChunkingStrategyResponseParam:
+      type: object
+      title: Other Chunking Strategy
+      description: This is returned when the chunking strategy is unknown. Typically,
+        this is because the file was indexed before the `chunking_strategy`
+        concept was introduced in the API.
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          description: Always `other`.
+          enum:
+            - other
+          x-stainless-const: true
+      required:
+        - type
+    ParallelToolCalls:
+      description: Whether to enable [parallel function
+        calling](/docs/guides/function-calling#configuring-parallel-function-calling)
+        during tool use.
+      type: boolean
+      default: true
+    PredictionContent:
+      type: object
+      title: Static Content
+      description: >
+        Static predicted output content, such as the content of a text file that
+        is
+
+        being regenerated.
+      required:
+        - type
+        - content
+      properties:
+        type:
+          type: string
+          enum:
+            - content
+          description: |
+            The type of the predicted content you want to provide. This type is
+            currently always `content`.
+          x-stainless-const: true
+        content:
+          x-oaiExpandable: true
+          description: >
+            The content that should be matched when generating a model response.
+
+            If generated tokens would match this content, the entire model
+            response
+
+            can be returned much more quickly.
+          oneOf:
+            - type: string
+              title: Text content
+              description: |
+                The content used for a Predicted Output. This is often the
+                text of a file you are regenerating with minor changes.
+            - type: array
+              description: An array of content parts with a defined type. Supported options
+                differ based on the [model](/docs/models) being used to generate
+                the response. Can contain text inputs.
+              title: Array of content parts
+              items:
+                $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+              minItems: 1
+    Project:
+      type: object
+      description: Represents an individual project.
+      properties:
+        id:
+          type: string
+          description: The identifier, which can be referenced in API endpoints
+        object:
+          type: string
+          enum:
+            - organization.project
+          description: The object type, which is always `organization.project`
+          x-stainless-const: true
+        name:
+          type: string
+          description: The name of the project. This appears in reporting.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the project was created.
+        archived_at:
+          type: integer
+          nullable: true
+          description: The Unix timestamp (in seconds) of when the project was archived or
+            `null`.
+        status:
+          type: string
+          enum:
+            - active
+            - archived
+          description: "`active` or `archived`"
+      required:
+        - id
+        - object
+        - name
+        - created_at
+        - status
+      x-oaiMeta:
+        name: The project object
+        example: |
+          {
+              "id": "proj_abc",
+              "object": "organization.project",
+              "name": "Project example",
+              "created_at": 1711471533,
+              "archived_at": null,
+              "status": "active"
+          }
+    ProjectApiKey:
+      type: object
+      description: Represents an individual API key in a project.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.project.api_key
+          description: The object type, which is always `organization.project.api_key`
+          x-stainless-const: true
+        redacted_value:
+          type: string
+          description: The redacted value of the API key
+        name:
+          type: string
+          description: The name of the API key
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the API key was created
+        id:
+          type: string
+          description: The identifier, which can be referenced in API endpoints
+        owner:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - user
+                - service_account
+              description: "`user` or `service_account`"
+            user:
+              $ref: "#/components/schemas/ProjectUser"
+            service_account:
+              $ref: "#/components/schemas/ProjectServiceAccount"
+      required:
+        - object
+        - redacted_value
+        - name
+        - created_at
+        - id
+        - owner
+      x-oaiMeta:
+        name: The project API key object
+        example: |
+          {
+              "object": "organization.project.api_key",
+              "redacted_value": "sk-abc...def",
+              "name": "My API Key",
+              "created_at": 1711471533,
+              "id": "key_abc",
+              "owner": {
+                  "type": "user",
+                  "user": {
+                      "object": "organization.project.user",
+                      "id": "user_abc",
+                      "name": "First Last",
+                      "email": "user@example.com",
+                      "role": "owner",
+                      "created_at": 1711471533
+                  }
+              }
+          }
+    ProjectApiKeyDeleteResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.project.api_key.deleted
+          x-stainless-const: true
+        id:
+          type: string
+        deleted:
+          type: boolean
+      required:
+        - object
+        - id
+        - deleted
+    ProjectApiKeyListResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProjectApiKey"
+        first_id:
+          type: string
+        last_id:
+          type: string
+        has_more:
+          type: boolean
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ProjectCreateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The friendly name of the project, this name appears in reports.
+      required:
+        - name
+    ProjectListResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Project"
+        first_id:
+          type: string
+        last_id:
+          type: string
+        has_more:
+          type: boolean
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ProjectRateLimit:
+      type: object
+      description: Represents a project rate limit config.
+      properties:
+        object:
+          type: string
+          enum:
+            - project.rate_limit
+          description: The object type, which is always `project.rate_limit`
+          x-stainless-const: true
+        id:
+          type: string
+          description: The identifier, which can be referenced in API endpoints.
+        model:
+          type: string
+          description: The model this rate limit applies to.
+        max_requests_per_1_minute:
+          type: integer
+          description: The maximum requests per minute.
+        max_tokens_per_1_minute:
+          type: integer
+          description: The maximum tokens per minute.
+        max_images_per_1_minute:
+          type: integer
+          description: The maximum images per minute. Only present for relevant models.
+        max_audio_megabytes_per_1_minute:
+          type: integer
+          description: The maximum audio megabytes per minute. Only present for relevant
+            models.
+        max_requests_per_1_day:
+          type: integer
+          description: The maximum requests per day. Only present for relevant models.
+        batch_1_day_max_input_tokens:
+          type: integer
+          description: The maximum batch input tokens per day. Only present for relevant
+            models.
+      required:
+        - object
+        - id
+        - model
+        - max_requests_per_1_minute
+        - max_tokens_per_1_minute
+      x-oaiMeta:
+        name: The project rate limit object
+        example: |
+          {
+              "object": "project.rate_limit",
+              "id": "rl_ada",
+              "model": "ada",
+              "max_requests_per_1_minute": 600,
+              "max_tokens_per_1_minute": 150000,
+              "max_images_per_1_minute": 10
+          }
+    ProjectRateLimitListResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProjectRateLimit"
+        first_id:
+          type: string
+        last_id:
+          type: string
+        has_more:
+          type: boolean
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ProjectRateLimitUpdateRequest:
+      type: object
+      properties:
+        max_requests_per_1_minute:
+          type: integer
+          description: The maximum requests per minute.
+        max_tokens_per_1_minute:
+          type: integer
+          description: The maximum tokens per minute.
+        max_images_per_1_minute:
+          type: integer
+          description: The maximum images per minute. Only relevant for certain models.
+        max_audio_megabytes_per_1_minute:
+          type: integer
+          description: The maximum audio megabytes per minute. Only relevant for certain
+            models.
+        max_requests_per_1_day:
+          type: integer
+          description: The maximum requests per day. Only relevant for certain models.
+        batch_1_day_max_input_tokens:
+          type: integer
+          description: The maximum batch input tokens per day. Only relevant for certain
+            models.
+    ProjectServiceAccount:
+      type: object
+      description: Represents an individual service account in a project.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.project.service_account
+          description: The object type, which is always
+            `organization.project.service_account`
+          x-stainless-const: true
+        id:
+          type: string
+          description: The identifier, which can be referenced in API endpoints
+        name:
+          type: string
+          description: The name of the service account
+        role:
+          type: string
+          enum:
+            - owner
+            - member
+          description: "`owner` or `member`"
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the service account was
+            created
+      required:
+        - object
+        - id
+        - name
+        - role
+        - created_at
+      x-oaiMeta:
+        name: The project service account object
+        example: |
+          {
+              "object": "organization.project.service_account",
+              "id": "svc_acct_abc",
+              "name": "Service Account",
+              "role": "owner",
+              "created_at": 1711471533
+          }
+    ProjectServiceAccountApiKey:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.project.service_account.api_key
+          description: The object type, which is always
+            `organization.project.service_account.api_key`
+          x-stainless-const: true
+        value:
+          type: string
+        name:
+          type: string
+        created_at:
+          type: integer
+        id:
+          type: string
+      required:
+        - object
+        - value
+        - name
+        - created_at
+        - id
+    ProjectServiceAccountCreateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the service account being created.
+      required:
+        - name
+    ProjectServiceAccountCreateResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.project.service_account
+          x-stainless-const: true
+        id:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
+          enum:
+            - member
+          description: Service accounts can only have one role of type `member`
+          x-stainless-const: true
+        created_at:
+          type: integer
+        api_key:
+          $ref: "#/components/schemas/ProjectServiceAccountApiKey"
+      required:
+        - object
+        - id
+        - name
+        - role
+        - created_at
+        - api_key
+    ProjectServiceAccountDeleteResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.project.service_account.deleted
+          x-stainless-const: true
+        id:
+          type: string
+        deleted:
+          type: boolean
+      required:
+        - object
+        - id
+        - deleted
+    ProjectServiceAccountListResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProjectServiceAccount"
+        first_id:
+          type: string
+        last_id:
+          type: string
+        has_more:
+          type: boolean
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ProjectUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The updated name of the project, this name appears in reports.
+      required:
+        - name
+    ProjectUser:
+      type: object
+      description: Represents an individual user in a project.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.project.user
+          description: The object type, which is always `organization.project.user`
+          x-stainless-const: true
+        id:
+          type: string
+          description: The identifier, which can be referenced in API endpoints
+        name:
+          type: string
+          description: The name of the user
+        email:
+          type: string
+          description: The email address of the user
+        role:
+          type: string
+          enum:
+            - owner
+            - member
+          description: "`owner` or `member`"
+        added_at:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the project was added.
+      required:
+        - object
+        - id
+        - name
+        - email
+        - role
+        - added_at
+      x-oaiMeta:
+        name: The project user object
+        example: |
+          {
+              "object": "organization.project.user",
+              "id": "user_abc",
+              "name": "First Last",
+              "email": "user@example.com",
+              "role": "owner",
+              "added_at": 1711471533
+          }
+    ProjectUserCreateRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: The ID of the user.
+        role:
+          type: string
+          enum:
+            - owner
+            - member
+          description: "`owner` or `member`"
+      required:
+        - user_id
+        - role
+    ProjectUserDeleteResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.project.user.deleted
+          x-stainless-const: true
+        id:
+          type: string
+        deleted:
+          type: boolean
+      required:
+        - object
+        - id
+        - deleted
+    ProjectUserListResponse:
+      type: object
+      properties:
+        object:
+          type: string
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProjectUser"
+        first_id:
+          type: string
+        last_id:
+          type: string
+        has_more:
+          type: boolean
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    ProjectUserUpdateRequest:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - owner
+            - member
+          description: "`owner` or `member`"
+      required:
+        - role
+    RealtimeClientEventConversationItemCreate:
+      type: object
+      description: >
+        Add a new Item to the Conversation's context, including messages,
+        function 
+
+        calls, and function call responses. This event can be used both to
+        populate a 
+
+        "history" of the conversation and to add new items mid-stream, but has
+        the 
+
+        current limitation that it cannot populate assistant audio messages.
+
+
+        If successful, the server will respond with a
+        `conversation.item.created` 
+
+        event, otherwise an `error` event will be sent.
+      properties:
+        event_id:
+          type: string
+          description: Optional client-generated ID used to identify this event.
+        type:
+          type: string
+          enum:
+            - conversation.item.create
+          description: The event type, must be `conversation.item.create`.
+          x-stainless-const: true
+        previous_item_id:
+          type: string
+          description: >
+            The ID of the preceding item after which the new item will be
+            inserted. 
+
+            If not set, the new item will be appended to the end of the
+            conversation.
+
+            If set to `root`, the new item will be added to the beginning of the
+            conversation.
+
+            If set to an existing ID, it allows an item to be inserted
+            mid-conversation. If the
+
+            ID cannot be found, an error will be returned and the item will not
+            be added.
+        item:
+          $ref: "#/components/schemas/RealtimeConversationItem"
+      required:
+        - type
+        - item
+      x-oaiMeta:
+        name: conversation.item.create
+        group: realtime
+        example: |
+          {
+              "event_id": "event_345",
+              "type": "conversation.item.create",
+              "previous_item_id": null,
+              "item": {
+                  "id": "msg_001",
+                  "type": "message",
+                  "role": "user",
+                  "content": [
+                      {
+                          "type": "input_text",
+                          "text": "Hello, how are you?"
+                      }
+                  ]
+              }
+          }
+    RealtimeClientEventConversationItemDelete:
+      type: object
+      description: >
+        Send this event when you want to remove any item from the conversation 
+
+        history. The server will respond with a `conversation.item.deleted`
+        event, 
+
+        unless the item does not exist in the conversation history, in which
+        case the 
+
+        server will respond with an error.
+      properties:
+        event_id:
+          type: string
+          description: Optional client-generated ID used to identify this event.
+        type:
+          type: string
+          enum:
+            - conversation.item.delete
+          description: The event type, must be `conversation.item.delete`.
+          x-stainless-const: true
+        item_id:
+          type: string
+          description: The ID of the item to delete.
+      required:
+        - type
+        - item_id
+      x-oaiMeta:
+        name: conversation.item.delete
+        group: realtime
+        example: |
+          {
+              "event_id": "event_901",
+              "type": "conversation.item.delete",
+              "item_id": "msg_003"
+          }
+    RealtimeClientEventConversationItemTruncate:
+      type: object
+      description: >
+        Send this event to truncate a previous assistant message’s audio. The
+        server 
+
+        will produce audio faster than realtime, so this event is useful when
+        the user 
+
+        interrupts to truncate audio that has already been sent to the client
+        but not 
+
+        yet played. This will synchronize the server's understanding of the
+        audio with 
+
+        the client's playback.
+
+
+        Truncating audio will delete the server-side text transcript to ensure
+        there 
+
+        is not text in the context that hasn't been heard by the user.
+
+
+        If successful, the server will respond with a
+        `conversation.item.truncated` 
+
+        event. 
+      properties:
+        event_id:
+          type: string
+          description: Optional client-generated ID used to identify this event.
+        type:
+          type: string
+          enum:
+            - conversation.item.truncate
+          description: The event type, must be `conversation.item.truncate`.
+          x-stainless-const: true
+        item_id:
+          type: string
+          description: >
+            The ID of the assistant message item to truncate. Only assistant
+            message 
+
+            items can be truncated.
+        content_index:
+          type: integer
+          description: The index of the content part to truncate. Set this to 0.
+        audio_end_ms:
+          type: integer
+          description: >
+            Inclusive duration up to which audio is truncated, in milliseconds.
+            If 
+
+            the audio_end_ms is greater than the actual audio duration, the
+            server 
+
+            will respond with an error.
+      required:
+        - type
+        - item_id
+        - content_index
+        - audio_end_ms
+      x-oaiMeta:
+        name: conversation.item.truncate
+        group: realtime
+        example: |
+          {
+              "event_id": "event_678",
+              "type": "conversation.item.truncate",
+              "item_id": "msg_002",
+              "content_index": 0,
+              "audio_end_ms": 1500
+          }
+    RealtimeClientEventInputAudioBufferAppend:
+      type: object
+      description: >
+        Send this event to append audio bytes to the input audio buffer. The
+        audio 
+
+        buffer is temporary storage you can write to and later commit. In Server
+        VAD 
+
+        mode, the audio buffer is used to detect speech and the server will
+        decide 
+
+        when to commit. When Server VAD is disabled, you must commit the audio
+        buffer
+
+        manually.
+
+
+        The client may choose how much audio to place in each event up to a
+        maximum 
+
+        of 15 MiB, for example streaming smaller chunks from the client may
+        allow the 
+
+        VAD to be more responsive. Unlike made other client events, the server
+        will 
+
+        not send a confirmation response to this event.
+      properties:
+        event_id:
+          type: string
+          description: Optional client-generated ID used to identify this event.
+        type:
+          type: string
+          enum:
+            - input_audio_buffer.append
+          description: The event type, must be `input_audio_buffer.append`.
+          x-stainless-const: true
+        audio:
+          type: string
+          description: >
+            Base64-encoded audio bytes. This must be in the format specified by
+            the 
+
+            `input_audio_format` field in the session configuration.
+      required:
+        - type
+        - audio
+      x-oaiMeta:
+        name: input_audio_buffer.append
+        group: realtime
+        example: |
+          {
+              "event_id": "event_456",
+              "type": "input_audio_buffer.append",
+              "audio": "Base64EncodedAudioData"
+          }
+    RealtimeClientEventInputAudioBufferClear:
+      type: object
+      description: |
+        Send this event to clear the audio bytes in the buffer. The server will 
+        respond with an `input_audio_buffer.cleared` event.
+      properties:
+        event_id:
+          type: string
+          description: Optional client-generated ID used to identify this event.
+        type:
+          type: string
+          enum:
+            - input_audio_buffer.clear
+          description: The event type, must be `input_audio_buffer.clear`.
+          x-stainless-const: true
+      required:
+        - type
+      x-oaiMeta:
+        name: input_audio_buffer.clear
+        group: realtime
+        example: |
+          {
+              "event_id": "event_012",
+              "type": "input_audio_buffer.clear"
+          }
+    RealtimeClientEventInputAudioBufferCommit:
+      type: object
+      description: >
+        Send this event to commit the user input audio buffer, which will create
+        a 
+
+        new user message item in the conversation. This event will produce an
+        error 
+
+        if the input audio buffer is empty. When in Server VAD mode, the client
+        does 
+
+        not need to send this event, the server will commit the audio buffer 
+
+        automatically.
+
+
+        Committing the input audio buffer will trigger input audio
+        transcription 
+
+        (if enabled in session configuration), but it will not create a
+        response 
+
+        from the model. The server will respond with an
+        `input_audio_buffer.committed` 
+
+        event.
+      properties:
+        event_id:
+          type: string
+          description: Optional client-generated ID used to identify this event.
+        type:
+          type: string
+          enum:
+            - input_audio_buffer.commit
+          description: The event type, must be `input_audio_buffer.commit`.
+          x-stainless-const: true
+      required:
+        - type
+      x-oaiMeta:
+        name: input_audio_buffer.commit
+        group: realtime
+        example: |
+          {
+              "event_id": "event_789",
+              "type": "input_audio_buffer.commit"
+          }
+    RealtimeClientEventResponseCancel:
+      type: object
+      description: >
+        Send this event to cancel an in-progress response. The server will
+        respond 
+
+        with a `response.cancelled` event or an error if there is no response
+        to 
+
+        cancel.
+      properties:
+        event_id:
+          type: string
+          description: Optional client-generated ID used to identify this event.
+        type:
+          type: string
+          enum:
+            - response.cancel
+          description: The event type, must be `response.cancel`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: |
+            A specific response ID to cancel - if not provided, will cancel an 
+            in-progress response in the default conversation.
+      required:
+        - type
+      x-oaiMeta:
+        name: response.cancel
+        group: realtime
+        example: |
+          {
+              "event_id": "event_567",
+              "type": "response.cancel"
+          }
+    RealtimeClientEventResponseCreate:
+      type: object
+      description: >
+        This event instructs the server to create a Response, which means
+        triggering 
+
+        model inference. When in Server VAD mode, the server will create
+        Responses 
+
+        automatically.
+
+
+        A Response will include at least one Item, and may have two, in which
+        case 
+
+        the second will be a function call. These Items will be appended to the 
+
+        conversation history.
+
+
+        The server will respond with a `response.created` event, events for
+        Items 
+
+        and content created, and finally a `response.done` event to indicate
+        the 
+
+        Response is complete.
+
+
+        The `response.create` event includes inference configuration like 
+
+        `instructions`, and `temperature`. These fields will override the
+        Session's 
+
+        configuration for this Response only.
+      properties:
+        event_id:
+          type: string
+          description: Optional client-generated ID used to identify this event.
+        type:
+          type: string
+          enum:
+            - response.create
+          description: The event type, must be `response.create`.
+          x-stainless-const: true
+        response:
+          $ref: "#/components/schemas/RealtimeResponseCreateParams"
+      required:
+        - type
+      x-oaiMeta:
+        name: response.create
+        group: realtime
+        example: |
+          {
+              "event_id": "event_234",
+              "type": "response.create",
+              "response": {
+                  "modalities": ["text", "audio"],
+                  "instructions": "Please assist the user.",
+                  "voice": "sage",
+                  "output_audio_format": "pcm16",
+                  "tools": [
+                      {
+                          "type": "function",
+                          "name": "calculate_sum",
+                          "description": "Calculates the sum of two numbers.",
+                          "parameters": {
+                              "type": "object",
+                              "properties": {
+                                  "a": { "type": "number" },
+                                  "b": { "type": "number" }
+                              },
+                              "required": ["a", "b"]
+                          }
+                      }
+                  ],
+                  "tool_choice": "auto",
+                  "temperature": 0.8,
+                  "max_output_tokens": 1024
+              }
+          }
+    RealtimeClientEventSessionUpdate:
+      type: object
+      description: >
+        Send this event to update the session’s default configuration. The
+        client may 
+
+        send this event at any time to update the session configuration, and
+        any 
+
+        field may be updated at any time, except for "voice". The server will
+        respond 
+
+        with a `session.updated` event that shows the full effective
+        configuration. 
+
+        Only fields that are present are updated, thus the correct way to clear
+        a 
+
+        field like "instructions" is to pass an empty string.
+      properties:
+        event_id:
+          type: string
+          description: Optional client-generated ID used to identify this event.
+        type:
+          type: string
+          enum:
+            - session.update
+          description: The event type, must be `session.update`.
+          x-stainless-const: true
+        session:
+          $ref: "#/components/schemas/RealtimeSessionCreateRequest"
+      required:
+        - type
+        - session
+      x-oaiMeta:
+        name: session.update
+        group: realtime
+        example: |
+          {
+              "event_id": "event_123",
+              "type": "session.update",
+              "session": {
+                  "modalities": ["text", "audio"],
+                  "instructions": "You are a helpful assistant.",
+                  "voice": "sage",
+                  "input_audio_format": "pcm16",
+                  "output_audio_format": "pcm16",
+                  "input_audio_transcription": {
+                      "model": "whisper-1"
+                  },
+                  "turn_detection": {
+                      "type": "server_vad",
+                      "threshold": 0.5,
+                      "prefix_padding_ms": 300,
+                      "silence_duration_ms": 500,
+                      "create_response": true
+                  },
+                  "tools": [
+                      {
+                          "type": "function",
+                          "name": "get_weather",
+                          "description": "Get the current weather...",
+                          "parameters": {
+                              "type": "object",
+                              "properties": {
+                                  "location": { "type": "string" }
+                              },
+                              "required": ["location"]
+                          }
+                      }
+                  ],
+                  "tool_choice": "auto",
+                  "temperature": 0.8,
+                  "max_response_output_tokens": "inf"
+              }
+          }
+    RealtimeConversationItem:
+      type: object
+      x-oaiExpandable: true
+      description: The item to add to the conversation.
+      properties:
+        id:
+          type: string
+          description: >
+            The unique ID of the item, this can be generated by the client to
+            help 
+
+            manage server-side context, but is not required because the server
+            will 
+
+            generate one if not provided.
+        type:
+          type: string
+          enum:
+            - message
+            - function_call
+            - function_call_output
+          description: >
+            The type of the item (`message`, `function_call`,
+            `function_call_output`).
+        object:
+          type: string
+          enum:
+            - realtime.item
+          description: >
+            Identifier for the API object being returned - always
+            `realtime.item`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - incomplete
+          description: >
+            The status of the item (`completed`, `incomplete`). These have no
+            effect 
+
+            on the conversation, but are accepted for consistency with the 
+
+            `conversation.item.created` event.
+        role:
+          type: string
+          enum:
+            - user
+            - assistant
+            - system
+          description: >
+            The role of the message sender (`user`, `assistant`, `system`),
+            only 
+
+            applicable for `message` items.
+        content:
+          type: array
+          x-oaiExpandable: true
+          description: >
+            The content of the message, applicable for `message` items. 
+
+            - Message items of role `system` support only `input_text` content
+
+            - Message items of role `user` support `input_text` and
+            `input_audio` 
+              content
+            - Message items of role `assistant` support `text` content.
+          items:
+            type: object
+            x-oaiExpandable: true
+            properties:
+              type:
+                type: string
+                enum:
+                  - input_audio
+                  - input_text
+                  - item_reference
+                  - text
+                description: >
+                  The content type (`input_text`, `input_audio`,
+                  `item_reference`, `text`).
+              text:
+                type: string
+                description: >
+                  The text content, used for `input_text` and `text` content
+                  types.
+              id:
+                type: string
+                description: >
+                  ID of a previous conversation item to reference (for
+                  `item_reference`
+
+                  content types in `response.create` events). These can
+                  reference both
+
+                  client and server created items.
+              audio:
+                type: string
+                description: >
+                  Base64-encoded audio bytes, used for `input_audio` content
+                  type.
+              transcript:
+                type: string
+                description: >
+                  The transcript of the audio, used for `input_audio` content
+                  type.
+        call_id:
+          type: string
+          description: >
+            The ID of the function call (for `function_call` and 
+
+            `function_call_output` items). If passed on a
+            `function_call_output` 
+
+            item, the server will check that a `function_call` item with the
+            same 
+
+            ID exists in the conversation history.
+        name:
+          type: string
+          description: |
+            The name of the function being called (for `function_call` items).
+        arguments:
+          type: string
+          description: |
+            The arguments of the function call (for `function_call` items).
+        output:
+          type: string
+          description: |
+            The output of the function call (for `function_call_output` items).
+    RealtimeResponse:
+      type: object
+      description: The response resource.
+      properties:
+        id:
+          type: string
+          description: The unique ID of the response.
+        object:
+          type: string
+          enum:
+            - realtime.response
+          description: The object type, must be `realtime.response`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - cancelled
+            - failed
+            - incomplete
+          description: >
+            The final status of the response (`completed`, `cancelled`,
+            `failed`, or 
+
+            `incomplete`).
+        status_details:
+          type: object
+          description: Additional details about the status.
+          properties:
+            type:
+              type: string
+              enum:
+                - completed
+                - cancelled
+                - failed
+                - incomplete
+              description: >
+                The type of error that caused the response to fail,
+                corresponding 
+
+                with the `status` field (`completed`, `cancelled`,
+                `incomplete`, 
+
+                `failed`).
+            reason:
+              type: string
+              enum:
+                - turn_detected
+                - client_cancelled
+                - max_output_tokens
+                - content_filter
+              description: >
+                The reason the Response did not complete. For a `cancelled`
+                Response, 
+
+                one of `turn_detected` (the server VAD detected a new start of
+                speech) 
+
+                or `client_cancelled` (the client sent a cancel event). For an 
+
+                `incomplete` Response, one of `max_output_tokens` or
+                `content_filter` 
+
+                (the server-side safety filter activated and cut off the
+                response).
+            error:
+              type: object
+              description: |
+                A description of the error that caused the response to fail, 
+                populated when the `status` is `failed`.
+              properties:
+                type:
+                  type: string
+                  description: The type of error.
+                code:
+                  type: string
+                  description: Error code, if any.
+        output:
+          type: array
+          description: The list of output items generated by the response.
+          items:
+            $ref: "#/components/schemas/RealtimeConversationItem"
+        metadata:
+          description: >
+            Developer-provided string key-value pairs associated with this
+            response.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+        usage:
+          type: object
+          description: >
+            Usage statistics for the Response, this will correspond to billing.
+            A 
+
+            Realtime API session will maintain a conversation context and append
+            new 
+
+            Items to the Conversation, thus output from previous turns (text
+            and 
+
+            audio tokens) will become the input for later turns.
+          properties:
+            total_tokens:
+              type: integer
+              description: >
+                The total number of tokens in the Response including input and
+                output 
+
+                text and audio tokens.
+            input_tokens:
+              type: integer
+              description: >
+                The number of input tokens used in the Response, including text
+                and 
+
+                audio tokens.
+            output_tokens:
+              type: integer
+              description: >
+                The number of output tokens sent in the Response, including text
+                and 
+
+                audio tokens.
+            input_token_details:
+              type: object
+              description: Details about the input tokens used in the Response.
+              properties:
+                cached_tokens:
+                  type: integer
+                  description: The number of cached tokens used in the Response.
+                text_tokens:
+                  type: integer
+                  description: The number of text tokens used in the Response.
+                audio_tokens:
+                  type: integer
+                  description: The number of audio tokens used in the Response.
+            output_token_details:
+              type: object
+              description: Details about the output tokens used in the Response.
+              properties:
+                text_tokens:
+                  type: integer
+                  description: The number of text tokens used in the Response.
+                audio_tokens:
+                  type: integer
+                  description: The number of audio tokens used in the Response.
+    RealtimeResponseCreateParams:
+      type: object
+      description: Create a new Realtime response with these parameters
+      properties:
+        modalities:
+          type: array
+          description: |
+            The set of modalities the model can respond with. To disable audio,
+            set this to ["text"].
+          items:
+            type: string
+            enum:
+              - text
+              - audio
+        instructions:
+          type: string
+          description: >
+            The default system instructions (i.e. system message) prepended to
+            model 
+
+            calls. This field allows the client to guide the model on desired 
+
+            responses. The model can be instructed on response content and
+            format, 
+
+            (e.g. "be extremely succinct", "act friendly", "here are examples of
+            good 
+
+            responses") and on audio behavior (e.g. "talk quickly", "inject
+            emotion 
+
+            into your voice", "laugh frequently"). The instructions are not
+            guaranteed 
+
+            to be followed by the model, but they provide guidance to the model
+            on the 
+
+            desired behavior.
+
+
+            Note that the server sets default instructions which will be used if
+            this 
+
+            field is not set and are visible in the `session.created` event at
+            the 
+
+            start of the session.
+        voice:
+          type: string
+          enum:
+            - alloy
+            - ash
+            - ballad
+            - coral
+            - echo
+            - sage
+            - shimmer
+            - verse
+          description: >
+            The voice the model uses to respond. Voice cannot be changed during
+            the 
+
+            session once the model has responded with audio at least once.
+            Current 
+
+            voice options are `alloy`, `ash`, `ballad`, `coral`, `echo` `sage`, 
+
+            `shimmer` and `verse`.
+        output_audio_format:
+          type: string
+          enum:
+            - pcm16
+            - g711_ulaw
+            - g711_alaw
+          description: >
+            The format of output audio. Options are `pcm16`, `g711_ulaw`, or
+            `g711_alaw`.
+        tools:
+          type: array
+          description: Tools (functions) available to the model.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - function
+                description: The type of the tool, i.e. `function`.
+                x-stainless-const: true
+              name:
+                type: string
+                description: The name of the function.
+              description:
+                type: string
+                description: >
+                  The description of the function, including guidance on when
+                  and how 
+
+                  to call it, and guidance about what to tell the user when
+                  calling 
+
+                  (if anything).
+              parameters:
+                type: object
+                description: Parameters of the function in JSON Schema.
+        tool_choice:
+          type: string
+          description: >
+            How the model chooses tools. Options are `auto`, `none`, `required`,
+            or 
+
+            specify a function, like `{"type": "function", "function": {"name":
+            "my_function"}}`.
+        temperature:
+          type: number
+          description: >
+            Sampling temperature for the model, limited to [0.6, 1.2]. Defaults
+            to 0.8.
+        max_response_output_tokens:
+          oneOf:
+            - type: integer
+            - type: string
+              enum:
+                - inf
+              x-stainless-const: true
+          description: |
+            Maximum number of output tokens for a single assistant response,
+            inclusive of tool calls. Provide an integer between 1 and 4096 to
+            limit output tokens, or `inf` for the maximum available tokens for a
+            given model. Defaults to `inf`.
+        conversation:
+          description: >
+            Controls which conversation the response is added to. Currently
+            supports
+
+            `auto` and `none`, with `auto` as the default value. The `auto`
+            value
+
+            means that the contents of the response will be added to the default
+
+            conversation. Set this to `none` to create an out-of-band response
+            which 
+
+            will not add items to default conversation.
+          oneOf:
+            - type: string
+            - type: string
+              default: auto
+              enum:
+                - auto
+                - none
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be
+
+            useful for storing additional information about the object in a
+            structured
+
+            format. Keys can be a maximum of 64 characters long and values can
+            be a
+
+            maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+        input:
+          type: array
+          description: >
+            Input items to include in the prompt for the model. Creates a new
+            context
+
+            for this response, without including the default conversation. Can
+            include
+
+            references to items from the default conversation.
+          items:
+            $ref: "#/components/schemas/RealtimeConversationItem"
+    RealtimeServerEventConversationCreated:
+      type: object
+      description: >
+        Returned when a conversation is created. Emitted right after session
+        creation.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - conversation.created
+          description: The event type, must be `conversation.created`.
+          x-stainless-const: true
+        conversation:
+          type: object
+          description: The conversation resource.
+          properties:
+            id:
+              type: string
+              description: The unique ID of the conversation.
+            object:
+              type: string
+              description: The object type, must be `realtime.conversation`.
+      required:
+        - event_id
+        - type
+        - conversation
+      x-oaiMeta:
+        name: conversation.created
+        group: realtime
+        example: |
+          {
+              "event_id": "event_9101",
+              "type": "conversation.created",
+              "conversation": {
+                  "id": "conv_001",
+                  "object": "realtime.conversation"
+              }
+          }
+    RealtimeServerEventConversationItemCreated:
+      type: object
+      description: >
+        Returned when a conversation item is created. There are several
+        scenarios that 
+
+        produce this event:
+          - The server is generating a Response, which if successful will produce 
+            either one or two Items, which will be of type `message` 
+            (role `assistant`) or type `function_call`.
+          - The input audio buffer has been committed, either by the client or the 
+            server (in `server_vad` mode). The server will take the content of the 
+            input audio buffer and add it to a new user message Item.
+          - The client has sent a `conversation.item.create` event to add a new Item 
+            to the Conversation.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - conversation.item.created
+          description: The event type, must be `conversation.item.created`.
+          x-stainless-const: true
+        previous_item_id:
+          type: string
+          description: >
+            The ID of the preceding item in the Conversation context, allows
+            the 
+
+            client to understand the order of the conversation.
+        item:
+          $ref: "#/components/schemas/RealtimeConversationItem"
+      required:
+        - event_id
+        - type
+        - previous_item_id
+        - item
+      x-oaiMeta:
+        name: conversation.item.created
+        group: realtime
+        example: |
+          {
+              "event_id": "event_1920",
+              "type": "conversation.item.created",
+              "previous_item_id": "msg_002",
+              "item": {
+                  "id": "msg_003",
+                  "object": "realtime.item",
+                  "type": "message",
+                  "status": "completed",
+                  "role": "user",
+                  "content": [
+                      {
+                          "type": "input_audio",
+                          "transcript": "hello how are you",
+                          "audio": "base64encodedaudio=="
+                      }
+                  ]
+              }
+          }
+    RealtimeServerEventConversationItemDeleted:
+      type: object
+      description: >
+        Returned when an item in the conversation is deleted by the client with
+        a 
+
+        `conversation.item.delete` event. This event is used to synchronize the 
+
+        server's understanding of the conversation history with the client's
+        view.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - conversation.item.deleted
+          description: The event type, must be `conversation.item.deleted`.
+          x-stainless-const: true
+        item_id:
+          type: string
+          description: The ID of the item that was deleted.
+      required:
+        - event_id
+        - type
+        - item_id
+      x-oaiMeta:
+        name: conversation.item.deleted
+        group: realtime
+        example: |
+          {
+              "event_id": "event_2728",
+              "type": "conversation.item.deleted",
+              "item_id": "msg_005"
+          }
+    RealtimeServerEventConversationItemInputAudioTranscriptionCompleted:
+      type: object
+      description: >
+        This event is the output of audio transcription for user audio written
+        to the 
+
+        user audio buffer. Transcription begins when the input audio buffer is 
+
+        committed by the client or server (in `server_vad` mode). Transcription
+        runs 
+
+        asynchronously with Response creation, so this event may come before or
+        after 
+
+        the Response events.
+
+
+        Realtime API models accept audio natively, and thus input transcription
+        is a 
+
+        separate process run on a separate ASR (Automatic Speech Recognition)
+        model, 
+
+        currently always `whisper-1`. Thus the transcript may diverge somewhat
+        from 
+
+        the model's interpretation, and should be treated as a rough guide.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - conversation.item.input_audio_transcription.completed
+          description: |
+            The event type, must be
+            `conversation.item.input_audio_transcription.completed`.
+          x-stainless-const: true
+        item_id:
+          type: string
+          description: The ID of the user message item containing the audio.
+        content_index:
+          type: integer
+          description: The index of the content part containing the audio.
+        transcript:
+          type: string
+          description: The transcribed text.
+      required:
+        - event_id
+        - type
+        - item_id
+        - content_index
+        - transcript
+      x-oaiMeta:
+        name: conversation.item.input_audio_transcription.completed
+        group: realtime
+        example: |
+          {
+              "event_id": "event_2122",
+              "type": "conversation.item.input_audio_transcription.completed",
+              "item_id": "msg_003",
+              "content_index": 0,
+              "transcript": "Hello, how are you?"
+          }
+    RealtimeServerEventConversationItemInputAudioTranscriptionFailed:
+      type: object
+      description: >
+        Returned when input audio transcription is configured, and a
+        transcription 
+
+        request for a user message failed. These events are separate from other 
+
+        `error` events so that the client can identify the related Item.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - conversation.item.input_audio_transcription.failed
+          description: |
+            The event type, must be
+            `conversation.item.input_audio_transcription.failed`.
+          x-stainless-const: true
+        item_id:
+          type: string
+          description: The ID of the user message item.
+        content_index:
+          type: integer
+          description: The index of the content part containing the audio.
+        error:
+          type: object
+          description: Details of the transcription error.
+          properties:
+            type:
+              type: string
+              description: The type of error.
+            code:
+              type: string
+              description: Error code, if any.
+            message:
+              type: string
+              description: A human-readable error message.
+            param:
+              type: string
+              description: Parameter related to the error, if any.
+      required:
+        - event_id
+        - type
+        - item_id
+        - content_index
+        - error
+      x-oaiMeta:
+        name: conversation.item.input_audio_transcription.failed
+        group: realtime
+        example: |
+          {
+              "event_id": "event_2324",
+              "type": "conversation.item.input_audio_transcription.failed",
+              "item_id": "msg_003",
+              "content_index": 0,
+              "error": {
+                  "type": "transcription_error",
+                  "code": "audio_unintelligible",
+                  "message": "The audio could not be transcribed.",
+                  "param": null
+              }
+          }
+    RealtimeServerEventConversationItemTruncated:
+      type: object
+      description: >
+        Returned when an earlier assistant audio message item is truncated by
+        the 
+
+        client with a `conversation.item.truncate` event. This event is used to 
+
+        synchronize the server's understanding of the audio with the client's
+        playback.
+
+
+        This action will truncate the audio and remove the server-side text
+        transcript 
+
+        to ensure there is no text in the context that hasn't been heard by the
+        user.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - conversation.item.truncated
+          description: The event type, must be `conversation.item.truncated`.
+          x-stainless-const: true
+        item_id:
+          type: string
+          description: The ID of the assistant message item that was truncated.
+        content_index:
+          type: integer
+          description: The index of the content part that was truncated.
+        audio_end_ms:
+          type: integer
+          description: |
+            The duration up to which the audio was truncated, in milliseconds.
+      required:
+        - event_id
+        - type
+        - item_id
+        - content_index
+        - audio_end_ms
+      x-oaiMeta:
+        name: conversation.item.truncated
+        group: realtime
+        example: |
+          {
+              "event_id": "event_2526",
+              "type": "conversation.item.truncated",
+              "item_id": "msg_004",
+              "content_index": 0,
+              "audio_end_ms": 1500
+          }
+    RealtimeServerEventError:
+      type: object
+      description: >
+        Returned when an error occurs, which could be a client problem or a
+        server 
+
+        problem. Most errors are recoverable and the session will stay open, we 
+
+        recommend to implementors to monitor and log error messages by default.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - error
+          description: The event type, must be `error`.
+          x-stainless-const: true
+        error:
+          type: object
+          description: Details of the error.
+          required:
+            - type
+            - message
+          properties:
+            type:
+              type: string
+              description: >
+                The type of error (e.g., "invalid_request_error",
+                "server_error").
+            code:
+              type: string
+              description: Error code, if any.
+              nullable: true
+            message:
+              type: string
+              description: A human-readable error message.
+            param:
+              type: string
+              description: Parameter related to the error, if any.
+              nullable: true
+            event_id:
+              type: string
+              description: >
+                The event_id of the client event that caused the error, if
+                applicable.
+              nullable: true
+      required:
+        - event_id
+        - type
+        - error
+      x-oaiMeta:
+        name: error
+        group: realtime
+        example: |
+          {
+              "event_id": "event_890",
+              "type": "error",
+              "error": {
+                  "type": "invalid_request_error",
+                  "code": "invalid_event",
+                  "message": "The 'type' field is missing.",
+                  "param": null,
+                  "event_id": "event_567"
+              }
+          }
+    RealtimeServerEventInputAudioBufferCleared:
+      type: object
+      description: |
+        Returned when the input audio buffer is cleared by the client with a 
+        `input_audio_buffer.clear` event.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - input_audio_buffer.cleared
+          description: The event type, must be `input_audio_buffer.cleared`.
+          x-stainless-const: true
+      required:
+        - event_id
+        - type
+      x-oaiMeta:
+        name: input_audio_buffer.cleared
+        group: realtime
+        example: |
+          {
+              "event_id": "event_1314",
+              "type": "input_audio_buffer.cleared"
+          }
+    RealtimeServerEventInputAudioBufferCommitted:
+      type: object
+      description: >
+        Returned when an input audio buffer is committed, either by the client
+        or 
+
+        automatically in server VAD mode. The `item_id` property is the ID of
+        the user
+
+        message item that will be created, thus a `conversation.item.created`
+        event 
+
+        will also be sent to the client.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - input_audio_buffer.committed
+          description: The event type, must be `input_audio_buffer.committed`.
+          x-stainless-const: true
+        previous_item_id:
+          type: string
+          description: >
+            The ID of the preceding item after which the new item will be
+            inserted.
+        item_id:
+          type: string
+          description: The ID of the user message item that will be created.
+      required:
+        - event_id
+        - type
+        - previous_item_id
+        - item_id
+      x-oaiMeta:
+        name: input_audio_buffer.committed
+        group: realtime
+        example: |
+          {
+              "event_id": "event_1121",
+              "type": "input_audio_buffer.committed",
+              "previous_item_id": "msg_001",
+              "item_id": "msg_002"
+          }
+    RealtimeServerEventInputAudioBufferSpeechStarted:
+      type: object
+      description: >
+        Sent by the server when in `server_vad` mode to indicate that speech has
+        been 
+
+        detected in the audio buffer. This can happen any time audio is added to
+        the 
+
+        buffer (unless speech is already detected). The client may want to use
+        this 
+
+        event to interrupt audio playback or provide visual feedback to the
+        user. 
+
+
+        The client should expect to receive a
+        `input_audio_buffer.speech_stopped` event 
+
+        when speech stops. The `item_id` property is the ID of the user message
+        item 
+
+        that will be created when speech stops and will also be included in the 
+
+        `input_audio_buffer.speech_stopped` event (unless the client manually
+        commits 
+
+        the audio buffer during VAD activation).
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - input_audio_buffer.speech_started
+          description: The event type, must be `input_audio_buffer.speech_started`.
+          x-stainless-const: true
+        audio_start_ms:
+          type: integer
+          description: >
+            Milliseconds from the start of all audio written to the buffer
+            during the 
+
+            session when speech was first detected. This will correspond to the 
+
+            beginning of audio sent to the model, and thus includes the 
+
+            `prefix_padding_ms` configured in the Session.
+        item_id:
+          type: string
+          description: >
+            The ID of the user message item that will be created when speech
+            stops.
+      required:
+        - event_id
+        - type
+        - audio_start_ms
+        - item_id
+      x-oaiMeta:
+        name: input_audio_buffer.speech_started
+        group: realtime
+        example: |
+          {
+              "event_id": "event_1516",
+              "type": "input_audio_buffer.speech_started",
+              "audio_start_ms": 1000,
+              "item_id": "msg_003"
+          }
+    RealtimeServerEventInputAudioBufferSpeechStopped:
+      type: object
+      description: >
+        Returned in `server_vad` mode when the server detects the end of speech
+        in 
+
+        the audio buffer. The server will also send an
+        `conversation.item.created` 
+
+        event with the user message item that is created from the audio buffer.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - input_audio_buffer.speech_stopped
+          description: The event type, must be `input_audio_buffer.speech_stopped`.
+          x-stainless-const: true
+        audio_end_ms:
+          type: integer
+          description: >
+            Milliseconds since the session started when speech stopped. This
+            will 
+
+            correspond to the end of audio sent to the model, and thus includes
+            the 
+
+            `min_silence_duration_ms` configured in the Session.
+        item_id:
+          type: string
+          description: The ID of the user message item that will be created.
+      required:
+        - event_id
+        - type
+        - audio_end_ms
+        - item_id
+      x-oaiMeta:
+        name: input_audio_buffer.speech_stopped
+        group: realtime
+        example: |
+          {
+              "event_id": "event_1718",
+              "type": "input_audio_buffer.speech_stopped",
+              "audio_end_ms": 2000,
+              "item_id": "msg_003"
+          }
+    RealtimeServerEventRateLimitsUpdated:
+      type: object
+      description: >
+        Emitted at the beginning of a Response to indicate the updated rate
+        limits. 
+
+        When a Response is created some tokens will be "reserved" for the
+        output 
+
+        tokens, the rate limits shown here reflect that reservation, which is
+        then 
+
+        adjusted accordingly once the Response is completed.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - rate_limits.updated
+          description: The event type, must be `rate_limits.updated`.
+          x-stainless-const: true
+        rate_limits:
+          type: array
+          description: List of rate limit information.
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                enum:
+                  - requests
+                  - tokens
+                description: |
+                  The name of the rate limit (`requests`, `tokens`).
+              limit:
+                type: integer
+                description: The maximum allowed value for the rate limit.
+              remaining:
+                type: integer
+                description: The remaining value before the limit is reached.
+              reset_seconds:
+                type: number
+                description: Seconds until the rate limit resets.
+      required:
+        - event_id
+        - type
+        - rate_limits
+      x-oaiMeta:
+        name: rate_limits.updated
+        group: realtime
+        example: |
+          {
+              "event_id": "event_5758",
+              "type": "rate_limits.updated",
+              "rate_limits": [
+                  {
+                      "name": "requests",
+                      "limit": 1000,
+                      "remaining": 999,
+                      "reset_seconds": 60
+                  },
+                  {
+                      "name": "tokens",
+                      "limit": 50000,
+                      "remaining": 49950,
+                      "reset_seconds": 60
+                  }
+              ]
+          }
+    RealtimeServerEventResponseAudioDelta:
+      type: object
+      description: Returned when the model-generated audio is updated.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.audio.delta
+          description: The event type, must be `response.audio.delta`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the item.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        content_index:
+          type: integer
+          description: The index of the content part in the item's content array.
+        delta:
+          type: string
+          description: Base64-encoded audio data delta.
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - content_index
+        - delta
+      x-oaiMeta:
+        name: response.audio.delta
+        group: realtime
+        example: |
+          {
+              "event_id": "event_4950",
+              "type": "response.audio.delta",
+              "response_id": "resp_001",
+              "item_id": "msg_008",
+              "output_index": 0,
+              "content_index": 0,
+              "delta": "Base64EncodedAudioDelta"
+          }
+    RealtimeServerEventResponseAudioDone:
+      type: object
+      description: >
+        Returned when the model-generated audio is done. Also emitted when a
+        Response
+
+        is interrupted, incomplete, or cancelled.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.audio.done
+          description: The event type, must be `response.audio.done`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the item.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        content_index:
+          type: integer
+          description: The index of the content part in the item's content array.
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - content_index
+      x-oaiMeta:
+        name: response.audio.done
+        group: realtime
+        example: |
+          {
+              "event_id": "event_5152",
+              "type": "response.audio.done",
+              "response_id": "resp_001",
+              "item_id": "msg_008",
+              "output_index": 0,
+              "content_index": 0
+          }
+    RealtimeServerEventResponseAudioTranscriptDelta:
+      type: object
+      description: >
+        Returned when the model-generated transcription of audio output is
+        updated.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.audio_transcript.delta
+          description: The event type, must be `response.audio_transcript.delta`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the item.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        content_index:
+          type: integer
+          description: The index of the content part in the item's content array.
+        delta:
+          type: string
+          description: The transcript delta.
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - content_index
+        - delta
+      x-oaiMeta:
+        name: response.audio_transcript.delta
+        group: realtime
+        example: |
+          {
+              "event_id": "event_4546",
+              "type": "response.audio_transcript.delta",
+              "response_id": "resp_001",
+              "item_id": "msg_008",
+              "output_index": 0,
+              "content_index": 0,
+              "delta": "Hello, how can I a"
+          }
+    RealtimeServerEventResponseAudioTranscriptDone:
+      type: object
+      description: |
+        Returned when the model-generated transcription of audio output is done
+        streaming. Also emitted when a Response is interrupted, incomplete, or
+        cancelled.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.audio_transcript.done
+          description: The event type, must be `response.audio_transcript.done`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the item.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        content_index:
+          type: integer
+          description: The index of the content part in the item's content array.
+        transcript:
+          type: string
+          description: The final transcript of the audio.
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - content_index
+        - transcript
+      x-oaiMeta:
+        name: response.audio_transcript.done
+        group: realtime
+        example: |
+          {
+              "event_id": "event_4748",
+              "type": "response.audio_transcript.done",
+              "response_id": "resp_001",
+              "item_id": "msg_008",
+              "output_index": 0,
+              "content_index": 0,
+              "transcript": "Hello, how can I assist you today?"
+          }
+    RealtimeServerEventResponseContentPartAdded:
+      type: object
+      description: >
+        Returned when a new content part is added to an assistant message item
+        during
+
+        response generation.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.content_part.added
+          description: The event type, must be `response.content_part.added`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the item to which the content part was added.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        content_index:
+          type: integer
+          description: The index of the content part in the item's content array.
+        part:
+          type: object
+          description: The content part that was added.
+          properties:
+            type:
+              type: string
+              enum:
+                - audio
+                - text
+              description: The content type ("text", "audio").
+            text:
+              type: string
+              description: The text content (if type is "text").
+            audio:
+              type: string
+              description: Base64-encoded audio data (if type is "audio").
+            transcript:
+              type: string
+              description: The transcript of the audio (if type is "audio").
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - content_index
+        - part
+      x-oaiMeta:
+        name: response.content_part.added
+        group: realtime
+        example: |
+          {
+              "event_id": "event_3738",
+              "type": "response.content_part.added",
+              "response_id": "resp_001",
+              "item_id": "msg_007",
+              "output_index": 0,
+              "content_index": 0,
+              "part": {
+                  "type": "text",
+                  "text": ""
+              }
+          }
+    RealtimeServerEventResponseContentPartDone:
+      type: object
+      description: >
+        Returned when a content part is done streaming in an assistant message
+        item.
+
+        Also emitted when a Response is interrupted, incomplete, or cancelled.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.content_part.done
+          description: The event type, must be `response.content_part.done`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the item.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        content_index:
+          type: integer
+          description: The index of the content part in the item's content array.
+        part:
+          type: object
+          description: The content part that is done.
+          properties:
+            type:
+              type: string
+              enum:
+                - audio
+                - text
+              description: The content type ("text", "audio").
+            text:
+              type: string
+              description: The text content (if type is "text").
+            audio:
+              type: string
+              description: Base64-encoded audio data (if type is "audio").
+            transcript:
+              type: string
+              description: The transcript of the audio (if type is "audio").
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - content_index
+        - part
+      x-oaiMeta:
+        name: response.content_part.done
+        group: realtime
+        example: |
+          {
+              "event_id": "event_3940",
+              "type": "response.content_part.done",
+              "response_id": "resp_001",
+              "item_id": "msg_007",
+              "output_index": 0,
+              "content_index": 0,
+              "part": {
+                  "type": "text",
+                  "text": "Sure, I can help with that."
+              }
+          }
+    RealtimeServerEventResponseCreated:
+      type: object
+      description: >
+        Returned when a new Response is created. The first event of response
+        creation,
+
+        where the response is in an initial state of `in_progress`.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.created
+          description: The event type, must be `response.created`.
+          x-stainless-const: true
+        response:
+          $ref: "#/components/schemas/RealtimeResponse"
+      required:
+        - event_id
+        - type
+        - response
+      x-oaiMeta:
+        name: response.created
+        group: realtime
+        example: |
+          {
+              "event_id": "event_2930",
+              "type": "response.created",
+              "response": {
+                  "id": "resp_001",
+                  "object": "realtime.response",
+                  "status": "in_progress",
+                  "status_details": null,
+                  "output": [],
+                  "usage": null
+              }
+          }
+    RealtimeServerEventResponseDone:
+      type: object
+      description: >
+        Returned when a Response is done streaming. Always emitted, no matter
+        the 
+
+        final state. The Response object included in the `response.done` event
+        will 
+
+        include all output Items in the Response but will omit the raw audio
+        data.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.done
+          description: The event type, must be `response.done`.
+          x-stainless-const: true
+        response:
+          $ref: "#/components/schemas/RealtimeResponse"
+      required:
+        - event_id
+        - type
+        - response
+      x-oaiMeta:
+        name: response.done
+        group: realtime
+        example: |
+          {
+              "event_id": "event_3132",
+              "type": "response.done",
+              "response": {
+                  "id": "resp_001",
+                  "object": "realtime.response",
+                  "status": "completed",
+                  "status_details": null,
+                  "output": [
+                      {
+                          "id": "msg_006",
+                          "object": "realtime.item",
+                          "type": "message",
+                          "status": "completed",
+                          "role": "assistant",
+                          "content": [
+                              {
+                                  "type": "text",
+                                  "text": "Sure, how can I assist you today?"
+                              }
+                          ]
+                      }
+                  ],
+                  "usage": {
+                      "total_tokens":275,
+                      "input_tokens":127,
+                      "output_tokens":148,
+                      "input_token_details": {
+                          "cached_tokens":384,
+                          "text_tokens":119,
+                          "audio_tokens":8,
+                          "cached_tokens_details": {
+                              "text_tokens": 128,
+                              "audio_tokens": 256
+                          }
+                      },
+                      "output_token_details": {
+                        "text_tokens":36,
+                        "audio_tokens":112
+                      }
+                  }
+              }
+          }
+    RealtimeServerEventResponseFunctionCallArgumentsDelta:
+      type: object
+      description: |
+        Returned when the model-generated function call arguments are updated.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.function_call_arguments.delta
+          description: |
+            The event type, must be `response.function_call_arguments.delta`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the function call item.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        call_id:
+          type: string
+          description: The ID of the function call.
+        delta:
+          type: string
+          description: The arguments delta as a JSON string.
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - call_id
+        - delta
+      x-oaiMeta:
+        name: response.function_call_arguments.delta
+        group: realtime
+        example: |
+          {
+              "event_id": "event_5354",
+              "type": "response.function_call_arguments.delta",
+              "response_id": "resp_002",
+              "item_id": "fc_001",
+              "output_index": 0,
+              "call_id": "call_001",
+              "delta": "{\"location\": \"San\""
+          }
+    RealtimeServerEventResponseFunctionCallArgumentsDone:
+      type: object
+      description: >
+        Returned when the model-generated function call arguments are done
+        streaming.
+
+        Also emitted when a Response is interrupted, incomplete, or cancelled.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.function_call_arguments.done
+          description: |
+            The event type, must be `response.function_call_arguments.done`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the function call item.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        call_id:
+          type: string
+          description: The ID of the function call.
+        arguments:
+          type: string
+          description: The final arguments as a JSON string.
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - call_id
+        - arguments
+      x-oaiMeta:
+        name: response.function_call_arguments.done
+        group: realtime
+        example: |
+          {
+              "event_id": "event_5556",
+              "type": "response.function_call_arguments.done",
+              "response_id": "resp_002",
+              "item_id": "fc_001",
+              "output_index": 0,
+              "call_id": "call_001",
+              "arguments": "{\"location\": \"San Francisco\"}"
+          }
+    RealtimeServerEventResponseOutputItemAdded:
+      type: object
+      description: Returned when a new Item is created during Response generation.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.output_item.added
+          description: The event type, must be `response.output_item.added`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the Response to which the item belongs.
+        output_index:
+          type: integer
+          description: The index of the output item in the Response.
+        item:
+          $ref: "#/components/schemas/RealtimeConversationItem"
+      required:
+        - event_id
+        - type
+        - response_id
+        - output_index
+        - item
+      x-oaiMeta:
+        name: response.output_item.added
+        group: realtime
+        example: |
+          {
+              "event_id": "event_3334",
+              "type": "response.output_item.added",
+              "response_id": "resp_001",
+              "output_index": 0,
+              "item": {
+                  "id": "msg_007",
+                  "object": "realtime.item",
+                  "type": "message",
+                  "status": "in_progress",
+                  "role": "assistant",
+                  "content": []
+              }
+          }
+    RealtimeServerEventResponseOutputItemDone:
+      type: object
+      description: >
+        Returned when an Item is done streaming. Also emitted when a Response
+        is 
+
+        interrupted, incomplete, or cancelled.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.output_item.done
+          description: The event type, must be `response.output_item.done`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the Response to which the item belongs.
+        output_index:
+          type: integer
+          description: The index of the output item in the Response.
+        item:
+          $ref: "#/components/schemas/RealtimeConversationItem"
+      required:
+        - event_id
+        - type
+        - response_id
+        - output_index
+        - item
+      x-oaiMeta:
+        name: response.output_item.done
+        group: realtime
+        example: |
+          {
+              "event_id": "event_3536",
+              "type": "response.output_item.done",
+              "response_id": "resp_001",
+              "output_index": 0,
+              "item": {
+                  "id": "msg_007",
+                  "object": "realtime.item",
+                  "type": "message",
+                  "status": "completed",
+                  "role": "assistant",
+                  "content": [
+                      {
+                          "type": "text",
+                          "text": "Sure, I can help with that."
+                      }
+                  ]
+              }
+          }
+    RealtimeServerEventResponseTextDelta:
+      type: object
+      description: Returned when the text value of a "text" content part is updated.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.text.delta
+          description: The event type, must be `response.text.delta`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the item.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        content_index:
+          type: integer
+          description: The index of the content part in the item's content array.
+        delta:
+          type: string
+          description: The text delta.
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - content_index
+        - delta
+      x-oaiMeta:
+        name: response.text.delta
+        group: realtime
+        example: |
+          {
+              "event_id": "event_4142",
+              "type": "response.text.delta",
+              "response_id": "resp_001",
+              "item_id": "msg_007",
+              "output_index": 0,
+              "content_index": 0,
+              "delta": "Sure, I can h"
+          }
+    RealtimeServerEventResponseTextDone:
+      type: object
+      description: >
+        Returned when the text value of a "text" content part is done streaming.
+        Also
+
+        emitted when a Response is interrupted, incomplete, or cancelled.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - response.text.done
+          description: The event type, must be `response.text.done`.
+          x-stainless-const: true
+        response_id:
+          type: string
+          description: The ID of the response.
+        item_id:
+          type: string
+          description: The ID of the item.
+        output_index:
+          type: integer
+          description: The index of the output item in the response.
+        content_index:
+          type: integer
+          description: The index of the content part in the item's content array.
+        text:
+          type: string
+          description: The final text content.
+      required:
+        - event_id
+        - type
+        - response_id
+        - item_id
+        - output_index
+        - content_index
+        - text
+      x-oaiMeta:
+        name: response.text.done
+        group: realtime
+        example: |
+          {
+              "event_id": "event_4344",
+              "type": "response.text.done",
+              "response_id": "resp_001",
+              "item_id": "msg_007",
+              "output_index": 0,
+              "content_index": 0,
+              "text": "Sure, I can help with that."
+          }
+    RealtimeServerEventSessionCreated:
+      type: object
+      description: >
+        Returned when a Session is created. Emitted automatically when a new 
+
+        connection is established as the first server event. This event will
+        contain 
+
+        the default Session configuration.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - session.created
+          description: The event type, must be `session.created`.
+          x-stainless-const: true
+        session:
+          $ref: "#/components/schemas/RealtimeSession"
+      required:
+        - event_id
+        - type
+        - session
+      x-oaiMeta:
+        name: session.created
+        group: realtime
+        example: |
+          {
+              "event_id": "event_1234",
+              "type": "session.created",
+              "session": {
+                  "id": "sess_001",
+                  "object": "realtime.session",
+                  "model": "gpt-4o-realtime-preview-2024-12-17",
+                  "modalities": ["text", "audio"],
+                  "instructions": "...model instructions here...",
+                  "voice": "sage",
+                  "input_audio_format": "pcm16",
+                  "output_audio_format": "pcm16",
+                  "input_audio_transcription": null,
+                  "turn_detection": {
+                      "type": "server_vad",
+                      "threshold": 0.5,
+                      "prefix_padding_ms": 300,
+                      "silence_duration_ms": 200
+                  },
+                  "tools": [],
+                  "tool_choice": "auto",
+                  "temperature": 0.8,
+                  "max_response_output_tokens": "inf"
+              }
+          }
+    RealtimeServerEventSessionUpdated:
+      type: object
+      description: >
+        Returned when a session is updated with a `session.update` event,
+        unless 
+
+        there is an error.
+      properties:
+        event_id:
+          type: string
+          description: The unique ID of the server event.
+        type:
+          type: string
+          enum:
+            - session.updated
+          description: The event type, must be `session.updated`.
+          x-stainless-const: true
+        session:
+          $ref: "#/components/schemas/RealtimeSession"
+      required:
+        - event_id
+        - type
+        - session
+      x-oaiMeta:
+        name: session.updated
+        group: realtime
+        example: |
+          {
+              "event_id": "event_5678",
+              "type": "session.updated",
+              "session": {
+                  "id": "sess_001",
+                  "object": "realtime.session",
+                  "model": "gpt-4o-realtime-preview-2024-12-17",
+                  "modalities": ["text"],
+                  "instructions": "New instructions",
+                  "voice": "sage",
+                  "input_audio_format": "pcm16",
+                  "output_audio_format": "pcm16",
+                  "input_audio_transcription": {
+                      "model": "whisper-1"
+                  },
+                  "turn_detection": null,
+                  "tools": [],
+                  "tool_choice": "none",
+                  "temperature": 0.7,
+                  "max_response_output_tokens": 200
+              }
+          }
+    RealtimeSession:
+      type: object
+      description: Realtime session object configuration.
+      properties:
+        id:
+          type: string
+          description: |
+            Unique identifier for the session object.
+        modalities:
+          description: |
+            The set of modalities the model can respond with. To disable audio,
+            set this to ["text"].
+          items:
+            type: string
+            enum:
+              - text
+              - audio
+        model:
+          description: |
+            The Realtime model used for this session.
+          anyOf:
+            - type: string
+            - type: string
+              enum:
+                - gpt-4o-realtime-preview
+                - gpt-4o-realtime-preview-2024-10-01
+                - gpt-4o-realtime-preview-2024-12-17
+                - gpt-4o-mini-realtime-preview
+                - gpt-4o-mini-realtime-preview-2024-12-17
+        instructions:
+          type: string
+          description: >
+            The default system instructions (i.e. system message) prepended to
+            model 
+
+            calls. This field allows the client to guide the model on desired 
+
+            responses. The model can be instructed on response content and
+            format, 
+
+            (e.g. "be extremely succinct", "act friendly", "here are examples of
+            good 
+
+            responses") and on audio behavior (e.g. "talk quickly", "inject
+            emotion 
+
+            into your voice", "laugh frequently"). The instructions are not
+            guaranteed 
+
+            to be followed by the model, but they provide guidance to the model
+            on the 
+
+            desired behavior.
+
+
+            Note that the server sets default instructions which will be used if
+            this 
+
+            field is not set and are visible in the `session.created` event at
+            the 
+
+            start of the session.
+        voice:
+          type: string
+          enum:
+            - alloy
+            - ash
+            - ballad
+            - coral
+            - echo
+            - sage
+            - shimmer
+            - verse
+          description: >
+            The voice the model uses to respond. Voice cannot be changed during
+            the 
+
+            session once the model has responded with audio at least once.
+            Current 
+
+            voice options are `alloy`, `ash`, `ballad`, `coral`, `echo` `sage`, 
+
+            `shimmer` and `verse`.
+        input_audio_format:
+          type: string
+          enum:
+            - pcm16
+            - g711_ulaw
+            - g711_alaw
+          description: >
+            The format of input audio. Options are `pcm16`, `g711_ulaw`, or
+            `g711_alaw`.
+
+            For `pcm16`, input audio must be 16-bit PCM at a 24kHz sample rate, 
+
+            single channel (mono), and little-endian byte order.
+        output_audio_format:
+          type: string
+          enum:
+            - pcm16
+            - g711_ulaw
+            - g711_alaw
+          description: >
+            The format of output audio. Options are `pcm16`, `g711_ulaw`, or
+            `g711_alaw`.
+
+            For `pcm16`, output audio is sampled at a rate of 24kHz.
+        input_audio_transcription:
+          type: object
+          description: >
+            Configuration for input audio transcription, defaults to off and can
+            be 
+
+            set to `null` to turn off once on. Input audio transcription is not
+            native 
+
+            to the model, since the model consumes audio directly. Transcription
+            runs 
+
+            asynchronously through Whisper and should be treated as rough
+            guidance 
+
+            rather than the representation understood by the model.
+          properties:
+            model:
+              type: string
+              description: >
+                The model to use for transcription, `whisper-1` is the only
+                currently 
+
+                supported model.
+        turn_detection:
+          type: object
+          nullable: true
+          description: >
+            Configuration for turn detection. Can be set to `null` to turn off.
+            Server 
+
+            VAD means that the model will detect the start and end of speech
+            based on 
+
+            audio volume and respond at the end of user speech.
+          properties:
+            type:
+              type: string
+              enum:
+                - server_vad
+              description: >
+                Type of turn detection, only `server_vad` is currently supported.
+              x-stainless-const: true
+            threshold:
+              type: number
+              description: >
+                Activation threshold for VAD (0.0 to 1.0), this defaults to 0.5.
+                A 
+
+                higher threshold will require louder audio to activate the
+                model, and 
+
+                thus might perform better in noisy environments.
+            prefix_padding_ms:
+              type: integer
+              description: |
+                Amount of audio to include before the VAD detected speech (in 
+                milliseconds). Defaults to 300ms.
+            silence_duration_ms:
+              type: integer
+              description: >
+                Duration of silence to detect speech stop (in milliseconds).
+                Defaults 
+
+                to 500ms. With shorter values the model will respond more
+                quickly, 
+
+                but may jump in on short pauses from the user.
+        tools:
+          type: array
+          description: Tools (functions) available to the model.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - function
+                description: The type of the tool, i.e. `function`.
+                x-stainless-const: true
+              name:
+                type: string
+                description: The name of the function.
+              description:
+                type: string
+                description: >
+                  The description of the function, including guidance on when
+                  and how 
+
+                  to call it, and guidance about what to tell the user when
+                  calling 
+
+                  (if anything).
+              parameters:
+                type: object
+                description: Parameters of the function in JSON Schema.
+        tool_choice:
+          type: string
+          description: >
+            How the model chooses tools. Options are `auto`, `none`, `required`,
+            or 
+
+            specify a function.
+        temperature:
+          type: number
+          description: >
+            Sampling temperature for the model, limited to [0.6, 1.2]. Defaults
+            to 0.8.
+        max_response_output_tokens:
+          oneOf:
+            - type: integer
+            - type: string
+              enum:
+                - inf
+              x-stainless-const: true
+          description: |
+            Maximum number of output tokens for a single assistant response,
+            inclusive of tool calls. Provide an integer between 1 and 4096 to
+            limit output tokens, or `inf` for the maximum available tokens for a
+            given model. Defaults to `inf`.
+    RealtimeSessionCreateRequest:
+      type: object
+      description: Realtime session object configuration.
+      properties:
+        modalities:
+          description: |
+            The set of modalities the model can respond with. To disable audio,
+            set this to ["text"].
+          items:
+            type: string
+            enum:
+              - text
+              - audio
+        model:
+          type: string
+          description: |
+            The Realtime model used for this session.
+          enum:
+            - gpt-4o-realtime-preview
+            - gpt-4o-realtime-preview-2024-10-01
+            - gpt-4o-realtime-preview-2024-12-17
+            - gpt-4o-mini-realtime-preview
+            - gpt-4o-mini-realtime-preview-2024-12-17
+        instructions:
+          type: string
+          description: >
+            The default system instructions (i.e. system message) prepended to
+            model 
+
+            calls. This field allows the client to guide the model on desired 
+
+            responses. The model can be instructed on response content and
+            format, 
+
+            (e.g. "be extremely succinct", "act friendly", "here are examples of
+            good 
+
+            responses") and on audio behavior (e.g. "talk quickly", "inject
+            emotion 
+
+            into your voice", "laugh frequently"). The instructions are not
+            guaranteed 
+
+            to be followed by the model, but they provide guidance to the model
+            on the 
+
+            desired behavior.
+
+
+            Note that the server sets default instructions which will be used if
+            this 
+
+            field is not set and are visible in the `session.created` event at
+            the 
+
+            start of the session.
+        voice:
+          type: string
+          enum:
+            - alloy
+            - ash
+            - ballad
+            - coral
+            - echo
+            - sage
+            - shimmer
+            - verse
+          description: >
+            The voice the model uses to respond. Voice cannot be changed during
+            the 
+
+            session once the model has responded with audio at least once.
+            Current 
+
+            voice options are `alloy`, `ash`, `ballad`, `coral`, `echo` `sage`, 
+
+            `shimmer` and `verse`.
+        input_audio_format:
+          type: string
+          enum:
+            - pcm16
+            - g711_ulaw
+            - g711_alaw
+          description: >
+            The format of input audio. Options are `pcm16`, `g711_ulaw`, or
+            `g711_alaw`.
+
+            For `pcm16`, input audio must be 16-bit PCM at a 24kHz sample rate, 
+
+            single channel (mono), and little-endian byte order.
+        output_audio_format:
+          type: string
+          enum:
+            - pcm16
+            - g711_ulaw
+            - g711_alaw
+          description: >
+            The format of output audio. Options are `pcm16`, `g711_ulaw`, or
+            `g711_alaw`.
+
+            For `pcm16`, output audio is sampled at a rate of 24kHz.
+        input_audio_transcription:
+          type: object
+          description: >
+            Configuration for input audio transcription, defaults to off and can
+            be 
+
+            set to `null` to turn off once on. Input audio transcription is not
+            native 
+
+            to the model, since the model consumes audio directly. Transcription
+            runs 
+
+            asynchronously through Whisper and should be treated as rough
+            guidance 
+
+            rather than the representation understood by the model.
+          properties:
+            model:
+              type: string
+              description: >
+                The model to use for transcription, `whisper-1` is the only
+                currently 
+
+                supported model.
+        turn_detection:
+          type: object
+          description: >
+            Configuration for turn detection. Can be set to `null` to turn off.
+            Server 
+
+            VAD means that the model will detect the start and end of speech
+            based on 
+
+            audio volume and respond at the end of user speech.
+          properties:
+            type:
+              type: string
+              description: >
+                Type of turn detection, only `server_vad` is currently supported.
+            threshold:
+              type: number
+              description: >
+                Activation threshold for VAD (0.0 to 1.0), this defaults to 0.5.
+                A 
+
+                higher threshold will require louder audio to activate the
+                model, and 
+
+                thus might perform better in noisy environments.
+            prefix_padding_ms:
+              type: integer
+              description: |
+                Amount of audio to include before the VAD detected speech (in 
+                milliseconds). Defaults to 300ms.
+            silence_duration_ms:
+              type: integer
+              description: >
+                Duration of silence to detect speech stop (in milliseconds).
+                Defaults 
+
+                to 500ms. With shorter values the model will respond more
+                quickly, 
+
+                but may jump in on short pauses from the user.
+            create_response:
+              type: boolean
+              default: true
+              description: |
+                Whether or not to automatically generate a response when VAD is
+                enabled. `true` by default.
+        tools:
+          type: array
+          description: Tools (functions) available to the model.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - function
+                description: The type of the tool, i.e. `function`.
+                x-stainless-const: true
+              name:
+                type: string
+                description: The name of the function.
+              description:
+                type: string
+                description: >
+                  The description of the function, including guidance on when
+                  and how 
+
+                  to call it, and guidance about what to tell the user when
+                  calling 
+
+                  (if anything).
+              parameters:
+                type: object
+                description: Parameters of the function in JSON Schema.
+        tool_choice:
+          type: string
+          description: >
+            How the model chooses tools. Options are `auto`, `none`, `required`,
+            or 
+
+            specify a function.
+        temperature:
+          type: number
+          description: >
+            Sampling temperature for the model, limited to [0.6, 1.2]. Defaults
+            to 0.8.
+        max_response_output_tokens:
+          oneOf:
+            - type: integer
+            - type: string
+              enum:
+                - inf
+              x-stainless-const: true
+          description: |
+            Maximum number of output tokens for a single assistant response,
+            inclusive of tool calls. Provide an integer between 1 and 4096 to
+            limit output tokens, or `inf` for the maximum available tokens for a
+            given model. Defaults to `inf`.
+    RealtimeSessionCreateResponse:
+      type: object
+      description: >
+        A new Realtime session configuration, with an ephermeral key. Default
+        TTL
+
+        for keys is one minute.
+      properties:
+        client_secret:
+          type: object
+          description: Ephemeral key returned by the API.
+          properties:
+            value:
+              type: string
+              description: >
+                Ephemeral key usable in client environments to authenticate
+                connections
+
+                to the Realtime API. Use this in client-side environments rather
+                than
+
+                a standard API token, which should only be used server-side.
+            expires_at:
+              type: integer
+              description: >
+                Timestamp for when the token expires. Currently, all tokens
+                expire
+
+                after one minute.
+        modalities:
+          description: |
+            The set of modalities the model can respond with. To disable audio,
+            set this to ["text"].
+          items:
+            type: string
+            enum:
+              - text
+              - audio
+        instructions:
+          type: string
+          description: >
+            The default system instructions (i.e. system message) prepended to
+            model 
+
+            calls. This field allows the client to guide the model on desired 
+
+            responses. The model can be instructed on response content and
+            format, 
+
+            (e.g. "be extremely succinct", "act friendly", "here are examples of
+            good 
+
+            responses") and on audio behavior (e.g. "talk quickly", "inject
+            emotion 
+
+            into your voice", "laugh frequently"). The instructions are not
+            guaranteed 
+
+            to be followed by the model, but they provide guidance to the model
+            on the 
+
+            desired behavior.
+
+
+            Note that the server sets default instructions which will be used if
+            this 
+
+            field is not set and are visible in the `session.created` event at
+            the 
+
+            start of the session.
+        voice:
+          type: string
+          enum:
+            - alloy
+            - ash
+            - ballad
+            - coral
+            - echo
+            - sage
+            - shimmer
+            - verse
+          description: >
+            The voice the model uses to respond. Voice cannot be changed during
+            the 
+
+            session once the model has responded with audio at least once.
+            Current 
+
+            voice options are `alloy`, `ash`, `ballad`, `coral`, `echo` `sage`, 
+
+            `shimmer` and `verse`.
+        input_audio_format:
+          type: string
+          description: >
+            The format of input audio. Options are `pcm16`, `g711_ulaw`, or
+            `g711_alaw`.
+        output_audio_format:
+          type: string
+          description: >
+            The format of output audio. Options are `pcm16`, `g711_ulaw`, or
+            `g711_alaw`.
+        input_audio_transcription:
+          type: object
+          description: >
+            Configuration for input audio transcription, defaults to off and can
+            be 
+
+            set to `null` to turn off once on. Input audio transcription is not
+            native 
+
+            to the model, since the model consumes audio directly. Transcription
+            runs 
+
+            asynchronously through Whisper and should be treated as rough
+            guidance 
+
+            rather than the representation understood by the model.
+          properties:
+            model:
+              type: string
+              description: >
+                The model to use for transcription, `whisper-1` is the only
+                currently 
+
+                supported model.
+        turn_detection:
+          type: object
+          description: >
+            Configuration for turn detection. Can be set to `null` to turn off.
+            Server 
+
+            VAD means that the model will detect the start and end of speech
+            based on 
+
+            audio volume and respond at the end of user speech.
+          properties:
+            type:
+              type: string
+              description: >
+                Type of turn detection, only `server_vad` is currently supported.
+            threshold:
+              type: number
+              description: >
+                Activation threshold for VAD (0.0 to 1.0), this defaults to 0.5.
+                A 
+
+                higher threshold will require louder audio to activate the
+                model, and 
+
+                thus might perform better in noisy environments.
+            prefix_padding_ms:
+              type: integer
+              description: |
+                Amount of audio to include before the VAD detected speech (in 
+                milliseconds). Defaults to 300ms.
+            silence_duration_ms:
+              type: integer
+              description: >
+                Duration of silence to detect speech stop (in milliseconds).
+                Defaults 
+
+                to 500ms. With shorter values the model will respond more
+                quickly, 
+
+                but may jump in on short pauses from the user.
+        tools:
+          type: array
+          description: Tools (functions) available to the model.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                  - function
+                description: The type of the tool, i.e. `function`.
+                x-stainless-const: true
+              name:
+                type: string
+                description: The name of the function.
+              description:
+                type: string
+                description: >
+                  The description of the function, including guidance on when
+                  and how 
+
+                  to call it, and guidance about what to tell the user when
+                  calling 
+
+                  (if anything).
+              parameters:
+                type: object
+                description: Parameters of the function in JSON Schema.
+        tool_choice:
+          type: string
+          description: >
+            How the model chooses tools. Options are `auto`, `none`, `required`,
+            or 
+
+            specify a function.
+        temperature:
+          type: number
+          description: >
+            Sampling temperature for the model, limited to [0.6, 1.2]. Defaults
+            to 0.8.
+        max_response_output_tokens:
+          oneOf:
+            - type: integer
+            - type: string
+              enum:
+                - inf
+              x-stainless-const: true
+          description: |
+            Maximum number of output tokens for a single assistant response,
+            inclusive of tool calls. Provide an integer between 1 and 4096 to
+            limit output tokens, or `inf` for the maximum available tokens for a
+            given model. Defaults to `inf`.
+      x-oaiMeta:
+        name: The session object
+        group: realtime
+        example: |
+          {
+            "id": "sess_001",
+            "object": "realtime.session",
+            "model": "gpt-4o-realtime-preview-2024-12-17",
+            "modalities": ["audio", "text"],
+            "instructions": "You are a friendly assistant.",
+            "voice": "alloy",
+            "input_audio_format": "pcm16",
+            "output_audio_format": "pcm16",
+            "input_audio_transcription": {
+                "model": "whisper-1"
+            },
+            "turn_detection": null,
+            "tools": [],
+            "tool_choice": "none",
+            "temperature": 0.7,
+            "max_response_output_tokens": 200,
+            "client_secret": {
+              "value": "ek_abc123", 
+              "expires_at": 1234567890
+            }
+          }
+    ResponseFormatJsonObject:
+      type: object
+      properties:
+        type:
+          type: string
+          description: "The type of response format being defined: `json_object`"
+          enum:
+            - json_object
+          x-stainless-const: true
+      required:
+        - type
+    ResponseFormatJsonSchema:
+      type: object
+      properties:
+        type:
+          type: string
+          description: "The type of response format being defined: `json_schema`"
+          enum:
+            - json_schema
+          x-stainless-const: true
+        json_schema:
+          type: object
+          properties:
+            description:
+              type: string
+              description: A description of what the response format is for, used by the model
+                to determine how to respond in the format.
+            name:
+              type: string
+              description: The name of the response format. Must be a-z, A-Z, 0-9, or contain
+                underscores and dashes, with a maximum length of 64.
+            schema:
+              $ref: "#/components/schemas/ResponseFormatJsonSchemaSchema"
+            strict:
+              type: boolean
+              nullable: true
+              default: false
+              description: Whether to enable strict schema adherence when generating the
+                output. If set to true, the model will always follow the exact
+                schema defined in the `schema` field. Only a subset of JSON
+                Schema is supported when `strict` is `true`. To learn more, read
+                the [Structured Outputs guide](/docs/guides/structured-outputs).
+          required:
+            - name
+      required:
+        - type
+        - json_schema
+    ResponseFormatJsonSchemaSchema:
+      type: object
+      description: The schema for the response format, described as a JSON Schema object.
+      additionalProperties: true
+    ResponseFormatText:
+      type: object
+      properties:
+        type:
+          type: string
+          description: "The type of response format being defined: `text`"
+          enum:
+            - text
+          x-stainless-const: true
+      required:
+        - type
+    RunCompletionUsage:
+      type: object
+      description: Usage statistics related to the run. This value will be `null` if
+        the run is not in a terminal state (i.e. `in_progress`, `queued`, etc.).
+      properties:
+        completion_tokens:
+          type: integer
+          description: Number of completion tokens used over the course of the run.
+        prompt_tokens:
+          type: integer
+          description: Number of prompt tokens used over the course of the run.
+        total_tokens:
+          type: integer
+          description: Total number of tokens used (prompt + completion).
+      required:
+        - prompt_tokens
+        - completion_tokens
+        - total_tokens
+      nullable: true
+    RunObject:
+      type: object
+      title: A run on a thread
+      description: Represents an execution run on a [thread](/docs/api-reference/threads).
+      properties:
+        id:
+          description: The identifier, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `thread.run`.
+          type: string
+          enum:
+            - thread.run
+          x-stainless-const: true
+        created_at:
+          description: The Unix timestamp (in seconds) for when the run was created.
+          type: integer
+        thread_id:
+          description: The ID of the [thread](/docs/api-reference/threads) that was
+            executed on as a part of this run.
+          type: string
+        assistant_id:
+          description: The ID of the [assistant](/docs/api-reference/assistants) used for
+            execution of this run.
+          type: string
+        status:
+          description: The status of the run, which can be either `queued`, `in_progress`,
+            `requires_action`, `cancelling`, `cancelled`, `failed`, `completed`,
+            `incomplete`, or `expired`.
+          type: string
+          enum:
+            - queued
+            - in_progress
+            - requires_action
+            - cancelling
+            - cancelled
+            - failed
+            - completed
+            - incomplete
+            - expired
+        required_action:
+          type: object
+          description: Details on the action required to continue the run. Will be `null`
+            if no action is required.
+          nullable: true
+          properties:
+            type:
+              description: For now, this is always `submit_tool_outputs`.
+              type: string
+              enum:
+                - submit_tool_outputs
+              x-stainless-const: true
+            submit_tool_outputs:
+              type: object
+              description: Details on the tool outputs needed for this run to continue.
+              properties:
+                tool_calls:
+                  type: array
+                  description: A list of the relevant tool calls.
+                  items:
+                    $ref: "#/components/schemas/RunToolCallObject"
+              required:
+                - tool_calls
+          required:
+            - type
+            - submit_tool_outputs
+        last_error:
+          type: object
+          description: The last error associated with this run. Will be `null` if there
+            are no errors.
+          nullable: true
+          properties:
+            code:
+              type: string
+              description: One of `server_error`, `rate_limit_exceeded`, or `invalid_prompt`.
+              enum:
+                - server_error
+                - rate_limit_exceeded
+                - invalid_prompt
+            message:
+              type: string
+              description: A human-readable description of the error.
+          required:
+            - code
+            - message
+        expires_at:
+          description: The Unix timestamp (in seconds) for when the run will expire.
+          type: integer
+          nullable: true
+        started_at:
+          description: The Unix timestamp (in seconds) for when the run was started.
+          type: integer
+          nullable: true
+        cancelled_at:
+          description: The Unix timestamp (in seconds) for when the run was cancelled.
+          type: integer
+          nullable: true
+        failed_at:
+          description: The Unix timestamp (in seconds) for when the run failed.
+          type: integer
+          nullable: true
+        completed_at:
+          description: The Unix timestamp (in seconds) for when the run was completed.
+          type: integer
+          nullable: true
+        incomplete_details:
+          description: Details on why the run is incomplete. Will be `null` if the run is
+            not incomplete.
+          type: object
+          nullable: true
+          properties:
+            reason:
+              description: The reason why the run is incomplete. This will point to which
+                specific token limit was reached over the course of the run.
+              type: string
+              enum:
+                - max_completion_tokens
+                - max_prompt_tokens
+        model:
+          description: The model that the [assistant](/docs/api-reference/assistants) used
+            for this run.
+          type: string
+        instructions:
+          description: The instructions that the
+            [assistant](/docs/api-reference/assistants) used for this run.
+          type: string
+        tools:
+          description: The list of tools that the
+            [assistant](/docs/api-reference/assistants) used for this run.
+          default: []
+          type: array
+          maxItems: 20
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/AssistantToolsCode"
+              - $ref: "#/components/schemas/AssistantToolsFileSearch"
+              - $ref: "#/components/schemas/AssistantToolsFunction"
+            x-oaiExpandable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+        usage:
+          $ref: "#/components/schemas/RunCompletionUsage"
+        temperature:
+          description: The sampling temperature used for this run. If not set, defaults to
+            1.
+          type: number
+          nullable: true
+        top_p:
+          description: The nucleus sampling value used for this run. If not set, defaults
+            to 1.
+          type: number
+          nullable: true
+        max_prompt_tokens:
+          type: integer
+          nullable: true
+          description: >
+            The maximum number of prompt tokens specified to have been used over
+            the course of the run.
+          minimum: 256
+        max_completion_tokens:
+          type: integer
+          nullable: true
+          description: >
+            The maximum number of completion tokens specified to have been used
+            over the course of the run.
+          minimum: 256
+        truncation_strategy:
+          allOf:
+            - $ref: "#/components/schemas/TruncationObject"
+            - nullable: true
+        tool_choice:
+          allOf:
+            - $ref: "#/components/schemas/AssistantsApiToolChoiceOption"
+            - nullable: true
+        parallel_tool_calls:
+          $ref: "#/components/schemas/ParallelToolCalls"
+        response_format:
+          allOf:
+            - $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
+            - nullable: true
+      required:
+        - id
+        - object
+        - created_at
+        - thread_id
+        - assistant_id
+        - status
+        - required_action
+        - last_error
+        - expires_at
+        - started_at
+        - cancelled_at
+        - failed_at
+        - completed_at
+        - model
+        - instructions
+        - tools
+        - metadata
+        - usage
+        - incomplete_details
+        - max_prompt_tokens
+        - max_completion_tokens
+        - truncation_strategy
+        - tool_choice
+        - parallel_tool_calls
+        - response_format
+      x-oaiMeta:
+        name: The run object
+        beta: true
+        example: |
+          {
+            "id": "run_abc123",
+            "object": "thread.run",
+            "created_at": 1698107661,
+            "assistant_id": "asst_abc123",
+            "thread_id": "thread_abc123",
+            "status": "completed",
+            "started_at": 1699073476,
+            "expires_at": null,
+            "cancelled_at": null,
+            "failed_at": null,
+            "completed_at": 1699073498,
+            "last_error": null,
+            "model": "gpt-4o",
+            "instructions": null,
+            "tools": [{"type": "file_search"}, {"type": "code_interpreter"}],
+            "metadata": {},
+            "incomplete_details": null,
+            "usage": {
+              "prompt_tokens": 123,
+              "completion_tokens": 456,
+              "total_tokens": 579
+            },
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "max_prompt_tokens": 1000,
+            "max_completion_tokens": 1000,
+            "truncation_strategy": {
+              "type": "auto",
+              "last_messages": null
+            },
+            "response_format": "auto",
+            "tool_choice": "auto",
+            "parallel_tool_calls": true
+          }
+    RunStepCompletionUsage:
+      type: object
+      description: Usage statistics related to the run step. This value will be `null`
+        while the run step's status is `in_progress`.
+      properties:
+        completion_tokens:
+          type: integer
+          description: Number of completion tokens used over the course of the run step.
+        prompt_tokens:
+          type: integer
+          description: Number of prompt tokens used over the course of the run step.
+        total_tokens:
+          type: integer
+          description: Total number of tokens used (prompt + completion).
+      required:
+        - prompt_tokens
+        - completion_tokens
+        - total_tokens
+      nullable: true
+    RunStepDeltaObject:
+      type: object
+      title: Run step delta object
+      description: >
+        Represents a run step delta i.e. any changed fields on a run step during
+        streaming.
+      properties:
+        id:
+          description: The identifier of the run step, which can be referenced in API
+            endpoints.
+          type: string
+        object:
+          description: The object type, which is always `thread.run.step.delta`.
+          type: string
+          enum:
+            - thread.run.step.delta
+          x-stainless-const: true
+        delta:
+          description: The delta containing the fields that have changed on the run step.
+          type: object
+          properties:
+            step_details:
+              type: object
+              description: The details of the run step.
+              oneOf:
+                - $ref: "#/components/schemas/RunStepDeltaStepDetailsMessageCreationObject"
+                - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsObject"
+              x-oaiExpandable: true
+      required:
+        - id
+        - object
+        - delta
+      x-oaiMeta:
+        name: The run step delta object
+        beta: true
+        example: |
+          {
+            "id": "step_123",
+            "object": "thread.run.step.delta",
+            "delta": {
+              "step_details": {
+                "type": "tool_calls",
+                "tool_calls": [
+                  {
+                    "index": 0,
+                    "id": "call_123",
+                    "type": "code_interpreter",
+                    "code_interpreter": { "input": "", "outputs": [] }
+                  }
+                ]
+              }
+            }
+          }
+    RunStepDeltaStepDetailsMessageCreationObject:
+      title: Message creation
+      type: object
+      description: Details of the message creation by the run step.
+      properties:
+        type:
+          description: Always `message_creation`.
+          type: string
+          enum:
+            - message_creation
+          x-stainless-const: true
+        message_creation:
+          type: object
+          properties:
+            message_id:
+              type: string
+              description: The ID of the message that was created by this run step.
+      required:
+        - type
+    RunStepDeltaStepDetailsToolCallsCodeObject:
+      title: Code interpreter tool call
+      type: object
+      description: Details of the Code Interpreter tool call the run step was involved in.
+      properties:
+        index:
+          type: integer
+          description: The index of the tool call in the tool calls array.
+        id:
+          type: string
+          description: The ID of the tool call.
+        type:
+          type: string
+          description: The type of tool call. This is always going to be
+            `code_interpreter` for this type of tool call.
+          enum:
+            - code_interpreter
+          x-stainless-const: true
+        code_interpreter:
+          type: object
+          description: The Code Interpreter tool call definition.
+          properties:
+            input:
+              type: string
+              description: The input to the Code Interpreter tool call.
+            outputs:
+              type: array
+              description: The outputs from the Code Interpreter tool call. Code Interpreter
+                can output one or more items, including text (`logs`) or images
+                (`image`). Each of these are represented by a different object
+                type.
+              items:
+                type: object
+                oneOf:
+                  - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputLogsObjec\
+                      t"
+                  - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeOutputImageObje\
+                      ct"
+                x-oaiExpandable: true
+      required:
+        - index
+        - type
+    RunStepDeltaStepDetailsToolCallsCodeOutputImageObject:
+      title: Code interpreter image output
+      type: object
+      properties:
+        index:
+          type: integer
+          description: The index of the output in the outputs array.
+        type:
+          description: Always `image`.
+          type: string
+          enum:
+            - image
+          x-stainless-const: true
+        image:
+          type: object
+          properties:
+            file_id:
+              description: The [file](/docs/api-reference/files) ID of the image.
+              type: string
+      required:
+        - index
+        - type
+    RunStepDeltaStepDetailsToolCallsCodeOutputLogsObject:
+      title: Code interpreter log output
+      type: object
+      description: Text output from the Code Interpreter tool call as part of a run step.
+      properties:
+        index:
+          type: integer
+          description: The index of the output in the outputs array.
+        type:
+          description: Always `logs`.
+          type: string
+          enum:
+            - logs
+          x-stainless-const: true
+        logs:
+          type: string
+          description: The text output from the Code Interpreter tool call.
+      required:
+        - index
+        - type
+    RunStepDeltaStepDetailsToolCallsFileSearchObject:
+      title: File search tool call
+      type: object
+      properties:
+        index:
+          type: integer
+          description: The index of the tool call in the tool calls array.
+        id:
+          type: string
+          description: The ID of the tool call object.
+        type:
+          type: string
+          description: The type of tool call. This is always going to be `file_search` for
+            this type of tool call.
+          enum:
+            - file_search
+          x-stainless-const: true
+        file_search:
+          type: object
+          description: For now, this is always going to be an empty object.
+          x-oaiTypeLabel: map
+      required:
+        - index
+        - type
+        - file_search
+    RunStepDeltaStepDetailsToolCallsFunctionObject:
+      type: object
+      title: Function tool call
+      properties:
+        index:
+          type: integer
+          description: The index of the tool call in the tool calls array.
+        id:
+          type: string
+          description: The ID of the tool call object.
+        type:
+          type: string
+          description: The type of tool call. This is always going to be `function` for
+            this type of tool call.
+          enum:
+            - function
+          x-stainless-const: true
+        function:
+          type: object
+          description: The definition of the function that was called.
+          properties:
+            name:
+              type: string
+              description: The name of the function.
+            arguments:
+              type: string
+              description: The arguments passed to the function.
+            output:
+              type: string
+              description: The output of the function. This will be `null` if the outputs have
+                not been [submitted](/docs/api-reference/runs/submitToolOutputs)
+                yet.
+              nullable: true
+      required:
+        - index
+        - type
+    RunStepDeltaStepDetailsToolCallsObject:
+      title: Tool calls
+      type: object
+      description: Details of the tool call.
+      properties:
+        type:
+          description: Always `tool_calls`.
+          type: string
+          enum:
+            - tool_calls
+          x-stainless-const: true
+        tool_calls:
+          type: array
+          description: >
+            An array of tool calls the run step was involved in. These can be
+            associated with one of three types of tools: `code_interpreter`,
+            `file_search`, or `function`.
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsCodeObject"
+              - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsFileSearchObject"
+              - $ref: "#/components/schemas/RunStepDeltaStepDetailsToolCallsFunctionObject"
+            x-oaiExpandable: true
+      required:
+        - type
+    RunStepDetailsMessageCreationObject:
+      title: Message creation
+      type: object
+      description: Details of the message creation by the run step.
+      properties:
+        type:
+          description: Always `message_creation`.
+          type: string
+          enum:
+            - message_creation
+          x-stainless-const: true
+        message_creation:
+          type: object
+          properties:
+            message_id:
+              type: string
+              description: The ID of the message that was created by this run step.
+          required:
+            - message_id
+      required:
+        - type
+        - message_creation
+    RunStepDetailsToolCallsCodeObject:
+      title: Code Interpreter tool call
+      type: object
+      description: Details of the Code Interpreter tool call the run step was involved in.
+      properties:
+        id:
+          type: string
+          description: The ID of the tool call.
+        type:
+          type: string
+          description: The type of tool call. This is always going to be
+            `code_interpreter` for this type of tool call.
+          enum:
+            - code_interpreter
+          x-stainless-const: true
+        code_interpreter:
+          type: object
+          description: The Code Interpreter tool call definition.
+          required:
+            - input
+            - outputs
+          properties:
+            input:
+              type: string
+              description: The input to the Code Interpreter tool call.
+            outputs:
+              type: array
+              description: The outputs from the Code Interpreter tool call. Code Interpreter
+                can output one or more items, including text (`logs`) or images
+                (`image`). Each of these are represented by a different object
+                type.
+              items:
+                type: object
+                oneOf:
+                  - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeOutputLogsObject"
+                  - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeOutputImageObject"
+                x-oaiExpandable: true
+      required:
+        - id
+        - type
+        - code_interpreter
+    RunStepDetailsToolCallsCodeOutputImageObject:
+      title: Code Interpreter image output
+      type: object
+      properties:
+        type:
+          description: Always `image`.
+          type: string
+          enum:
+            - image
+          x-stainless-const: true
+        image:
+          type: object
+          properties:
+            file_id:
+              description: The [file](/docs/api-reference/files) ID of the image.
+              type: string
+          required:
+            - file_id
+      required:
+        - type
+        - image
+    RunStepDetailsToolCallsCodeOutputLogsObject:
+      title: Code Interpreter log output
+      type: object
+      description: Text output from the Code Interpreter tool call as part of a run step.
+      properties:
+        type:
+          description: Always `logs`.
+          type: string
+          enum:
+            - logs
+          x-stainless-const: true
+        logs:
+          type: string
+          description: The text output from the Code Interpreter tool call.
+      required:
+        - type
+        - logs
+    RunStepDetailsToolCallsFileSearchObject:
+      title: File search tool call
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the tool call object.
+        type:
+          type: string
+          description: The type of tool call. This is always going to be `file_search` for
+            this type of tool call.
+          enum:
+            - file_search
+          x-stainless-const: true
+        file_search:
+          type: object
+          description: For now, this is always going to be an empty object.
+          x-oaiTypeLabel: map
+          properties:
+            ranking_options:
+              $ref: "#/components/schemas/RunStepDetailsToolCallsFileSearchRankingOptionsObje\
+                ct"
+            results:
+              type: array
+              description: The results of the file search.
+              items:
+                $ref: "#/components/schemas/RunStepDetailsToolCallsFileSearchResultObject"
+      required:
+        - id
+        - type
+        - file_search
+    RunStepDetailsToolCallsFileSearchRankingOptionsObject:
+      title: File search tool call ranking options
+      type: object
+      description: The ranking options for the file search.
+      properties:
+        ranker:
+          type: string
+          description: The ranker used for the file search.
+          enum:
+            - default_2024_08_21
+          x-stainless-const: true
+        score_threshold:
+          type: number
+          description: The score threshold for the file search. All values must be a
+            floating point number between 0 and 1.
+          minimum: 0
+          maximum: 1
+      required:
+        - ranker
+        - score_threshold
+    RunStepDetailsToolCallsFileSearchResultObject:
+      title: File search tool call result
+      type: object
+      description: A result instance of the file search.
+      x-oaiTypeLabel: map
+      properties:
+        file_id:
+          type: string
+          description: The ID of the file that result was found in.
+        file_name:
+          type: string
+          description: The name of the file that result was found in.
+        score:
+          type: number
+          description: The score of the result. All values must be a floating point number
+            between 0 and 1.
+          minimum: 0
+          maximum: 1
+        content:
+          type: array
+          description: The content of the result that was found. The content is only
+            included if requested via the include query parameter.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: The type of the content.
+                enum:
+                  - text
+                x-stainless-const: true
+              text:
+                type: string
+                description: The text content of the file.
+      required:
+        - file_id
+        - file_name
+        - score
+    RunStepDetailsToolCallsFunctionObject:
+      type: object
+      title: Function tool call
+      properties:
+        id:
+          type: string
+          description: The ID of the tool call object.
+        type:
+          type: string
+          description: The type of tool call. This is always going to be `function` for
+            this type of tool call.
+          enum:
+            - function
+          x-stainless-const: true
+        function:
+          type: object
+          description: The definition of the function that was called.
+          properties:
+            name:
+              type: string
+              description: The name of the function.
+            arguments:
+              type: string
+              description: The arguments passed to the function.
+            output:
+              type: string
+              description: The output of the function. This will be `null` if the outputs have
+                not been [submitted](/docs/api-reference/runs/submitToolOutputs)
+                yet.
+              nullable: true
+          required:
+            - name
+            - arguments
+            - output
+      required:
+        - id
+        - type
+        - function
+    RunStepDetailsToolCallsObject:
+      title: Tool calls
+      type: object
+      description: Details of the tool call.
+      properties:
+        type:
+          description: Always `tool_calls`.
+          type: string
+          enum:
+            - tool_calls
+          x-stainless-const: true
+        tool_calls:
+          type: array
+          description: >
+            An array of tool calls the run step was involved in. These can be
+            associated with one of three types of tools: `code_interpreter`,
+            `file_search`, or `function`.
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/RunStepDetailsToolCallsCodeObject"
+              - $ref: "#/components/schemas/RunStepDetailsToolCallsFileSearchObject"
+              - $ref: "#/components/schemas/RunStepDetailsToolCallsFunctionObject"
+            x-oaiExpandable: true
+      required:
+        - type
+        - tool_calls
+    RunStepObject:
+      type: object
+      title: Run steps
+      description: |
+        Represents a step in execution of a run.
+      properties:
+        id:
+          description: The identifier of the run step, which can be referenced in API
+            endpoints.
+          type: string
+        object:
+          description: The object type, which is always `thread.run.step`.
+          type: string
+          enum:
+            - thread.run.step
+          x-stainless-const: true
+        created_at:
+          description: The Unix timestamp (in seconds) for when the run step was created.
+          type: integer
+        assistant_id:
+          description: The ID of the [assistant](/docs/api-reference/assistants)
+            associated with the run step.
+          type: string
+        thread_id:
+          description: The ID of the [thread](/docs/api-reference/threads) that was run.
+          type: string
+        run_id:
+          description: The ID of the [run](/docs/api-reference/runs) that this run step is
+            a part of.
+          type: string
+        type:
+          description: The type of run step, which can be either `message_creation` or
+            `tool_calls`.
+          type: string
+          enum:
+            - message_creation
+            - tool_calls
+        status:
+          description: The status of the run step, which can be either `in_progress`,
+            `cancelled`, `failed`, `completed`, or `expired`.
+          type: string
+          enum:
+            - in_progress
+            - cancelled
+            - failed
+            - completed
+            - expired
+        step_details:
+          type: object
+          description: The details of the run step.
+          oneOf:
+            - $ref: "#/components/schemas/RunStepDetailsMessageCreationObject"
+            - $ref: "#/components/schemas/RunStepDetailsToolCallsObject"
+          x-oaiExpandable: true
+        last_error:
+          type: object
+          description: The last error associated with this run step. Will be `null` if
+            there are no errors.
+          nullable: true
+          properties:
+            code:
+              type: string
+              description: One of `server_error` or `rate_limit_exceeded`.
+              enum:
+                - server_error
+                - rate_limit_exceeded
+            message:
+              type: string
+              description: A human-readable description of the error.
+          required:
+            - code
+            - message
+        expired_at:
+          description: The Unix timestamp (in seconds) for when the run step expired. A
+            step is considered expired if the parent run is expired.
+          type: integer
+          nullable: true
+        cancelled_at:
+          description: The Unix timestamp (in seconds) for when the run step was cancelled.
+          type: integer
+          nullable: true
+        failed_at:
+          description: The Unix timestamp (in seconds) for when the run step failed.
+          type: integer
+          nullable: true
+        completed_at:
+          description: The Unix timestamp (in seconds) for when the run step completed.
+          type: integer
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+        usage:
+          $ref: "#/components/schemas/RunStepCompletionUsage"
+      required:
+        - id
+        - object
+        - created_at
+        - assistant_id
+        - thread_id
+        - run_id
+        - type
+        - status
+        - step_details
+        - last_error
+        - expired_at
+        - cancelled_at
+        - failed_at
+        - completed_at
+        - metadata
+        - usage
+      x-oaiMeta:
+        name: The run step object
+        beta: true
+        example: |
+          {
+            "id": "step_abc123",
+            "object": "thread.run.step",
+            "created_at": 1699063291,
+            "run_id": "run_abc123",
+            "assistant_id": "asst_abc123",
+            "thread_id": "thread_abc123",
+            "type": "message_creation",
+            "status": "completed",
+            "cancelled_at": null,
+            "completed_at": 1699063291,
+            "expired_at": null,
+            "failed_at": null,
+            "last_error": null,
+            "step_details": {
+              "type": "message_creation",
+              "message_creation": {
+                "message_id": "msg_abc123"
+              }
+            },
+            "usage": {
+              "prompt_tokens": 123,
+              "completion_tokens": 456,
+              "total_tokens": 579
+            }
+          }
+    RunStepStreamEvent:
+      oneOf:
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.step.created
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/run-steps/step-object)
+            is created.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/run-steps/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.step.in_progress
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/run-steps/step-object)
+            moves to an `in_progress` state.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/run-steps/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.step.delta
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunStepDeltaObject"
+          required:
+            - event
+            - data
+          description: Occurs when parts of a [run
+            step](/docs/api-reference/run-steps/step-object) are being streamed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step
+              delta](/docs/api-reference/assistants-streaming/run-step-delta-ob\
+              ject)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.step.completed
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/run-steps/step-object)
+            is completed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/run-steps/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.step.failed
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/run-steps/step-object)
+            fails.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/run-steps/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.step.cancelled
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/run-steps/step-object)
+            is cancelled.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/run-steps/step-object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.step.expired
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunStepObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run step](/docs/api-reference/run-steps/step-object)
+            expires.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run step](/docs/api-reference/run-steps/step-object)"
+    RunStreamEvent:
+      oneOf:
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.created
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a new [run](/docs/api-reference/runs/object) is created.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.queued
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) moves to a
+            `queued` status.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.in_progress
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) moves to an
+            `in_progress` status.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.requires_action
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) moves to a
+            `requires_action` status.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.completed
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) is completed.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.incomplete
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) ends with
+            status `incomplete`.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.failed
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) fails.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.cancelling
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) moves to a
+            `cancelling` status.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.cancelled
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) is cancelled.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+        - type: object
+          properties:
+            event:
+              type: string
+              enum:
+                - thread.run.expired
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/RunObject"
+          required:
+            - event
+            - data
+          description: Occurs when a [run](/docs/api-reference/runs/object) expires.
+          x-oaiMeta:
+            dataDescription: "`data` is a [run](/docs/api-reference/runs/object)"
+    RunToolCallObject:
+      type: object
+      description: Tool call objects
+      properties:
+        id:
+          type: string
+          description: The ID of the tool call. This ID must be referenced when you submit
+            the tool outputs in using the [Submit tool outputs to
+            run](/docs/api-reference/runs/submitToolOutputs) endpoint.
+        type:
+          type: string
+          description: The type of tool call the output is required for. For now, this is
+            always `function`.
+          enum:
+            - function
+          x-stainless-const: true
+        function:
+          type: object
+          description: The function definition.
+          properties:
+            name:
+              type: string
+              description: The name of the function.
+            arguments:
+              type: string
+              description: The arguments that the model expects you to pass to the function.
+          required:
+            - name
+            - arguments
+      required:
+        - id
+        - type
+        - function
+    StaticChunkingStrategy:
+      type: object
+      additionalProperties: false
+      properties:
+        max_chunk_size_tokens:
+          type: integer
+          minimum: 100
+          maximum: 4096
+          description: The maximum number of tokens in each chunk. The default value is
+            `800`. The minimum value is `100` and the maximum value is `4096`.
+        chunk_overlap_tokens:
+          type: integer
+          description: >
+            The number of tokens that overlap between chunks. The default value
+            is `400`.
+
+
+            Note that the overlap must not exceed half of
+            `max_chunk_size_tokens`.
+      required:
+        - max_chunk_size_tokens
+        - chunk_overlap_tokens
+    StaticChunkingStrategyRequestParam:
+      type: object
+      title: Static Chunking Strategy
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          description: Always `static`.
+          enum:
+            - static
+          x-stainless-const: true
+        static:
+          $ref: "#/components/schemas/StaticChunkingStrategy"
+      required:
+        - type
+        - static
+    StaticChunkingStrategyResponseParam:
+      type: object
+      title: Static Chunking Strategy
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          description: Always `static`.
+          enum:
+            - static
+          x-stainless-const: true
+        static:
+          $ref: "#/components/schemas/StaticChunkingStrategy"
+      required:
+        - type
+        - static
+    SubmitToolOutputsRunRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        tool_outputs:
+          description: A list of tools for which the outputs are being submitted.
+          type: array
+          items:
+            type: object
+            properties:
+              tool_call_id:
+                type: string
+                description: The ID of the tool call in the `required_action` object within the
+                  run object the output is being submitted for.
+              output:
+                type: string
+                description: The output of the tool call to be submitted to continue the run.
+        stream:
+          type: boolean
+          nullable: true
+          description: >
+            If `true`, returns a stream of events that happen during the Run as
+            server-sent events, terminating when the Run enters a terminal state
+            with a `data: [DONE]` message.
+      required:
+        - tool_outputs
+    ThreadObject:
+      type: object
+      title: Thread
+      description: Represents a thread that contains
+        [messages](/docs/api-reference/messages).
+      properties:
+        id:
+          description: The identifier, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `thread`.
+          type: string
+          enum:
+            - thread
+          x-stainless-const: true
+        created_at:
+          description: The Unix timestamp (in seconds) for when the thread was created.
+          type: integer
+        tool_resources:
+          type: object
+          description: >
+            A set of resources that are made available to the assistant's tools
+            in this thread. The resources are specific to the type of tool. For
+            example, the `code_interpreter` tool requires a list of file IDs,
+            while the `file_search` tool requires a list of vector store IDs.
+          properties:
+            code_interpreter:
+              type: object
+              properties:
+                file_ids:
+                  type: array
+                  description: >
+                    A list of [file](/docs/api-reference/files) IDs made
+                    available to the `code_interpreter` tool. There can be a
+                    maximum of 20 files associated with the tool.
+                  default: []
+                  maxItems: 20
+                  items:
+                    type: string
+            file_search:
+              type: object
+              properties:
+                vector_store_ids:
+                  type: array
+                  description: >
+                    The [vector store](/docs/api-reference/vector-stores/object)
+                    attached to this thread. There can be a maximum of 1 vector
+                    store attached to the thread.
+                  maxItems: 1
+                  items:
+                    type: string
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+      required:
+        - id
+        - object
+        - created_at
+        - tool_resources
+        - metadata
+      x-oaiMeta:
+        name: The thread object
+        beta: true
+        example: |
+          {
+            "id": "thread_abc123",
+            "object": "thread",
+            "created_at": 1698107661,
+            "metadata": {}
+          }
+    ThreadStreamEvent:
+      oneOf:
+        - type: object
+          properties:
+            enabled:
+              type: boolean
+              description: Whether to enable input audio transcription.
+            event:
+              type: string
+              enum:
+                - thread.created
+              x-stainless-const: true
+            data:
+              $ref: "#/components/schemas/ThreadObject"
+          required:
+            - event
+            - data
+          description: Occurs when a new [thread](/docs/api-reference/threads/object) is
+            created.
+          x-oaiMeta:
+            dataDescription: "`data` is a [thread](/docs/api-reference/threads/object)"
+    TranscriptionSegment:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Unique identifier of the segment.
+        seek:
+          type: integer
+          description: Seek offset of the segment.
+        start:
+          type: number
+          format: float
+          description: Start time of the segment in seconds.
+        end:
+          type: number
+          format: float
+          description: End time of the segment in seconds.
+        text:
+          type: string
+          description: Text content of the segment.
+        tokens:
+          type: array
+          items:
+            type: integer
+          description: Array of token IDs for the text content.
+        temperature:
+          type: number
+          format: float
+          description: Temperature parameter used for generating the segment.
+        avg_logprob:
+          type: number
+          format: float
+          description: Average logprob of the segment. If the value is lower than -1,
+            consider the logprobs failed.
+        compression_ratio:
+          type: number
+          format: float
+          description: Compression ratio of the segment. If the value is greater than 2.4,
+            consider the compression failed.
+        no_speech_prob:
+          type: number
+          format: float
+          description: Probability of no speech in the segment. If the value is higher
+            than 1.0 and the `avg_logprob` is below -1, consider this segment
+            silent.
+      required:
+        - id
+        - seek
+        - start
+        - end
+        - text
+        - tokens
+        - temperature
+        - avg_logprob
+        - compression_ratio
+        - no_speech_prob
+    TranscriptionWord:
+      type: object
+      properties:
+        word:
+          type: string
+          description: The text content of the word.
+        start:
+          type: number
+          format: float
+          description: Start time of the word in seconds.
+        end:
+          type: number
+          format: float
+          description: End time of the word in seconds.
+      required:
+        - word
+        - start
+        - end
+    TruncationObject:
+      type: object
+      title: Thread Truncation Controls
+      description: Controls for how a thread will be truncated prior to the run. Use
+        this to control the intial context window of the run.
+      properties:
+        type:
+          type: string
+          description: The truncation strategy to use for the thread. The default is
+            `auto`. If set to `last_messages`, the thread will be truncated to
+            the n most recent messages in the thread. When set to `auto`,
+            messages in the middle of the thread will be dropped to fit the
+            context length of the model, `max_prompt_tokens`.
+          enum:
+            - auto
+            - last_messages
+        last_messages:
+          type: integer
+          description: The number of most recent messages from the thread when
+            constructing the context for the run.
+          minimum: 1
+          nullable: true
+      required:
+        - type
+    UpdateVectorStoreRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: The name of the vector store.
+          type: string
+          nullable: true
+        expires_after:
+          allOf:
+            - $ref: "#/components/schemas/VectorStoreExpirationAfter"
+            - nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+    Upload:
+      type: object
+      title: Upload
+      description: |
+        The Upload object can accept byte chunks in the form of Parts.
+      properties:
+        id:
+          type: string
+          description: The Upload unique identifier, which can be referenced in API
+            endpoints.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the Upload was created.
+        filename:
+          type: string
+          description: The name of the file to be uploaded.
+        bytes:
+          type: integer
+          description: The intended number of bytes to be uploaded.
+        purpose:
+          type: string
+          description: The intended purpose of the file. [Please refer
+            here](/docs/api-reference/files/object#files/object-purpose) for
+            acceptable values.
+        status:
+          type: string
+          description: The status of the Upload.
+          enum:
+            - pending
+            - completed
+            - cancelled
+            - expired
+        expires_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the Upload was created.
+        object:
+          type: string
+          description: The object type, which is always "upload".
+          enum:
+            - upload
+          x-stainless-const: true
+        file:
+          allOf:
+            - $ref: "#/components/schemas/OpenAIFile"
+            - nullable: true
+              description: The ready File object after the Upload is completed.
+      required:
+        - bytes
+        - created_at
+        - expires_at
+        - filename
+        - id
+        - purpose
+        - status
+      x-oaiMeta:
+        name: The upload object
+        example: |
+          {
+            "id": "upload_abc123",
+            "object": "upload",
+            "bytes": 2147483648,
+            "created_at": 1719184911,
+            "filename": "training_examples.jsonl",
+            "purpose": "fine-tune",
+            "status": "completed",
+            "expires_at": 1719127296,
+            "file": {
+              "id": "file-xyz321",
+              "object": "file",
+              "bytes": 2147483648,
+              "created_at": 1719186911,
+              "filename": "training_examples.jsonl",
+              "purpose": "fine-tune",
+            }
+          }
+    UploadPart:
+      type: object
+      title: UploadPart
+      description: >
+        The upload Part represents a chunk of bytes we can add to an Upload
+        object.
+      properties:
+        id:
+          type: string
+          description: The upload Part unique identifier, which can be referenced in API
+            endpoints.
+        created_at:
+          type: integer
+          description: The Unix timestamp (in seconds) for when the Part was created.
+        upload_id:
+          type: string
+          description: The ID of the Upload object that this Part was added to.
+        object:
+          type: string
+          description: The object type, which is always `upload.part`.
+          enum:
+            - upload.part
+          x-stainless-const: true
+      required:
+        - created_at
+        - id
+        - object
+        - upload_id
+      x-oaiMeta:
+        name: The upload part object
+        example: |
+          {
+              "id": "part_def456",
+              "object": "upload.part",
+              "created_at": 1719186911,
+              "upload_id": "upload_abc123"
+          }
+    UsageAudioSpeechesResult:
+      type: object
+      description: The aggregated audio speeches usage details of the specific time bucket.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.usage.audio_speeches.result
+          x-stainless-const: true
+        characters:
+          type: integer
+          description: The number of characters processed.
+        num_model_requests:
+          type: integer
+          description: The count of requests made to the model.
+        project_id:
+          type: string
+          nullable: true
+          description: When `group_by=project_id`, this field provides the project ID of
+            the grouped usage result.
+        user_id:
+          type: string
+          nullable: true
+          description: When `group_by=user_id`, this field provides the user ID of the
+            grouped usage result.
+        api_key_id:
+          type: string
+          nullable: true
+          description: When `group_by=api_key_id`, this field provides the API key ID of
+            the grouped usage result.
+        model:
+          type: string
+          nullable: true
+          description: When `group_by=model`, this field provides the model name of the
+            grouped usage result.
+      required:
+        - object
+        - characters
+        - num_model_requests
+      x-oaiMeta:
+        name: Audio speeches usage object
+        example: |
+          {
+              "object": "organization.usage.audio_speeches.result",
+              "characters": 45,
+              "num_model_requests": 1,
+              "project_id": "proj_abc",
+              "user_id": "user-abc",
+              "api_key_id": "key_abc",
+              "model": "tts-1"
+          }
+    UsageAudioTranscriptionsResult:
+      type: object
+      description: The aggregated audio transcriptions usage details of the specific
+        time bucket.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.usage.audio_transcriptions.result
+          x-stainless-const: true
+        seconds:
+          type: integer
+          description: The number of seconds processed.
+        num_model_requests:
+          type: integer
+          description: The count of requests made to the model.
+        project_id:
+          type: string
+          nullable: true
+          description: When `group_by=project_id`, this field provides the project ID of
+            the grouped usage result.
+        user_id:
+          type: string
+          nullable: true
+          description: When `group_by=user_id`, this field provides the user ID of the
+            grouped usage result.
+        api_key_id:
+          type: string
+          nullable: true
+          description: When `group_by=api_key_id`, this field provides the API key ID of
+            the grouped usage result.
+        model:
+          type: string
+          nullable: true
+          description: When `group_by=model`, this field provides the model name of the
+            grouped usage result.
+      required:
+        - object
+        - seconds
+        - num_model_requests
+      x-oaiMeta:
+        name: Audio transcriptions usage object
+        example: |
+          {
+              "object": "organization.usage.audio_transcriptions.result",
+              "seconds": 10,
+              "num_model_requests": 1,
+              "project_id": "proj_abc",
+              "user_id": "user-abc",
+              "api_key_id": "key_abc",
+              "model": "tts-1"
+          }
+    UsageCodeInterpreterSessionsResult:
+      type: object
+      description: The aggregated code interpreter sessions usage details of the
+        specific time bucket.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.usage.code_interpreter_sessions.result
+          x-stainless-const: true
+        sessions:
+          type: integer
+          description: The number of code interpreter sessions.
+        project_id:
+          type: string
+          nullable: true
+          description: When `group_by=project_id`, this field provides the project ID of
+            the grouped usage result.
+      required:
+        - object
+        - sessions
+      x-oaiMeta:
+        name: Code interpreter sessions usage object
+        example: |
+          {
+              "object": "organization.usage.code_interpreter_sessions.result",
+              "sessions": 1,
+              "project_id": "proj_abc"
+          }
+    UsageCompletionsResult:
+      type: object
+      description: The aggregated completions usage details of the specific time bucket.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.usage.completions.result
+          x-stainless-const: true
+        input_tokens:
+          type: integer
+          description: The aggregated number of text input tokens used, including cached
+            tokens. For customers subscribe to scale tier, this includes scale
+            tier tokens.
+        input_cached_tokens:
+          type: integer
+          description: The aggregated number of text input tokens that has been cached
+            from previous requests. For customers subscribe to scale tier, this
+            includes scale tier tokens.
+        output_tokens:
+          type: integer
+          description: The aggregated number of text output tokens used. For customers
+            subscribe to scale tier, this includes scale tier tokens.
+        input_audio_tokens:
+          type: integer
+          description: The aggregated number of audio input tokens used, including cached
+            tokens.
+        output_audio_tokens:
+          type: integer
+          description: The aggregated number of audio output tokens used.
+        num_model_requests:
+          type: integer
+          description: The count of requests made to the model.
+        project_id:
+          type: string
+          nullable: true
+          description: When `group_by=project_id`, this field provides the project ID of
+            the grouped usage result.
+        user_id:
+          type: string
+          nullable: true
+          description: When `group_by=user_id`, this field provides the user ID of the
+            grouped usage result.
+        api_key_id:
+          type: string
+          nullable: true
+          description: When `group_by=api_key_id`, this field provides the API key ID of
+            the grouped usage result.
+        model:
+          type: string
+          nullable: true
+          description: When `group_by=model`, this field provides the model name of the
+            grouped usage result.
+        batch:
+          type: boolean
+          nullable: true
+          description: When `group_by=batch`, this field tells whether the grouped usage
+            result is batch or not.
+      required:
+        - object
+        - input_tokens
+        - output_tokens
+        - num_model_requests
+      x-oaiMeta:
+        name: Completions usage object
+        example: |
+          {
+              "object": "organization.usage.completions.result",
+              "input_tokens": 5000,
+              "output_tokens": 1000,
+              "input_cached_tokens": 4000,
+              "input_audio_tokens": 300,
+              "output_audio_tokens": 200,
+              "num_model_requests": 5,
+              "project_id": "proj_abc",
+              "user_id": "user-abc",
+              "api_key_id": "key_abc",
+              "model": "gpt-4o-mini-2024-07-18",
+              "batch": false
+          }
+    UsageEmbeddingsResult:
+      type: object
+      description: The aggregated embeddings usage details of the specific time bucket.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.usage.embeddings.result
+          x-stainless-const: true
+        input_tokens:
+          type: integer
+          description: The aggregated number of input tokens used.
+        num_model_requests:
+          type: integer
+          description: The count of requests made to the model.
+        project_id:
+          type: string
+          nullable: true
+          description: When `group_by=project_id`, this field provides the project ID of
+            the grouped usage result.
+        user_id:
+          type: string
+          nullable: true
+          description: When `group_by=user_id`, this field provides the user ID of the
+            grouped usage result.
+        api_key_id:
+          type: string
+          nullable: true
+          description: When `group_by=api_key_id`, this field provides the API key ID of
+            the grouped usage result.
+        model:
+          type: string
+          nullable: true
+          description: When `group_by=model`, this field provides the model name of the
+            grouped usage result.
+      required:
+        - object
+        - input_tokens
+        - num_model_requests
+      x-oaiMeta:
+        name: Embeddings usage object
+        example: |
+          {
+              "object": "organization.usage.embeddings.result",
+              "input_tokens": 20,
+              "num_model_requests": 2,
+              "project_id": "proj_abc",
+              "user_id": "user-abc",
+              "api_key_id": "key_abc",
+              "model": "text-embedding-ada-002-v2"
+          }
+    UsageImagesResult:
+      type: object
+      description: The aggregated images usage details of the specific time bucket.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.usage.images.result
+          x-stainless-const: true
+        images:
+          type: integer
+          description: The number of images processed.
+        num_model_requests:
+          type: integer
+          description: The count of requests made to the model.
+        source:
+          type: string
+          nullable: true
+          description: When `group_by=source`, this field provides the source of the
+            grouped usage result, possible values are `image.generation`,
+            `image.edit`, `image.variation`.
+        size:
+          type: string
+          nullable: true
+          description: When `group_by=size`, this field provides the image size of the
+            grouped usage result.
+        project_id:
+          type: string
+          nullable: true
+          description: When `group_by=project_id`, this field provides the project ID of
+            the grouped usage result.
+        user_id:
+          type: string
+          nullable: true
+          description: When `group_by=user_id`, this field provides the user ID of the
+            grouped usage result.
+        api_key_id:
+          type: string
+          nullable: true
+          description: When `group_by=api_key_id`, this field provides the API key ID of
+            the grouped usage result.
+        model:
+          type: string
+          nullable: true
+          description: When `group_by=model`, this field provides the model name of the
+            grouped usage result.
+      required:
+        - object
+        - images
+        - num_model_requests
+      x-oaiMeta:
+        name: Images usage object
+        example: |
+          {
+              "object": "organization.usage.images.result",
+              "images": 2,
+              "num_model_requests": 2,
+              "size": "1024x1024",
+              "source": "image.generation",
+              "project_id": "proj_abc",
+              "user_id": "user-abc",
+              "api_key_id": "key_abc",
+              "model": "dall-e-3"
+          }
+    UsageModerationsResult:
+      type: object
+      description: The aggregated moderations usage details of the specific time bucket.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.usage.moderations.result
+          x-stainless-const: true
+        input_tokens:
+          type: integer
+          description: The aggregated number of input tokens used.
+        num_model_requests:
+          type: integer
+          description: The count of requests made to the model.
+        project_id:
+          type: string
+          nullable: true
+          description: When `group_by=project_id`, this field provides the project ID of
+            the grouped usage result.
+        user_id:
+          type: string
+          nullable: true
+          description: When `group_by=user_id`, this field provides the user ID of the
+            grouped usage result.
+        api_key_id:
+          type: string
+          nullable: true
+          description: When `group_by=api_key_id`, this field provides the API key ID of
+            the grouped usage result.
+        model:
+          type: string
+          nullable: true
+          description: When `group_by=model`, this field provides the model name of the
+            grouped usage result.
+      required:
+        - object
+        - input_tokens
+        - num_model_requests
+      x-oaiMeta:
+        name: Moderations usage object
+        example: |
+          {
+              "object": "organization.usage.moderations.result",
+              "input_tokens": 20,
+              "num_model_requests": 2,
+              "project_id": "proj_abc",
+              "user_id": "user-abc",
+              "api_key_id": "key_abc",
+              "model": "text-moderation"
+          }
+    UsageResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - page
+          x-stainless-const: true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/UsageTimeBucket"
+        has_more:
+          type: boolean
+        next_page:
+          type: string
+      required:
+        - object
+        - data
+        - has_more
+        - next_page
+    UsageTimeBucket:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - bucket
+          x-stainless-const: true
+        start_time:
+          type: integer
+        end_time:
+          type: integer
+        result:
+          type: array
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/UsageCompletionsResult"
+              - $ref: "#/components/schemas/UsageEmbeddingsResult"
+              - $ref: "#/components/schemas/UsageModerationsResult"
+              - $ref: "#/components/schemas/UsageImagesResult"
+              - $ref: "#/components/schemas/UsageAudioSpeechesResult"
+              - $ref: "#/components/schemas/UsageAudioTranscriptionsResult"
+              - $ref: "#/components/schemas/UsageVectorStoresResult"
+              - $ref: "#/components/schemas/UsageCodeInterpreterSessionsResult"
+              - $ref: "#/components/schemas/CostsResult"
+      required:
+        - object
+        - start_time
+        - end_time
+        - result
+    UsageVectorStoresResult:
+      type: object
+      description: The aggregated vector stores usage details of the specific time bucket.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.usage.vector_stores.result
+          x-stainless-const: true
+        usage_bytes:
+          type: integer
+          description: The vector stores usage in bytes.
+        project_id:
+          type: string
+          nullable: true
+          description: When `group_by=project_id`, this field provides the project ID of
+            the grouped usage result.
+      required:
+        - object
+        - usage_bytes
+      x-oaiMeta:
+        name: Vector stores usage object
+        example: |
+          {
+              "object": "organization.usage.vector_stores.result",
+              "usage_bytes": 1024,
+              "project_id": "proj_abc"
+          }
+    User:
+      type: object
+      description: Represents an individual `user` within an organization.
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.user
+          description: The object type, which is always `organization.user`
+          x-stainless-const: true
+        id:
+          type: string
+          description: The identifier, which can be referenced in API endpoints
+        name:
+          type: string
+          description: The name of the user
+        email:
+          type: string
+          description: The email address of the user
+        role:
+          type: string
+          enum:
+            - owner
+            - reader
+          description: "`owner` or `reader`"
+        added_at:
+          type: integer
+          description: The Unix timestamp (in seconds) of when the user was added.
+      required:
+        - object
+        - id
+        - name
+        - email
+        - role
+        - added_at
+      x-oaiMeta:
+        name: The user object
+        example: |
+          {
+              "object": "organization.user",
+              "id": "user_abc",
+              "name": "First Last",
+              "email": "user@example.com",
+              "role": "owner",
+              "added_at": 1711471533
+          }
+    UserDeleteResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - organization.user.deleted
+          x-stainless-const: true
+        id:
+          type: string
+        deleted:
+          type: boolean
+      required:
+        - object
+        - id
+        - deleted
+    UserListResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          x-stainless-const: true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/User"
+        first_id:
+          type: string
+        last_id:
+          type: string
+        has_more:
+          type: boolean
+      required:
+        - object
+        - data
+        - first_id
+        - last_id
+        - has_more
+    UserRoleUpdateRequest:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - owner
+            - reader
+          description: "`owner` or `reader`"
+      required:
+        - role
+    VectorStoreExpirationAfter:
+      type: object
+      title: Vector store expiration policy
+      description: The expiration policy for a vector store.
+      properties:
+        anchor:
+          description: "Anchor timestamp after which the expiration policy applies.
+            Supported anchors: `last_active_at`."
+          type: string
+          enum:
+            - last_active_at
+          x-stainless-const: true
+        days:
+          description: The number of days after the anchor time that the vector store will
+            expire.
+          type: integer
+          minimum: 1
+          maximum: 365
+      required:
+        - anchor
+        - days
+    VectorStoreFileBatchObject:
+      type: object
+      title: Vector store file batch
+      description: A batch of files attached to a vector store.
+      properties:
+        id:
+          description: The identifier, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `vector_store.file_batch`.
+          type: string
+          enum:
+            - vector_store.files_batch
+          x-stainless-const: true
+        created_at:
+          description: The Unix timestamp (in seconds) for when the vector store files
+            batch was created.
+          type: integer
+        vector_store_id:
+          description: The ID of the [vector
+            store](/docs/api-reference/vector-stores/object) that the
+            [File](/docs/api-reference/files) is attached to.
+          type: string
+        status:
+          description: The status of the vector store files batch, which can be either
+            `in_progress`, `completed`, `cancelled` or `failed`.
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - cancelled
+            - failed
+        file_counts:
+          type: object
+          properties:
+            in_progress:
+              description: The number of files that are currently being processed.
+              type: integer
+            completed:
+              description: The number of files that have been processed.
+              type: integer
+            failed:
+              description: The number of files that have failed to process.
+              type: integer
+            cancelled:
+              description: The number of files that where cancelled.
+              type: integer
+            total:
+              description: The total number of files.
+              type: integer
+          required:
+            - in_progress
+            - completed
+            - cancelled
+            - failed
+            - total
+      required:
+        - id
+        - object
+        - created_at
+        - vector_store_id
+        - status
+        - file_counts
+      x-oaiMeta:
+        name: The vector store files batch object
+        beta: true
+        example: |
+          {
+            "id": "vsfb_123",
+            "object": "vector_store.files_batch",
+            "created_at": 1698107661,
+            "vector_store_id": "vs_abc123",
+            "status": "completed",
+            "file_counts": {
+              "in_progress": 0,
+              "completed": 100,
+              "failed": 0,
+              "cancelled": 0,
+              "total": 100
+            }
+          }
+    VectorStoreFileObject:
+      type: object
+      title: Vector store files
+      description: A list of files attached to a vector store.
+      properties:
+        id:
+          description: The identifier, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `vector_store.file`.
+          type: string
+          enum:
+            - vector_store.file
+          x-stainless-const: true
+        usage_bytes:
+          description: The total vector store usage in bytes. Note that this may be
+            different from the original file size.
+          type: integer
+        created_at:
+          description: The Unix timestamp (in seconds) for when the vector store file was
+            created.
+          type: integer
+        vector_store_id:
+          description: The ID of the [vector
+            store](/docs/api-reference/vector-stores/object) that the
+            [File](/docs/api-reference/files) is attached to.
+          type: string
+        status:
+          description: The status of the vector store file, which can be either
+            `in_progress`, `completed`, `cancelled`, or `failed`. The status
+            `completed` indicates that the vector store file is ready for use.
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - cancelled
+            - failed
+        last_error:
+          type: object
+          description: The last error associated with this vector store file. Will be
+            `null` if there are no errors.
+          nullable: true
+          properties:
+            code:
+              type: string
+              description: One of `server_error` or `rate_limit_exceeded`.
+              enum:
+                - server_error
+                - unsupported_file
+                - invalid_file
+            message:
+              type: string
+              description: A human-readable description of the error.
+          required:
+            - code
+            - message
+        chunking_strategy:
+          type: object
+          description: The strategy used to chunk the file.
+          oneOf:
+            - $ref: "#/components/schemas/StaticChunkingStrategyResponseParam"
+            - $ref: "#/components/schemas/OtherChunkingStrategyResponseParam"
+          x-oaiExpandable: true
+      required:
+        - id
+        - object
+        - usage_bytes
+        - created_at
+        - vector_store_id
+        - status
+        - last_error
+      x-oaiMeta:
+        name: The vector store file object
+        beta: true
+        example: |
+          {
+            "id": "file-abc123",
+            "object": "vector_store.file",
+            "usage_bytes": 1234,
+            "created_at": 1698107661,
+            "vector_store_id": "vs_abc123",
+            "status": "completed",
+            "last_error": null,
+            "chunking_strategy": {
+              "type": "static",
+              "static": {
+                "max_chunk_size_tokens": 800,
+                "chunk_overlap_tokens": 400
+              }
+            }
+          }
+    VectorStoreObject:
+      type: object
+      title: Vector store
+      description: A vector store is a collection of processed files can be used by
+        the `file_search` tool.
+      properties:
+        id:
+          description: The identifier, which can be referenced in API endpoints.
+          type: string
+        object:
+          description: The object type, which is always `vector_store`.
+          type: string
+          enum:
+            - vector_store
+          x-stainless-const: true
+        created_at:
+          description: The Unix timestamp (in seconds) for when the vector store was
+            created.
+          type: integer
+        name:
+          description: The name of the vector store.
+          type: string
+        usage_bytes:
+          description: The total number of bytes used by the files in the vector store.
+          type: integer
+        file_counts:
+          type: object
+          properties:
+            in_progress:
+              description: The number of files that are currently being processed.
+              type: integer
+            completed:
+              description: The number of files that have been successfully processed.
+              type: integer
+            failed:
+              description: The number of files that have failed to process.
+              type: integer
+            cancelled:
+              description: The number of files that were cancelled.
+              type: integer
+            total:
+              description: The total number of files.
+              type: integer
+          required:
+            - in_progress
+            - completed
+            - failed
+            - cancelled
+            - total
+        status:
+          description: The status of the vector store, which can be either `expired`,
+            `in_progress`, or `completed`. A status of `completed` indicates
+            that the vector store is ready for use.
+          type: string
+          enum:
+            - expired
+            - in_progress
+            - completed
+        expires_after:
+          $ref: "#/components/schemas/VectorStoreExpirationAfter"
+        expires_at:
+          description: The Unix timestamp (in seconds) for when the vector store will
+            expire.
+          type: integer
+          nullable: true
+        last_active_at:
+          description: The Unix timestamp (in seconds) for when the vector store was last
+            active.
+          type: integer
+          nullable: true
+        metadata:
+          description: >
+            Set of 16 key-value pairs that can be attached to an object. This
+            can be useful for storing additional information about the object in
+            a structured format. Keys can be a maximum of 64 characters long and
+            values can be a maximum of 512 characters long.
+          type: object
+          x-oaiTypeLabel: map
+          nullable: true
+      required:
+        - id
+        - object
+        - usage_bytes
+        - created_at
+        - status
+        - last_active_at
+        - name
+        - file_counts
+        - metadata
+      x-oaiMeta:
+        name: The vector store object
+        beta: true
+        example: |
+          {
+            "id": "vs_123",
+            "object": "vector_store",
+            "created_at": 1698107661,
+            "usage_bytes": 123456,
+            "last_active_at": 1698107661,
+            "name": "my_vector_store",
+            "status": "completed",
+            "file_counts": {
+              "in_progress": 0,
+              "completed": 100,
+              "cancelled": 0,
+              "failed": 0,
+              "total": 100
+            },
+            "metadata": {},
+            "last_used_at": 1698107661
+          }
+  securitySchemes:
+    ApiKeyAuth:
+      type: http
+      scheme: bearer
+security:
+  - ApiKeyAuth: []
+x-oaiMeta:
+  navigationGroups:
+    - id: endpoints
+      title: Endpoints
+    - id: assistants
+      title: Assistants
+      beta: true
+    - id: administration
+      title: Administration
+    - id: realtime
+      title: Realtime
+      beta: true
+    - id: legacy
+      title: Legacy
+  groups:
+    - id: audio
+      title: Audio
+      description: |
+        Learn how to turn audio into text or text into audio.
+
+        Related guide: [Speech to text](/docs/guides/speech-to-text)
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createSpeech
+          path: createSpeech
+        - type: endpoint
+          key: createTranscription
+          path: createTranscription
+        - type: endpoint
+          key: createTranslation
+          path: createTranslation
+        - type: object
+          key: CreateTranscriptionResponseJson
+          path: json-object
+        - type: object
+          key: CreateTranscriptionResponseVerboseJson
+          path: verbose-json-object
+    - id: chat
+      title: Chat
+      description: >
+        Given a list of messages comprising a conversation, the model will
+        return a response.
+
+        Related guide: [Chat Completions](/docs/guides/text-generation)
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createChatCompletion
+          path: create
+        - type: object
+          key: CreateChatCompletionResponse
+          path: object
+        - type: object
+          key: CreateChatCompletionStreamResponse
+          path: streaming
+    - id: embeddings
+      title: Embeddings
+      description: >
+        Get a vector representation of a given input that can be easily consumed
+        by machine learning models and algorithms.
+
+        Related guide: [Embeddings](/docs/guides/embeddings)
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createEmbedding
+          path: create
+        - type: object
+          key: Embedding
+          path: object
+    - id: fine-tuning
+      title: Fine-tuning
+      description: >
+        Manage fine-tuning jobs to tailor a model to your specific training
+        data.
+
+        Related guide: [Fine-tune models](/docs/guides/fine-tuning)
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createFineTuningJob
+          path: create
+        - type: endpoint
+          key: listPaginatedFineTuningJobs
+          path: list
+        - type: endpoint
+          key: listFineTuningEvents
+          path: list-events
+        - type: endpoint
+          key: listFineTuningJobCheckpoints
+          path: list-checkpoints
+        - type: endpoint
+          key: retrieveFineTuningJob
+          path: retrieve
+        - type: endpoint
+          key: cancelFineTuningJob
+          path: cancel
+        - type: object
+          key: FineTuneChatRequestInput
+          path: chat-input
+        - type: object
+          key: FineTunePreferenceRequestInput
+          path: preference-input
+        - type: object
+          key: FineTuneCompletionRequestInput
+          path: completions-input
+        - type: object
+          key: FineTuningJob
+          path: object
+        - type: object
+          key: FineTuningJobEvent
+          path: event-object
+        - type: object
+          key: FineTuningJobCheckpoint
+          path: checkpoint-object
+    - id: batch
+      title: Batch
+      description: >
+        Create large batches of API requests for asynchronous processing. The
+        Batch API returns completions within 24 hours for a 50% discount.
+
+        Related guide: [Batch](/docs/guides/batch)
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createBatch
+          path: create
+        - type: endpoint
+          key: retrieveBatch
+          path: retrieve
+        - type: endpoint
+          key: cancelBatch
+          path: cancel
+        - type: endpoint
+          key: listBatches
+          path: list
+        - type: object
+          key: Batch
+          path: object
+        - type: object
+          key: BatchRequestInput
+          path: request-input
+        - type: object
+          key: BatchRequestOutput
+          path: request-output
+    - id: files
+      title: Files
+      description: >
+        Files are used to upload documents that can be used with features like
+        [Assistants](/docs/api-reference/assistants),
+        [Fine-tuning](/docs/api-reference/fine-tuning), and [Batch
+        API](/docs/guides/batch).
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createFile
+          path: create
+        - type: endpoint
+          key: listFiles
+          path: list
+        - type: endpoint
+          key: retrieveFile
+          path: retrieve
+        - type: endpoint
+          key: deleteFile
+          path: delete
+        - type: endpoint
+          key: downloadFile
+          path: retrieve-contents
+        - type: object
+          key: OpenAIFile
+          path: object
+    - id: uploads
+      title: Uploads
+      description: |
+        Allows you to upload large files in multiple parts.
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createUpload
+          path: create
+        - type: endpoint
+          key: addUploadPart
+          path: add-part
+        - type: endpoint
+          key: completeUpload
+          path: complete
+        - type: endpoint
+          key: cancelUpload
+          path: cancel
+        - type: object
+          key: Upload
+          path: object
+        - type: object
+          key: UploadPart
+          path: part-object
+    - id: images
+      title: Images
+      description: >
+        Given a prompt and/or an input image, the model will generate a new
+        image.
+
+        Related guide: [Image generation](/docs/guides/images)
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createImage
+          path: create
+        - type: endpoint
+          key: createImageEdit
+          path: createEdit
+        - type: endpoint
+          key: createImageVariation
+          path: createVariation
+        - type: object
+          key: Image
+          path: object
+    - id: models
+      title: Models
+      description: >
+        List and describe the various models available in the API. You can refer
+        to the [Models](/docs/models) documentation to understand what models
+        are available and the differences between them.
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: listModels
+          path: list
+        - type: endpoint
+          key: retrieveModel
+          path: retrieve
+        - type: endpoint
+          key: deleteModel
+          path: delete
+        - type: object
+          key: Model
+          path: object
+    - id: moderations
+      title: Moderations
+      description: >
+        Given text and/or image inputs, classifies if those inputs are
+        potentially harmful across several categories.
+
+        Related guide: [Moderations](/docs/guides/moderation)
+      navigationGroup: endpoints
+      sections:
+        - type: endpoint
+          key: createModeration
+          path: create
+        - type: object
+          key: CreateModerationResponse
+          path: object
+    - id: assistants
+      title: Assistants
+      beta: true
+      description: |
+        Build assistants that can call models and use tools to perform tasks.
+
+        [Get started with the Assistants API](/docs/assistants)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createAssistant
+          path: createAssistant
+        - type: endpoint
+          key: listAssistants
+          path: listAssistants
+        - type: endpoint
+          key: getAssistant
+          path: getAssistant
+        - type: endpoint
+          key: modifyAssistant
+          path: modifyAssistant
+        - type: endpoint
+          key: deleteAssistant
+          path: deleteAssistant
+        - type: object
+          key: AssistantObject
+          path: object
+    - id: threads
+      title: Threads
+      beta: true
+      description: |
+        Create threads that assistants can interact with.
+
+        Related guide: [Assistants](/docs/assistants/overview)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createThread
+          path: createThread
+        - type: endpoint
+          key: getThread
+          path: getThread
+        - type: endpoint
+          key: modifyThread
+          path: modifyThread
+        - type: endpoint
+          key: deleteThread
+          path: deleteThread
+        - type: object
+          key: ThreadObject
+          path: object
+    - id: messages
+      title: Messages
+      beta: true
+      description: |
+        Create messages within threads
+
+        Related guide: [Assistants](/docs/assistants/overview)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createMessage
+          path: createMessage
+        - type: endpoint
+          key: listMessages
+          path: listMessages
+        - type: endpoint
+          key: getMessage
+          path: getMessage
+        - type: endpoint
+          key: modifyMessage
+          path: modifyMessage
+        - type: endpoint
+          key: deleteMessage
+          path: deleteMessage
+        - type: object
+          key: MessageObject
+          path: object
+    - id: runs
+      title: Runs
+      beta: true
+      description: |
+        Represents an execution run on a thread.
+
+        Related guide: [Assistants](/docs/assistants/overview)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createRun
+          path: createRun
+        - type: endpoint
+          key: createThreadAndRun
+          path: createThreadAndRun
+        - type: endpoint
+          key: listRuns
+          path: listRuns
+        - type: endpoint
+          key: getRun
+          path: getRun
+        - type: endpoint
+          key: modifyRun
+          path: modifyRun
+        - type: endpoint
+          key: submitToolOuputsToRun
+          path: submitToolOutputs
+        - type: endpoint
+          key: cancelRun
+          path: cancelRun
+        - type: object
+          key: RunObject
+          path: object
+    - id: run-steps
+      title: Run steps
+      beta: true
+      description: |
+        Represents the steps (model and tool calls) taken during the run.
+
+        Related guide: [Assistants](/docs/assistants/overview)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: listRunSteps
+          path: listRunSteps
+        - type: endpoint
+          key: getRunStep
+          path: getRunStep
+        - type: object
+          key: RunStepObject
+          path: step-object
+    - id: vector-stores
+      title: Vector stores
+      beta: true
+      description: |
+        Vector stores are used to store files for use by the `file_search` tool.
+
+        Related guide: [File Search](/docs/assistants/tools/file-search)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createVectorStore
+          path: create
+        - type: endpoint
+          key: listVectorStores
+          path: list
+        - type: endpoint
+          key: getVectorStore
+          path: retrieve
+        - type: endpoint
+          key: modifyVectorStore
+          path: modify
+        - type: endpoint
+          key: deleteVectorStore
+          path: delete
+        - type: object
+          key: VectorStoreObject
+          path: object
+    - id: vector-stores-files
+      title: Vector store files
+      beta: true
+      description: |
+        Vector store files represent files inside a vector store.
+
+        Related guide: [File Search](/docs/assistants/tools/file-search)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createVectorStoreFile
+          path: createFile
+        - type: endpoint
+          key: listVectorStoreFiles
+          path: listFiles
+        - type: endpoint
+          key: getVectorStoreFile
+          path: getFile
+        - type: endpoint
+          key: deleteVectorStoreFile
+          path: deleteFile
+        - type: object
+          key: VectorStoreFileObject
+          path: file-object
+    - id: vector-stores-file-batches
+      title: Vector store file batches
+      beta: true
+      description: >
+        Vector store file batches represent operations to add multiple files to
+        a vector store.
+
+        Related guide: [File Search](/docs/assistants/tools/file-search)
+      navigationGroup: assistants
+      sections:
+        - type: endpoint
+          key: createVectorStoreFileBatch
+          path: createBatch
+        - type: endpoint
+          key: getVectorStoreFileBatch
+          path: getBatch
+        - type: endpoint
+          key: cancelVectorStoreFileBatch
+          path: cancelBatch
+        - type: endpoint
+          key: listFilesInVectorStoreBatch
+          path: listBatchFiles
+        - type: object
+          key: VectorStoreFileBatchObject
+          path: batch-object
+    - id: assistants-streaming
+      title: Streaming
+      beta: true
+      description: >
+        Stream the result of executing a Run or resuming a Run after submitting
+        tool outputs.
+
+        You can stream events from the [Create Thread and
+        Run](/docs/api-reference/runs/createThreadAndRun),
+
+        [Create Run](/docs/api-reference/runs/createRun), and [Submit Tool
+        Outputs](/docs/api-reference/runs/submitToolOutputs)
+
+        endpoints by passing `"stream": true`. The response will be a
+        [Server-Sent
+        events](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events)
+        stream.
+
+        Our Node and Python SDKs provide helpful utilities to make streaming
+        easy. Reference the
+
+        [Assistants API quickstart](/docs/assistants/overview) to learn more.
+      navigationGroup: assistants
+      sections:
+        - type: object
+          key: MessageDeltaObject
+          path: message-delta-object
+        - type: object
+          key: RunStepDeltaObject
+          path: run-step-delta-object
+        - type: object
+          key: AssistantStreamEvent
+          path: events
+    - id: administration
+      title: Administration
+      description: >
+        Programmatically manage your organization.
+
+        The Audit Logs endpoint provides a log of all actions taken in the
+        organization for security and monitoring purposes.
+
+        To access these endpoints please generate an Admin API Key through the
+        [API Platform Organization overview](/organization/admin-keys). Admin
+        API keys cannot be used for non-administration endpoints.
+
+        For best practices on setting up your organization, please refer to this
+        [guide](/docs/guides/production-best-practices#setting-up-your-organization)
+      navigationGroup: administration
+    - id: admin-api-keys
+      title: Admin API Keys
+      description: >
+        The **Usage API** provides detailed insights into your activity across
+        the OpenAI API. It also includes a separate [Costs
+        endpoint](/docs/api-reference/usage/costs), which offers visibility into
+        your spend, breaking down consumption by invoice line items and project
+        IDs.
+
+        While the Usage API delivers granular usage data, it may not always
+        reconcile perfectly with the Costs due to minor differences in how usage
+        and spend are recorded. For financial purposes, we recommend using the
+        [Costs endpoint](/docs/api-reference/usage/costs) or the [Costs
+        tab](/settings/organization/usage) in the Usage Dashboard, which will
+        reconcile back to your billing invoice.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: admin-api-keys-list
+          path: list
+        - type: endpoint
+          key: admin-api-keys-create
+          path: create
+        - type: endpoint
+          key: admin-api-keys-get
+          path: listget
+        - type: endpoint
+          key: admin-api-keys-delete
+          path: delete
+    - id: invite
+      title: Invites
+      description: Invite and manage invitations for an organization.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: list-invites
+          path: list
+        - type: endpoint
+          key: inviteUser
+          path: create
+        - type: endpoint
+          key: retrieve-invite
+          path: retrieve
+        - type: endpoint
+          key: delete-invite
+          path: delete
+        - type: object
+          key: Invite
+          path: object
+    - id: users
+      title: Users
+      description: |
+        Manage users and their role in an organization.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: list-users
+          path: list
+        - type: endpoint
+          key: modify-user
+          path: modify
+        - type: endpoint
+          key: retrieve-user
+          path: retrieve
+        - type: endpoint
+          key: delete-user
+          path: delete
+        - type: object
+          key: User
+          path: object
+    - id: projects
+      title: Projects
+      description: >
+        Manage the projects within an orgnanization includes creation, updating,
+        and archiving or projects.
+
+        The Default project cannot be archived.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: list-projects
+          path: list
+        - type: endpoint
+          key: create-project
+          path: create
+        - type: endpoint
+          key: retrieve-project
+          path: retrieve
+        - type: endpoint
+          key: modify-project
+          path: modify
+        - type: endpoint
+          key: archive-project
+          path: archive
+        - type: object
+          key: Project
+          path: object
+    - id: project-users
+      title: Project users
+      description: >
+        Manage users within a project, including adding, updating roles, and
+        removing users.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: list-project-users
+          path: list
+        - type: endpoint
+          key: create-project-user
+          path: creeate
+        - type: endpoint
+          key: retrieve-project-user
+          path: retrieve
+        - type: endpoint
+          key: modify-project-user
+          path: modify
+        - type: endpoint
+          key: delete-project-user
+          path: delete
+        - type: object
+          key: ProjectUser
+          path: object
+    - id: project-service-accounts
+      title: Project service accounts
+      description: >
+        Manage service accounts within a project. A service account is a bot
+        user that is not associated with a user.
+
+        If a user leaves an organization, their keys and membership in projects
+        will no longer work. Service accounts
+
+        do not have this limitation. However, service accounts can also be
+        deleted from a project.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: list-project-service-accounts
+          path: list
+        - type: endpoint
+          key: create-project-service-account
+          path: create
+        - type: endpoint
+          key: retrieve-project-service-account
+          path: retrieve
+        - type: endpoint
+          key: delete-project-service-account
+          path: delete
+        - type: object
+          key: ProjectServiceAccount
+          path: object
+    - id: project-api-keys
+      title: Project API keys
+      description: >
+        Manage API keys for a given project. Supports listing and deleting keys
+        for users.
+
+        This API does not allow issuing keys for users, as users need to
+        authorize themselves to generate keys.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: list-project-api-keys
+          path: list
+        - type: endpoint
+          key: retrieve-project-api-key
+          path: retrieve
+        - type: endpoint
+          key: delete-project-api-key
+          path: delete
+        - type: object
+          key: ProjectApiKey
+          path: object
+    - id: project-rate-limits
+      title: Project rate limits
+      description: >
+        Manage rate limits per model for projects. Rate limits may be configured
+        to be equal to or lower than the organization's rate limits.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: list-project-rate-limits
+          path: list
+        - type: endpoint
+          key: update-project-rate-limits
+          path: update
+        - type: object
+          key: ProjectRateLimit
+          path: object
+    - id: audit-logs
+      title: Audit logs
+      description: >
+        Logs of user actions and configuration changes within this organization.
+
+        To log events, you must activate logging in the [Organization
+        Settings](/settings/organization/general).
+
+        Once activated, for security reasons, logging cannot be deactivated.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: list-audit-logs
+          path: list
+        - type: object
+          key: AuditLog
+          path: object
+    - id: usage
+      title: Usage
+      description: >
+        The **Usage API** provides detailed insights into your activity across
+        the OpenAI API. It also includes a separate [Costs
+        endpoint](/docs/api-reference/usage/costs), which offers visibility into
+        your spend, breaking down consumption by invoice line items and project
+        IDs.
+
+
+        While the Usage API delivers granular usage data, it may not always
+        reconcile perfectly with the Costs due to minor differences in how usage
+        and spend are recorded. For financial purposes, we recommend using the
+        [Costs endpoint](/docs/api-reference/usage/costs) or the [Costs
+        tab](/settings/organization/usage) in the Usage Dashboard, which will
+        reconcile back to your billing invoice.
+      navigationGroup: administration
+      sections:
+        - type: endpoint
+          key: usage-completions
+          path: completions
+        - type: object
+          key: UsageCompletionsResult
+          path: completions_object
+        - type: endpoint
+          key: usage-embeddings
+          path: embeddings
+        - type: object
+          key: UsageEmbeddingsResult
+          path: embeddings_object
+        - type: endpoint
+          key: usage-moderations
+          path: moderations
+        - type: object
+          key: UsageModerationsResult
+          path: moderations_object
+        - type: endpoint
+          key: usage-images
+          path: images
+        - type: object
+          key: UsageImagesResult
+          path: images_object
+        - type: endpoint
+          key: usage-audio-speeches
+          path: audio_speeches
+        - type: object
+          key: UsageAudioSpeechesResult
+          path: audio_speeches_object
+        - type: endpoint
+          key: usage-audio-transcriptions
+          path: audio_transcriptions
+        - type: object
+          key: UsageAudioTranscriptionsResult
+          path: audio_transcriptions_object
+        - type: endpoint
+          key: usage-vector-stores
+          path: vector_stores
+        - type: object
+          key: UsageVectorStoresResult
+          path: vector_stores_object
+        - type: endpoint
+          key: usage-code-interpreter-sessions
+          path: code_interpreter_sessions
+        - type: object
+          key: UsageCodeInterpreterSessionsResult
+          path: code_interpreter_sessions_object
+        - type: endpoint
+          key: usage-costs
+          path: costs
+        - type: object
+          key: CostsResult
+          path: costs_object
+    - id: realtime
+      title: Realtime
+      beta: true
+      description: |
+        Communicate with a GPT-4o class model in real time using WebRTC or 
+        WebSockets. Supports text and audio inputs and ouputs, along with audio
+        transcriptions.
+        [Learn more about the Realtime API](/docs/guides/realtime).
+      navigationGroup: realtime
+    - id: realtime-sessions
+      title: Session tokens
+      description: >
+        REST API endpoint to generate ephemeral session tokens for use in
+        client-side
+
+        applications.
+      navigationGroup: realtime
+      sections:
+        - type: endpoint
+          key: create-realtime-session
+          path: create
+        - type: object
+          key: RealtimeSessionCreateResponse
+          path: session_object
+    - id: realtime-client-events
+      title: Client events
+      description: >
+        These are events that the OpenAI Realtime WebSocket server will accept
+        from the client.
+      navigationGroup: realtime
+      sections:
+        - type: object
+          key: RealtimeClientEventSessionUpdate
+          path: <auto>
+        - type: object
+          key: RealtimeClientEventInputAudioBufferAppend
+          path: <auto>
+        - type: object
+          key: RealtimeClientEventInputAudioBufferCommit
+          path: <auto>
+        - type: object
+          key: RealtimeClientEventInputAudioBufferClear
+          path: <auto>
+        - type: object
+          key: RealtimeClientEventConversationItemCreate
+          path: <auto>
+        - type: object
+          key: RealtimeClientEventConversationItemTruncate
+          path: <auto>
+        - type: object
+          key: RealtimeClientEventConversationItemDelete
+          path: <auto>
+        - type: object
+          key: RealtimeClientEventResponseCreate
+          path: <auto>
+        - type: object
+          key: RealtimeClientEventResponseCancel
+          path: <auto>
+    - id: realtime-server-events
+      title: Server events
+      description: >
+        These are events emitted from the OpenAI Realtime WebSocket server to
+        the client.
+      navigationGroup: realtime
+      sections:
+        - type: object
+          key: RealtimeServerEventError
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventSessionCreated
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventSessionUpdated
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventConversationCreated
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventConversationItemCreated
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventConversationItemInputAudioTranscriptionCompleted
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventConversationItemInputAudioTranscriptionFailed
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventConversationItemTruncated
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventConversationItemDeleted
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventInputAudioBufferCommitted
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventInputAudioBufferCleared
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventInputAudioBufferSpeechStarted
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventInputAudioBufferSpeechStopped
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseCreated
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseDone
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseOutputItemAdded
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseOutputItemDone
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseContentPartAdded
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseContentPartDone
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseTextDelta
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseTextDone
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseAudioTranscriptDelta
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseAudioTranscriptDone
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseAudioDelta
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseAudioDone
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseFunctionCallArgumentsDelta
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventResponseFunctionCallArgumentsDone
+          path: <auto>
+        - type: object
+          key: RealtimeServerEventRateLimitsUpdated
+          path: <auto>
+    - id: completions
+      title: Completions
+      legacy: true
+      navigationGroup: legacy
+      description: >
+        Given a prompt, the model will return one or more predicted completions
+        along with the probabilities of alternative tokens at each position.
+        Most developer should use our [Chat Completions
+        API](/docs/guides/text-generation#text-generation-models) to leverage
+        our best and newest models.
+      sections:
+        - type: endpoint
+          key: createCompletion
+          path: create
+        - type: object
+          key: CreateCompletionResponse
+          path: object

--- a/Examples/streaming-chatgpt-proxy/Sources/ClientCLI/main.swift
+++ b/Examples/streaming-chatgpt-proxy/Sources/ClientCLI/main.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIRuntime
+import OpenAPIURLSession
+import Foundation
+
+// Create a client.
+let client = Client(
+    serverURL: URL(string: "http://localhost:8080")!,
+    transport: URLSessionTransport()
+)
+
+let userInput = CommandLine.arguments.dropFirst().first ?? "Any team!"
+
+// Print some placeholder to the console.
+setbuf(stdout, nil)  // Don't buffer stdout.
+print("🧑‍💼: \(userInput)")
+print("---")
+print("🤖: ", terminator: "")
+
+// Make the request.
+let response = try await client.createChant(
+    body: .json(.init(userInput: userInput))
+)
+
+// Decode JSON Lines into an async sequence of typed values.
+let messages = try response.ok.body.applicationJsonl
+    .asDecodedJSONLines(of: Components.Schemas.ChantMessage.self)
+
+for try await message in messages {
+    print(message.delta, terminator: "")
+}

--- a/Examples/streaming-chatgpt-proxy/Sources/ClientCLI/openapi-generator-config.yaml
+++ b/Examples/streaming-chatgpt-proxy/Sources/ClientCLI/openapi-generator-config.yaml
@@ -1,0 +1,2 @@
+generate: [types, client]
+namingStrategy: idiomatic

--- a/Examples/streaming-chatgpt-proxy/Sources/ClientCLI/openapi.yaml
+++ b/Examples/streaming-chatgpt-proxy/Sources/ClientCLI/openapi.yaml
@@ -1,0 +1,42 @@
+openapi: '3.0.3'
+info:
+  title: ChantGPT
+  version: 0.1.0
+paths:
+#----------------------------------------------------------
+  /chant:
+    post:
+      operationId: createChant
+      summary: Generate a new chant for your favorite NBA team!
+      tags:
+        - Chants
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChantRequest"
+      responses:
+        "200":
+          description: A successful response with the generated chant.
+          content:
+            application/jsonl:
+              schema:
+                $ref: "#/components/schemas/ChantMessage"
+#----------------------------------------------------------
+components:
+  schemas:
+    ChantRequest:
+      type: object
+      required: [userInput]
+      properties:
+        userInput:
+          type: string
+      example:
+        userInput: The one with the bull logo.
+    ChantMessage:
+      type: object
+      required: [delta]
+      properties:
+        delta:
+          type: string

--- a/Examples/streaming-chatgpt-proxy/Sources/ProxyServer/main.swift
+++ b/Examples/streaming-chatgpt-proxy/Sources/ProxyServer/main.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIRuntime
+import OpenAPIVapor
+import Vapor
+import ChatGPT
+import OpenAPIAsyncHTTPClient
+
+// Declare a handler type, conforming to the generated Swift protocol.
+struct Handler: APIProtocol {
+    enum Error: Swift.Error { case unimplemented }
+
+    // POST /chant
+    func createChant(_ input: Operations.CreateChant.Input) async throws -> Operations.CreateChant.Output {
+        // Return 422 (Unprocessable Content) if request was not application/json.
+        guard case .json(let body) = input.body else {
+            return .undocumented(statusCode: 422, .init())
+        }
+
+        // Create a client.
+        let client = ChatGPT.Client(
+            serverURL: URL(string: "https://api.openai.com/v1")!,
+            transport: AsyncHTTPClientTransport(),
+            middlewares: [HeaderFieldMiddleware.authTokenFromEnvironment("OPENAI_TOKEN")]
+        )
+
+        // Construct the request payload.
+        let systemPrompt = """
+        Here is some data for the current NBA rosters.
+
+        \(try String(contentsOfFile: "./players.txt", encoding: .utf8))
+
+        Your role is to write fun and witty chants for basketball teams for fans to sing at games.
+
+        The user prompt may consist of any free form text that you should use to identify a team to make the chant.
+
+        The chant should be between four and five paragraphs long and have a title that includes the team name.
+        """
+        let userInput = body.userInput
+        let messages: [ChatGPT.Components.Schemas.ChatCompletionRequestMessage] = [
+            .ChatCompletionRequestSystemMessage(.init(content: .case1(systemPrompt), role: .system)),
+            .ChatCompletionRequestUserMessage(.init(content: .case1(userInput), role: .user)),
+        ]
+
+        // Make the request.
+        let chatGPTResponse = try await client.createChatCompletion(
+            body: .json(.init(messages: messages, model: .init(value2: .chatgpt4oLatest), stream: true, temperature: 0))
+        )
+
+        // Decode SSE stream into an async sequence of typed values.
+        typealias ChatGPTPayload = ChatGPT.Components.Schemas.CreateChatCompletionStreamResponse
+        let chatGPTStream = try chatGPTResponse.ok.body.textEventStream
+            .asDecodedServerSentEventsWithJSONData(of: ChatGPTPayload.self, while: { $0 != HTTPBody.ByteChunk("[DONE]".utf8)})
+
+        // Map the async sequence of ChatGPT values to an async sequence of Proxy values.
+        typealias ProxyPayload = ProxyServer.Components.Schemas.ChantMessage
+        let proxyStream = chatGPTStream.compactMap { chatGPTPayload -> ProxyPayload? in
+            guard let delta = chatGPTPayload.data?.choices.first?.delta.content else { return nil }
+            return ProxyPayload(delta: delta)
+        }
+
+        // Create a HTTP body by encoding the async sequence as JSON Lines.
+        // NOTE: unknown length and single iteration to support arbitrarily long streams.
+        let responseBody = HTTPBody(proxyStream.asEncodedJSONLines(), length: .unknown, iterationBehavior: .single)
+
+        // Return an OK response with the streaming body.
+        return .ok(.init(body: .applicationJsonl(responseBody)))
+    }
+}
+
+// Bootstrap the HTTP server.
+let app = try await Vapor.Application.make()
+let transport = VaporTransport(routesBuilder: app)
+let handler = Handler()
+try handler.registerHandlers(on: transport)
+try await app.execute()

--- a/Examples/streaming-chatgpt-proxy/Sources/ProxyServer/openapi-generator-config.yaml
+++ b/Examples/streaming-chatgpt-proxy/Sources/ProxyServer/openapi-generator-config.yaml
@@ -1,0 +1,2 @@
+generate: [types, server]
+namingStrategy: idiomatic

--- a/Examples/streaming-chatgpt-proxy/Sources/ProxyServer/openapi.yaml
+++ b/Examples/streaming-chatgpt-proxy/Sources/ProxyServer/openapi.yaml
@@ -1,0 +1,42 @@
+openapi: '3.0.3'
+info:
+  title: ChantGPT
+  version: 0.1.0
+paths:
+#----------------------------------------------------------
+  /chant:
+    post:
+      operationId: createChant
+      summary: Generate a new chant for your favorite NBA team!
+      tags:
+        - Chants
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChantRequest"
+      responses:
+        "200":
+          description: A successful response with the generated chant.
+          content:
+            application/jsonl:
+              schema:
+                $ref: "#/components/schemas/ChantMessage"
+#----------------------------------------------------------
+components:
+  schemas:
+    ChantRequest:
+      type: object
+      required: [userInput]
+      properties:
+        userInput:
+          type: string
+      example:
+        userInput: The one with the bull logo.
+    ChantMessage:
+      type: object
+      required: [delta]
+      properties:
+        delta:
+          type: string

--- a/Examples/streaming-chatgpt-proxy/players.txt
+++ b/Examples/streaming-chatgpt-proxy/players.txt
@@ -1,0 +1,525 @@
+A.J. Lawson: Toronto Raptors
+AJ Green: Milwaukee Bucks
+AJ Johnson: Milwaukee Bucks
+Aaron Gordon: Denver Nuggets
+Aaron Holiday: Houston Rockets
+Aaron Nesmith: Indiana Pacers
+Aaron Wiggins: Oklahoma City Thunder
+Adam Flagler: Oklahoma City Thunder
+Adama Sanogo: Chicago Bulls
+Adem Bona: Philadelphia 76ers
+Ajay Mitchell: Oklahoma City Thunder
+Al Horford: Boston Celtics
+Alec Burks: Miami Heat
+Alex Caruso: Oklahoma City Thunder
+Alex Ducas: Oklahoma City Thunder
+Alex Len: Sacramento Kings
+Alexandre Sarr: Washington Wizards
+Alperen Sengun: Houston Rockets
+Amen Thompson: Houston Rockets
+Amir Coffey: LA Clippers
+Andre Drummond: Philadelphia 76ers
+Andre Jackson Jr.: Milwaukee Bucks
+Andrew Nembhard: Indiana Pacers
+Andrew Wiggins: Golden State Warriors
+Anfernee Simons: Portland Trail Blazers
+Anthony Black: Orlando Magic
+Anthony Davis: Los Angeles Lakers
+Anthony Edwards: Minnesota Timberwolves
+Anthony Gill: Washington Wizards
+Anton Watson: Boston Celtics
+Antonio Reeves: New Orleans Pelicans
+Ariel Hukporti: New York Knicks
+Armel Traoré: Los Angeles Lakers
+Ausar Thompson: Detroit Pistons
+Austin Reaves: Los Angeles Lakers
+Ayo Dosunmu: Chicago Bulls
+Bam Adebayo: Miami Heat
+Baylor Scheierman: Boston Celtics
+Ben Sheppard: Indiana Pacers
+Ben Simmons: Brooklyn Nets
+Bennedict Mathurin: Indiana Pacers
+Bilal Coulibaly: Washington Wizards
+Blake Wesley: San Antonio Spurs
+Bobby Portis: Milwaukee Bucks
+Bobi Klintman: Detroit Pistons
+Bogdan Bogdanović: Atlanta Hawks
+Bojan Bogdanović: Brooklyn Nets
+Bol Bol: Phoenix Suns
+Bones Hyland: LA Clippers
+Bradley Beal: Phoenix Suns
+Branden Carlson: Oklahoma City Thunder
+Brandin Podziemski: Golden State Warriors
+Brandon Boston: New Orleans Pelicans
+Brandon Clarke: Memphis Grizzlies
+Brandon Ingram: New Orleans Pelicans
+Brandon Miller: Charlotte Hornets
+Brandon Williams: Dallas Mavericks
+Brice Sensabaugh: Utah Jazz
+Bronny James: Los Angeles Lakers
+Brook Lopez: Milwaukee Bucks
+Bruce Brown: Toronto Raptors
+Bryce McGowens: Portland Trail Blazers
+Buddy Hield: Golden State Warriors
+CJ McCollum: New Orleans Pelicans
+Cade Cunningham: Detroit Pistons
+Caleb Houstan: Orlando Magic
+Caleb Martin: Philadelphia 76ers
+Cam Christie: LA Clippers
+Cam Reddish: Los Angeles Lakers
+Cam Spencer: Memphis Grizzlies
+Cam Thomas: Brooklyn Nets
+Cam Whitmore: Houston Rockets
+Cameron Johnson: Brooklyn Nets
+Cameron Payne: New York Knicks
+Caris LeVert: Cleveland Cavaliers
+Carlton Carrington: Washington Wizards
+Cason Wallace: Oklahoma City Thunder
+Charles Bassey: San Antonio Spurs
+Chet Holmgren: Oklahoma City Thunder
+Chris Boucher: Toronto Raptors
+Chris Duarte: Chicago Bulls
+Chris Livingston: Milwaukee Bucks
+Chris Paul: San Antonio Spurs
+Christian Braun: Denver Nuggets
+Christian Koloko: Los Angeles Lakers
+Christian Wood: Los Angeles Lakers
+Clint Capela: Atlanta Hawks
+Coby White: Chicago Bulls
+Cody Martin: Charlotte Hornets
+Cody Williams: Utah Jazz
+Cody Zeller: Atlanta Hawks
+Colby Jones: Sacramento Kings
+Cole Anthony: Orlando Magic
+Collin Gillespie: Phoenix Suns
+Collin Sexton: Utah Jazz
+Corey Kispert: Washington Wizards
+Cory Joseph: Orlando Magic
+Craig Porter Jr.: Cleveland Cavaliers
+D'Angelo Russell: Brooklyn Nets
+DaQuan Jeffries: Charlotte Hornets
+DaRon Holmes II: Denver Nuggets
+Daeqwon Plowden: Atlanta Hawks
+Dalano Banton: Portland Trail Blazers
+Dalen Terry: Chicago Bulls
+Dalton Knecht: Los Angeles Lakers
+Damian Lillard: Milwaukee Bucks
+Damion Lee: Phoenix Suns
+Daniel Gafford: Dallas Mavericks
+Daniel Theis: New Orleans Pelicans
+Daniss Jenkins: Detroit Pistons
+Danté Exum: Dallas Mavericks
+Dario Šarić: Denver Nuggets
+Dariq Whitehead: Brooklyn Nets
+Darius Garland: Cleveland Cavaliers
+David Duke Jr.: San Antonio Spurs
+David Roddy: Atlanta Hawks
+Davion Mitchell: Toronto Raptors
+Day'Ron Sharpe: Brooklyn Nets
+De'Aaron Fox: Sacramento Kings
+De'Andre Hunter: Atlanta Hawks
+De'Anthony Melton: Brooklyn Nets
+DeAndre Jordan: Denver Nuggets
+DeMar DeRozan: Sacramento Kings
+Dean Wade: Cleveland Cavaliers
+Deandre Ayton: Portland Trail Blazers
+Dejounte Murray: New Orleans Pelicans
+Delon Wright: Milwaukee Bucks
+Deni Avdija: Portland Trail Blazers
+Dennis Schröder: Golden State Warriors
+Dereck Lively II: Dallas Mavericks
+Derrick Jones Jr.: LA Clippers
+Derrick White: Boston Celtics
+Desmond Bane: Memphis Grizzlies
+Devin Booker: Phoenix Suns
+Devin Carter: Sacramento Kings
+Devin Vassell: San Antonio Spurs
+Dillon Brooks: Houston Rockets
+Dillon Jones: Oklahoma City Thunder
+Domantas Sabonis: Sacramento Kings
+Dominick Barlow: Atlanta Hawks
+Donovan Clingan: Portland Trail Blazers
+Donovan Mitchell: Cleveland Cavaliers
+Donte DiVincenzo: Minnesota Timberwolves
+Dorian Finney-Smith: Los Angeles Lakers
+Doug McDermott: Sacramento Kings
+Draymond Green: Golden State Warriors
+Drew Eubanks: Utah Jazz
+Drew Peterson: Boston Celtics
+Dru Smith: Miami Heat
+Duncan Robinson: Miami Heat
+Duop Reath: Portland Trail Blazers
+Dwight Powell: Dallas Mavericks
+Dyson Daniels: Atlanta Hawks
+E.J. Liddell: Chicago Bulls
+Elijah Harkless: Utah Jazz
+Emanuel Miller: Chicago Bulls
+Emoni Bates: Cleveland Cavaliers
+Enrique Freeman: Indiana Pacers
+Eric Gordon: Philadelphia 76ers
+Eugene Omoruyi: Toronto Raptors
+Evan Mobley: Cleveland Cavaliers
+Franz Wagner: Orlando Magic
+Fred VanVleet: Houston Rockets
+GG Jackson: Memphis Grizzlies
+Gabe Vincent: Los Angeles Lakers
+Garrett Temple: Toronto Raptors
+Garrison Mathews: Atlanta Hawks
+Gary Harris: Orlando Magic
+Gary Payton II: Golden State Warriors
+Gary Trent Jr.: Milwaukee Bucks
+Georges Niang: Cleveland Cavaliers
+Giannis Antetokounmpo: Milwaukee Bucks
+Goga Bitadze: Orlando Magic
+Gradey Dick: Toronto Raptors
+Grant Williams: Charlotte Hornets
+Grayson Allen: Phoenix Suns
+Guerschon Yabusele: Philadelphia 76ers
+Gui Santos: Golden State Warriors
+Harrison Barnes: San Antonio Spurs
+Harrison Ingram: San Antonio Spurs
+Haywood Highsmith: Miami Heat
+Herbert Jones: New Orleans Pelicans
+Hunter Tyson: Denver Nuggets
+Immanuel Quickley: Toronto Raptors
+Isaac Jones: Sacramento Kings
+Isaac Okoro: Cleveland Cavaliers
+Isaiah Collier: Utah Jazz
+Isaiah Crawford: Sacramento Kings
+Isaiah Hartenstein: Oklahoma City Thunder
+Isaiah Jackson: Indiana Pacers
+Isaiah Joe: Oklahoma City Thunder
+Isaiah Stevens: Miami Heat
+Isaiah Stewart: Detroit Pistons
+Isaiah Wong: Charlotte Hornets
+Ivica Zubac: LA Clippers
+JD Davison: Boston Celtics
+JT Thor: Cleveland Cavaliers
+Ja Morant: Memphis Grizzlies
+Ja'Kobe Walter: Toronto Raptors
+Jabari Smith Jr.: Houston Rockets
+Jabari Walker: Portland Trail Blazers
+Jack McVeigh: Houston Rockets
+Jacob Toppin: New York Knicks
+Jaden Hardy: Dallas Mavericks
+Jaden Ivey: Detroit Pistons
+Jaden McDaniels: Minnesota Timberwolves
+Jaden Springer: Boston Celtics
+Jae Crowder: Sacramento Kings
+Jae'Sean Tate: Houston Rockets
+Jaime Jaquez Jr.: Miami Heat
+Jake LaRavia: Memphis Grizzlies
+Jakob Poeltl: Toronto Raptors
+Jalen Bridges: Phoenix Suns
+Jalen Brunson: New York Knicks
+Jalen Duren: Detroit Pistons
+Jalen Green: Houston Rockets
+Jalen Hood-Schifino: Los Angeles Lakers
+Jalen Johnson: Atlanta Hawks
+Jalen Pickett: Denver Nuggets
+Jalen Smith: Chicago Bulls
+Jalen Suggs: Orlando Magic
+Jalen Williams: Oklahoma City Thunder
+Jalen Wilson: Brooklyn Nets
+Jamal Cain: New Orleans Pelicans
+Jamal Murray: Denver Nuggets
+Jamal Shead: Toronto Raptors
+James Harden: LA Clippers
+James Johnson: Indiana Pacers
+James Wiseman: Indiana Pacers
+Jamison Battle: Toronto Raptors
+Jarace Walker: Indiana Pacers
+Jared Butler: Washington Wizards
+Jared McCain: Philadelphia 76ers
+Jaren Jackson Jr.: Memphis Grizzlies
+Jarred Vanderbilt: Los Angeles Lakers
+Jarrett Allen: Cleveland Cavaliers
+Javonte Green: New Orleans Pelicans
+Jaxson Hayes: Los Angeles Lakers
+Jay Huff: Memphis Grizzlies
+Jaylen Brown: Boston Celtics
+Jaylen Clark: Minnesota Timberwolves
+Jaylen Wells: Memphis Grizzlies
+Jaylin Williams: Oklahoma City Thunder
+Jaylon Tyson: Cleveland Cavaliers
+Jayson Tatum: Boston Celtics
+Jazian Gortman: Dallas Mavericks
+Jeff Dowtin Jr.: Philadelphia 76ers
+Jeff Green: Houston Rockets
+Jerami Grant: Portland Trail Blazers
+Jeremiah Robinson-Earl: New Orleans Pelicans
+Jeremy Sochan: San Antonio Spurs
+Jericho Sims: New York Knicks
+Jesse Edwards: Minnesota Timberwolves
+Jett Howard: Orlando Magic
+Jevon Carter: Chicago Bulls
+Jimmy Butler: Miami Heat
+Jock Landale: Houston Rockets
+Joe Ingles: Minnesota Timberwolves
+Joel Embiid: Philadelphia 76ers
+John Collins: Utah Jazz
+John Konchar: Memphis Grizzlies
+Johnny Davis: Washington Wizards
+Johnny Furphy: Indiana Pacers
+Johnny Juzang: Utah Jazz
+Jonas Valančiūnas: Washington Wizards
+Jonathan Isaac: Orlando Magic
+Jonathan Kuminga: Golden State Warriors
+Jonathan Mogbo: Toronto Raptors
+Jordan Clarkson: Utah Jazz
+Jordan Hawkins: New Orleans Pelicans
+Jordan McLaughlin: Sacramento Kings
+Jordan Miller: LA Clippers
+Jordan Poole: Washington Wizards
+Jordan Walsh: Boston Celtics
+Jose Alvarado: New Orleans Pelicans
+Josh Christopher: Miami Heat
+Josh Giddey: Chicago Bulls
+Josh Green: Charlotte Hornets
+Josh Hart: New York Knicks
+Josh Minott: Minnesota Timberwolves
+Josh Okogie: Phoenix Suns
+Josh Richardson: Miami Heat
+Jrue Holiday: Boston Celtics
+Julian Champagnie: San Antonio Spurs
+Julian Phillips: Chicago Bulls
+Julian Strawther: Denver Nuggets
+Julius Randle: Minnesota Timberwolves
+Justin Champagnie: Washington Wizards
+Justin Edwards: Philadelphia 76ers
+Justin Minaya: Portland Trail Blazers
+Jusuf Nurkić: Phoenix Suns
+KJ Martin: Philadelphia 76ers
+KJ Simpson: Charlotte Hornets
+Kai Jones: LA Clippers
+Karl-Anthony Towns: New York Knicks
+Karlo Matković: New Orleans Pelicans
+Kawhi Leonard: LA Clippers
+Keaton Wallace: Atlanta Hawks
+Keegan Murray: Sacramento Kings
+Keion Brooks Jr.: New Orleans Pelicans
+Kel'el Ware: Miami Heat
+Keldon Johnson: San Antonio Spurs
+Kelly Olynyk: Toronto Raptors
+Kelly Oubre Jr.: Philadelphia 76ers
+Kenrich Williams: Oklahoma City Thunder
+Kentavious Caldwell-Pope: Orlando Magic
+Keon Ellis: Sacramento Kings
+Keon Johnson: Brooklyn Nets
+Keshad Johnson: Miami Heat
+Kessler Edwards: Dallas Mavericks
+Kevin Durant: Phoenix Suns
+Kevin Huerter: Sacramento Kings
+Kevin Love: Miami Heat
+Kevin McCullar Jr.: New York Knicks
+Kevin Porter Jr.: LA Clippers
+Kevon Looney: Golden State Warriors
+Keyonte George: Utah Jazz
+Khris Middleton: Milwaukee Bucks
+Klay Thompson: Dallas Mavericks
+Kobe Brown: LA Clippers
+Kobe Bufkin: Atlanta Hawks
+Kris Dunn: LA Clippers
+Kris Murray: Portland Trail Blazers
+Kristaps Porziņģis: Boston Celtics
+Kyle Anderson: Golden State Warriors
+Kyle Filipowski: Utah Jazz
+Kyle Kuzma: Washington Wizards
+Kyle Lowry: Philadelphia 76ers
+Kyrie Irving: Dallas Mavericks
+Kyshawn George: Washington Wizards
+LaMelo Ball: Charlotte Hornets
+Landry Shamet: New York Knicks
+Larry Nance Jr.: Atlanta Hawks
+Lauri Markkanen: Utah Jazz
+LeBron James: Los Angeles Lakers
+Leonard Miller: Minnesota Timberwolves
+Liam Robbins: Milwaukee Bucks
+Lindy Waters III: Golden State Warriors
+Lonzo Ball: Chicago Bulls
+Luguentz Dort: Oklahoma City Thunder
+Luka Dončić: Dallas Mavericks
+Luka Garza: Minnesota Timberwolves
+Luke Kennard: Memphis Grizzlies
+Luke Kornet: Boston Celtics
+Luke Travers: Cleveland Cavaliers
+Mac McClung: Orlando Magic
+Malaki Branham: San Antonio Spurs
+Malcolm Brogdon: Washington Wizards
+Malik Beasley: Detroit Pistons
+Malik Monk: Sacramento Kings
+MarJon Beauchamp: Milwaukee Bucks
+Marcus Sasser: Detroit Pistons
+Marcus Smart: Memphis Grizzlies
+Mark Williams: Charlotte Hornets
+Markieff Morris: Dallas Mavericks
+Marvin Bagley III: Washington Wizards
+Mason Jones: Sacramento Kings
+Mason Plumlee: Phoenix Suns
+Matas Buzelis: Chicago Bulls
+Matisse Thybulle: Portland Trail Blazers
+Matt Ryan: New York Knicks
+Max Christie: Los Angeles Lakers
+Max Strus: Cleveland Cavaliers
+Maxi Kleber: Dallas Mavericks
+Maxwell Lewis: Brooklyn Nets
+Micah Potter: Utah Jazz
+Michael Porter Jr.: Denver Nuggets
+Mikal Bridges: New York Knicks
+Mike Conley: Minnesota Timberwolves
+Miles Bridges: Charlotte Hornets
+Miles McBride: New York Knicks
+Mitchell Robinson: New York Knicks
+Mo Bamba: LA Clippers
+Monté Morris: Phoenix Suns
+Moritz Wagner: Orlando Magic
+Moses Moody: Golden State Warriors
+Mouhamed Gueye: Atlanta Hawks
+Moussa Diabaté: Charlotte Hornets
+Myles Turner: Indiana Pacers
+N'Faly Dante: Houston Rockets
+Naji Marshall: Dallas Mavericks
+Nate Williams: Houston Rockets
+Naz Reid: Minnesota Timberwolves
+Neemias Queta: Boston Celtics
+Nic Claxton: Brooklyn Nets
+Nick Richards: Charlotte Hornets
+Nick Smith Jr.: Charlotte Hornets
+Nickeil Alexander-Walker: Minnesota Timberwolves
+Nicolas Batum: LA Clippers
+Nikola Jokić: Denver Nuggets
+Nikola Jović: Miami Heat
+Nikola Topić: Oklahoma City Thunder
+Nikola Vučević: Chicago Bulls
+Noah Clowney: Brooklyn Nets
+Norman Powell: LA Clippers
+OG Anunoby: New York Knicks
+Obi Toppin: Indiana Pacers
+Ochai Agbaji: Toronto Raptors
+Olivier-Maxence Prosper: Dallas Mavericks
+Onyeka Okongwu: Atlanta Hawks
+Oscar Tshiebwe: Utah Jazz
+Oso Ighodaro: Phoenix Suns
+Ousmane Dieng: Oklahoma City Thunder
+P.J. Tucker: LA Clippers
+P.J. Washington: Dallas Mavericks
+PJ Hall: Denver Nuggets
+Pacôme Dadiet: New York Knicks
+Paolo Banchero: Orlando Magic
+Pascal Siakam: Indiana Pacers
+Pat Connaughton: Milwaukee Bucks
+Pat Spencer: Golden State Warriors
+Patrick Baldwin Jr.: Washington Wizards
+Patrick Williams: Chicago Bulls
+Patty Mills: Utah Jazz
+Paul George: Philadelphia 76ers
+Paul Reed: Detroit Pistons
+Payton Pritchard: Boston Celtics
+Pelle Larsson: Miami Heat
+Peyton Watson: Denver Nuggets
+Precious Achiuwa: New York Knicks
+Quentin Grimes: Dallas Mavericks
+Quenton Jackson: Indiana Pacers
+Quincy Olivari: Los Angeles Lakers
+Quinten Post: Golden State Warriors
+RJ Barrett: Toronto Raptors
+RayJ Dennis: Indiana Pacers
+Rayan Rupert: Portland Trail Blazers
+Reece Beekman: Brooklyn Nets
+Reed Sheppard: Houston Rockets
+Reggie Jackson: Philadelphia 76ers
+Richaun Holmes: Washington Wizards
+Ricky Council IV: Philadelphia 76ers
+Riley Minix: San Antonio Spurs
+Rob Dillingham: Minnesota Timberwolves
+Robert Williams III: Portland Trail Blazers
+Ron Harper Jr.: Detroit Pistons
+Ronald Holland II: Detroit Pistons
+Royce O'Neale: Phoenix Suns
+Rudy Gobert: Minnesota Timberwolves
+Rui Hachimura: Los Angeles Lakers
+Russell Westbrook: Denver Nuggets
+Ryan Dunn: Phoenix Suns
+Ryan Rollins: Milwaukee Bucks
+Saddiq Bey: Washington Wizards
+Sam Hauser: Boston Celtics
+Sam Merrill: Cleveland Cavaliers
+Sandro Mamukelashvili: San Antonio Spurs
+Santi Aldama: Memphis Grizzlies
+Scoot Henderson: Portland Trail Blazers
+Scottie Barnes: Toronto Raptors
+Scotty Pippen Jr.: Memphis Grizzlies
+Seth Curry: Charlotte Hornets
+Shaedon Sharpe: Portland Trail Blazers
+Shai Gilgeous-Alexander: Oklahoma City Thunder
+Shake Milton: Los Angeles Lakers
+Sidy Cissoko: San Antonio Spurs
+Simone Fontecchio: Detroit Pistons
+Spencer Dinwiddie: Dallas Mavericks
+Spencer Jones: Denver Nuggets
+Stanley Umude: Milwaukee Bucks
+Stephen Curry: Golden State Warriors
+Stephon Castle: San Antonio Spurs
+Steven Adams: Houston Rockets
+Svi Mykhailiuk: Utah Jazz
+T.J. McConnell: Indiana Pacers
+Taj Gibson: Charlotte Hornets
+Talen Horton-Tucker: Chicago Bulls
+Tari Eason: Houston Rockets
+Taurean Prince: Milwaukee Bucks
+Taylor Hendricks: Utah Jazz
+Tazé Moore: Portland Trail Blazers
+Terance Mann: LA Clippers
+Terrence Shannon Jr.: Minnesota Timberwolves
+Terry Rozier: Miami Heat
+Thomas Bryant: Indiana Pacers
+Tidjane Salaün: Charlotte Hornets
+Tim Hardaway Jr.: Detroit Pistons
+Tobias Harris: Detroit Pistons
+Tolu Smith: Detroit Pistons
+Torrey Craig: Chicago Bulls
+Tosan Evbuomwan: Brooklyn Nets
+Toumani Camara: Portland Trail Blazers
+Trae Young: Atlanta Hawks
+Trayce Jackson-Davis: Golden State Warriors
+Tre Jones: San Antonio Spurs
+Tre Mann: Charlotte Hornets
+Trendon Watford: Brooklyn Nets
+Trentyn Flowers: LA Clippers
+Trevelin Queen: Orlando Magic
+Trey Alexander: Denver Nuggets
+Trey Lyles: Sacramento Kings
+Trey Murphy III: New Orleans Pelicans
+Tristan Thompson: Cleveland Cavaliers
+Tristan Vukcevic: Washington Wizards
+Tristan da Silva: Orlando Magic
+Tristen Newton: Minnesota Timberwolves
+Ty Jerome: Cleveland Cavaliers
+TyTy Washington Jr.: Phoenix Suns
+Tyler Herro: Miami Heat
+Tyler Kolek: New York Knicks
+Tyler Smith: Milwaukee Bucks
+Tyrese Haliburton: Indiana Pacers
+Tyrese Martin: Brooklyn Nets
+Tyrese Maxey: Philadelphia 76ers
+Tyus Jones: Phoenix Suns
+Ulrich Chomche: Toronto Raptors
+Vasilije Micić: Charlotte Hornets
+Victor Wembanyama: San Antonio Spurs
+Vince Williams Jr.: Memphis Grizzlies
+Vlatko Čančar: Denver Nuggets
+Vít Krejčí: Atlanta Hawks
+Walker Kessler: Utah Jazz
+Wendell Carter Jr.: Orlando Magic
+Wendell Moore Jr.: Detroit Pistons
+Xavier Tillman: Boston Celtics
+Yuki Kawamura: Memphis Grizzlies
+Yves Missi: New Orleans Pelicans
+Zaccharie Risacher: Atlanta Hawks
+Zach Collins: San Antonio Spurs
+Zach Edey: Memphis Grizzlies
+Zach LaVine: Chicago Bulls
+Zeke Nnaji: Denver Nuggets
+Ziaire Williams: Brooklyn Nets
+Zion Williamson: New Orleans Pelicans
+Zyon Pullin: Memphis Grizzlies


### PR DESCRIPTION
### Motivation

We recently demoed [building a streaming ChatGPT proxy with Swift OpenAPI, at FOSDEM 2025][0]. This PR adds the resulting package for people to refer to as reference material.

### Modifications

- Add package reflecting final state of the presentation.
- Add a `.env.example` file.
- Add covering README with link to presentation, abstract, and usage. 
- Add VS Code settings for Dev Containers.

### Result

Reference project available for people watching the presentation.

### Test Plan

CI will build the example.

[0]: https://fosdem.org/2025/schedule/event/fosdem-2025-5230-live-coding-a-streaming-chatgpt-proxy-with-swift-openapi-from-scratch-/
