### PR TITLE
[Bug] Exclude webhooks when filter is provided

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
+++ b/Sources/_OpenAPIGeneratorCore/Hooks/FilteredDocument.swift
@@ -128,6 +128,9 @@ struct FilteredDocumentBuilder {
             }
         }
         filteredDocument.components = components
+        // Always remove webhooks, as they may contain references to schemas that were not included.
+        // Webhooks are not supported for filtering, so whenever a filter is used, all webhooks are excluded.
+        filteredDocument.webhooks = [:]
         return filteredDocument
     }
 

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_FilteredDocument.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_FilteredDocument.swift
@@ -75,6 +75,13 @@ final class Test_FilteredDocument: XCTestCase {
                         $ref: '#/components/schemas/B'
                 Empty:
                   description: success
+            webhooks:
+              my-webhook:
+                post:
+                  description: Webhook
+                  responses:
+                    '200':
+                      description: OK
             """
         let document = try YAMLDecoder().decode(OpenAPI.Document.self, from: documentYAML)
         assert(filtering: document, filter: DocumentFilter(), hasPaths: [], hasOperations: [], hasSchemas: [])
@@ -189,6 +196,13 @@ final class Test_FilteredDocument: XCTestCase {
             filteredDocument.components.parameters.keys.map(\.rawValue),
             parameters,
             "Parameters don't match",
+            file: file,
+            line: line
+        )
+        XCTAssertUnsortedEqual(
+            filteredDocument.webhooks.keys,
+            [],
+            "Webhooks don't match",
             file: file,
             line: line
         )


### PR DESCRIPTION
### Motivation

Fixes #712.

When an OpenAPI document includes webhooks that include schema references, and a filter is provided, the generator would fail unless all the schemas needed by all webhooks were explicitly included in the filter.

### Modifications

Since we don't currently support filtering webhooks, just exclude them always when a filter is provided. This fixes the bug.

In the future, if we add support for webhooks, we can add support for filtering them as well.

### Result

Unblocks generating GitHub's OpenAPI 3.1.0 doc + filters.

### Test Plan

Adapted the filtering unit test, verified it fails without the fix, and passes with it.
