### PR TITLE
Add support for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ jobs:
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_0_enabled: true
+      windows_nightly_6_1_enabled: true
+      windows_nightly_main_enabled: true
+      windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   integration-test:
     name: Integration test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,12 @@ jobs:
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_0_enabled: true
+      windows_nightly_6_1_enabled: true
+      windows_nightly_main_enabled: true
+      windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   integration-test:
     name: Integration test

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         // Tests-only: Runtime library linked by generated code, and also
         // helps keep the runtime library new enough to work with the generated
         // code.
-        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.3.2"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.8.2"),
         .package(url: "https://github.com/apple/swift-http-types", from: "1.0.2"),
     ],
     targets: [
@@ -111,7 +111,10 @@ let package = Package(
         .testTarget(
             name: "OpenAPIGeneratorTests",
             dependencies: [
-                "swift-openapi-generator", .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                "_OpenAPIGeneratorCore",
+                // Everything except windows: https://github.com/swiftlang/swift-package-manager/issues/6367
+                .target(name: "swift-openapi-generator", condition: .when(platforms: [.android, .linux, .macOS, .openbsd, .wasi, .custom("freebsd")])),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             resources: [.copy("Resources")],
             swiftSettings: swiftSettings

--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ See also [Supported OpenAPI features][supported-openapi-features].
 
 ### Supported platforms and minimum versions
 
-The generator is used during development and is supported on macOS and Linux.
+The generator is used during development and is supported on macOS, Linux, and Windows.
 
 The generated code, runtime library, and transports are supported on more
 platforms, listed below.
 
-| Component                           | macOS     | Linux | iOS    | tvOS   | watchOS | visionOS |
+| Component                           | macOS     | Linux, Windows | iOS    | tvOS   | watchOS | visionOS |
 | ----------------------------------: | :---      | :---  | :-     | :--    | :-----  | :------  |
 | Generator plugin and CLI            | ✅ 10.15+ | ✅    | ✖️      | ✖️      | ✖️       | ✖️        |
 | Generated code and runtime library  | ✅ 10.15+ | ✅    | ✅ 13+ | ✅ 13+ | ✅ 6+   | ✅ 1+    |

--- a/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
@@ -190,6 +190,24 @@ extension FileBasedReferenceTests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
+        // Normalize newlines
+        #if os(Windows)
+        let hasCarriageReturns = String(
+            decoding: FileManager.default.contents(atPath: referenceFile.path) ?? Data(),
+            as: UTF8.self
+        )
+        .contains("\r\n")
+        XCTAssertNoThrow(
+            try Data(
+                (String(decoding: FileManager.default.contents(atPath: generatedFile.path) ?? Data(), as: UTF8.self)
+                    .split(omittingEmptySubsequences: false, whereSeparator: { $0 == "\r" || $0 == "\n" })
+                    .joined(separator: hasCarriageReturns ? "\r\n" : "\n"))
+                    .utf8
+            )
+            .write(to: URL(fileURLWithPath: generatedFile.path))
+        )
+        #endif
+
         if FileManager.default.contentsEqual(atPath: generatedFile.path, andPath: referenceFile.path) { return }
 
         let diffOutput: String?
@@ -219,10 +237,10 @@ extension FileBasedReferenceTests {
 
     private func runDiff(reference: URL, actual: URL) throws -> String {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.executableURL = try resolveExecutable("git")
         process.currentDirectoryURL = self.referenceTestResourcesDirectory
         process.arguments = [
-            "git", "diff", "--no-index", "-U5",
+            "diff", "--no-index", "-U5",
             // The following arguments are useful for development.
             //            "--ignore-space-change",
             //            "--ignore-all-space",

--- a/Tests/OpenAPIGeneratorReferenceTests/Helpers.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Helpers.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+func resolveExecutable(_ name: String) throws -> URL {
+    struct Static {
+        #if os(Windows)
+        static let separator = ";"
+        static let suffix = ".exe"
+        #else
+        static let separator = ":"
+        static let suffix = ""
+        #endif
+    }
+
+    enum PathResolutionError: Error, CustomStringConvertible {
+        case notFound(name: String, path: String)
+        var description: String {
+            switch self {
+            case let .notFound(name, path): "Could not find \(name)\(Static.suffix) in PATH: \(path)"
+            }
+        }
+    }
+    let env = Dictionary(
+        uniqueKeysWithValues: ProcessInfo.processInfo.environment.map { (k, v) in
+            #if os(Windows)
+            return (k.uppercased(), v)
+            #else
+            return (k, v)
+            #endif
+        }
+    )
+    let paths = (env["PATH"] ?? "").split(separator: Static.separator).map(String.init)
+    for path in paths {
+        let fullPath = path + "/" + name + Static.suffix
+        if FileManager.default.fileExists(atPath: fullPath) { return URL(fileURLWithPath: fullPath) }
+    }
+    throw PathResolutionError.notFound(name: name, path: env["PATH"] ?? "")
+}

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -6247,10 +6247,8 @@ private func XCTAssertSwiftEquivalent(
 
 private func diff(expected: String, actual: String) throws -> String {
     let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = [
-        "bash", "-c", "diff -U5 --label=expected <(echo '\(expected)') --label=actual <(echo '\(actual)')",
-    ]
+    process.executableURL = try resolveExecutable("bash")
+    process.arguments = ["-c", "diff -U5 --label=expected <(echo '\(expected)') --label=actual <(echo '\(actual)')"]
     let pipe = Pipe()
     process.standardOutput = pipe
     try process.run()

--- a/Tests/OpenAPIGeneratorTests/Test_GenerateOptions.swift
+++ b/Tests/OpenAPIGeneratorTests/Test_GenerateOptions.swift
@@ -15,7 +15,11 @@ import XCTest
 import _OpenAPIGeneratorCore
 import OpenAPIKit
 import ArgumentParser
+
+// https://github.com/swiftlang/swift-package-manager/issues/6367
+#if !os(Windows)
 @testable import swift_openapi_generator
+#endif
 
 final class Test_GenerateOptions: XCTestCase {
 
@@ -29,6 +33,8 @@ final class Test_GenerateOptions: XCTestCase {
         )
     }
 
+    // https://github.com/swiftlang/swift-package-manager/issues/6367
+    #if !os(Windows)
     func testRunGeneratorThrowsErrorDiagnostic() async throws {
         let outputDirectory = URL(fileURLWithPath: "/invalid/path")
         let docsDirectory = resourcesDirectory.appendingPathComponent("Docs")
@@ -45,4 +51,5 @@ final class Test_GenerateOptions: XCTestCase {
             XCTAssertEqual(diagnostic.severity, .error, "Expected diagnostic severity to be `.error`")
         } catch { XCTFail("Expected to throw a Diagnostic `.error`, but threw a different error: \(error)") }
     }
+    #endif
 }


### PR DESCRIPTION
Disable tests relying on the executable since those aren't yet supported by SwiftPM, and tweak a couple platform-conditional pieces of code to support the Windows path.