### PR TITLE
Enable macOS CI on merge to main and daily timer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,3 +30,9 @@ jobs:
     with:
       name: "Example packages"
       matrix_linux_command: "./scripts/test-examples.sh"
+
+    macos-tests:
+        name: macOS tests
+        uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+        with:
+            build_scheme: swift-openapi-generator-Package


### PR DESCRIPTION
Motivation:

* Improve test coverage
* Check test pass/fail status
* Monitor CI throughput

Modifications:

Enable macOS CI to be run on all merges to main and on a daily timer.

Result:

Improved test coverage run out-of-band at the moment so we can get a
feeling for if any changes need to be made in the repo or in the CI
pipelines to ensure timely and stable checks.
