### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ struct Handler: APIProtocol {
 
 @main struct HelloWorldVaporServer {
     static func main() async throws {
-        let app = Vapor.Application()
+        let app = try await Application.make(.detect())
         let transport = VaporTransport(routesBuilder: app)
         let handler = Handler()
         try handler.registerHandlers(on: transport, serverURL: URL(string: "/api")!)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ struct Handler: APIProtocol {
 
 @main struct HelloWorldVaporServer {
     static func main() async throws {
-        let app = try await Application.make(.detect())
+        let app = try await Application.make()
         let transport = VaporTransport(routesBuilder: app)
         let handler = Handler()
         try handler.registerHandlers(on: transport, serverURL: URL(string: "/api")!)

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Practicing-spec-driven-API-development.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Practicing-spec-driven-API-development.md
@@ -138,7 +138,7 @@ This example starts with a [Vapor](https://github.com/vapor/vapor) server that h
 The existing server might look something like this:
 
 ```swift
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 app.get("foo") { ... a, b, c ... }
 app.post("foo") { ... a, b, c ... }
 app.get("bar") { ... a, b, c ... }
@@ -173,7 +173,7 @@ As you go through the tutorial, the important part is that you only _add_ the ge
 After this step, your code looks something like this:
 
 ```swift
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 
 // Registers your existing routes.
 app.get("foo") { ... a, b, c ... }
@@ -216,7 +216,7 @@ paths:
 Comment out the first of the existing route implementations in your Vapor app:
 
 ```swift
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 
 // Registers your existing routes.
 // app.get("foo") { ... a, b, c ... } // <<< just comment this out, and this route will be registered below by registerHandlers, as it is now defined by your OpenAPI document.
@@ -236,7 +236,7 @@ When you compile the example above, you'll get a build error because `APIProtoco
 Xcode will offer a Fix-it, and if you accept it, it will drop in a function stub that you can fill in:
 
 ```swift
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 
 // Registers your existing routes.
 // <<< now you can just delete the first original route, as you've moved the business logic below into the Handler type
@@ -271,7 +271,7 @@ Endpoints that provide static content, such as CSS or JavaScript files, are not 
 The end result should look something like this:
 
 ```swift
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 
 // Register some manual routes, for example, for serving static files.
 app.middlewares.on(FileMiddleware(...))

--- a/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Swift-OpenAPI-Generator.md
@@ -65,7 +65,7 @@ struct Handler: APIProtocol {
 
 @main struct HelloWorldVaporServer {
     static func main() async throws {
-        let app = Vapor.Application()
+        let app = try await Application.make()
         let transport = VaporTransport(routesBuilder: app)
         let handler = Handler()
         try handler.registerHandlers(on: transport, serverURL: URL(string: "/api")!)

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.0.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.0.swift
@@ -15,7 +15,7 @@ struct GreetingServiceAPIImpl: APIProtocol {
 }
 
 // Create your Vapor application.
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 
 // Create a VaporTransport using your application.
 let transport = VaporTransport(routesBuilder: app)

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.1.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.1.swift
@@ -15,7 +15,7 @@ struct GreetingServiceAPIImpl: APIProtocol {
 }
 
 // Create your Vapor application.
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 
 // Create a VaporTransport using your application.
 let transport = VaporTransport(routesBuilder: app)

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server-openapi-endpoints.main.2.swift
@@ -15,7 +15,7 @@ struct GreetingServiceAPIImpl: APIProtocol {
 }
 
 // Create your Vapor application.
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 
 // Create a VaporTransport using your application.
 let transport = VaporTransport(routesBuilder: app)

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.1.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.1.2.swift
@@ -15,7 +15,7 @@ struct GreetingServiceAPIImpl: APIProtocol {
 }
 
 // Create your Vapor application.
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 
 // Create a VaporTransport using your application.
 let transport = VaporTransport(routesBuilder: app)

--- a/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.2.swift
+++ b/Sources/swift-openapi-generator/Documentation.docc/Tutorials/_Resources/server.main.2.swift
@@ -23,7 +23,7 @@ struct GreetingServiceAPIImpl: APIProtocol {
 }
 
 // Create your Vapor application.
-let app = Vapor.Application()
+let app = try await Vapor.Application.make()
 
 // Create a VaporTransport using your application.
 let transport = VaporTransport(routesBuilder: app)


### PR DESCRIPTION
This commit fixes an issue when starting Vapor in swift 6.  I believe earlier versions of Swift throw a warning about this.

### Motivation

I was following along with documentations but Vapor was throwing an error: Initializer 'init' is unavailable from asynchronous contexts; This initialiser cannot be used in async contexts, use Application.make(_:_:) instead

### Modifications

Just a very simple update to the documentation so others getting started don't hit the same issue

### Result

Vapor server will start when following docs.

### Test Plan

manual tests.