### PR TITLE
Adjust the platform-based linkage check

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
+++ b/Sources/_OpenAPIGeneratorCore/PlatformChecks.swift
@@ -14,9 +14,9 @@
 
 // Emit a compiler error if this library is linked with a target in an adopter
 // project.
-//
-// When compiling for MacCatalyst, the plugin is (erroneously?) compiled with os(iOS).
-#if !(os(macOS) || os(Linux) || (os(iOS) && targetEnvironment(macCatalyst)))
+// This is only done for platforms where the linkage was most likely added
+// erroneously (for platforms which can't be used as development hosts).
+#if (os(iOS) && !targetEnvironment(macCatalyst)) || os(tvOS) || os(watchOS) || os(visionOS)
 #error(
     "_OpenAPIGeneratorCore is only to be used by swift-openapi-generator itself—your target should not link this library or the command line tool directly."
 )


### PR DESCRIPTION
Limit this to Apple platforms except macOS in order to unblock use of swift-openapi-generator on more platforms like Windows, Android, FreeBSD, and so on.