### PR TITLE
Enable macOS CI on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
     name: macOS tests
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
+      runner_pool: nightly
       build_scheme: swift-openapi-generator-Package
       ios_xcode_build_enabled: false
       watchos_xcode_build_enabled: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,3 +57,14 @@ jobs:
             name: "Example packages"
             matrix_linux_command: "./scripts/test-examples.sh"
             matrix_linux_nightly_main_enabled: false
+
+  macos-tests:
+    name: macOS tests
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    with:
+      runner_pool: general
+      build_scheme: swift-openapi-generator-Package
+      ios_xcode_build_enabled: false
+      watchos_xcode_build_enabled: false
+      tvos_xcode_build_enabled: false
+      visionos_xcode_build_enabled: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,62 +1,62 @@
 name: PR
 
 on:
-    pull_request:
-      types: [opened, reopened, synchronize]
+  pull_request:
+   types: [opened, reopened, synchronize]
 
 jobs:
-    soundness:
-        name: Soundness
-        uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
-        with:
-            api_breakage_check_enabled: false
-            license_header_check_project_name: "SwiftOpenAPIGenerator"
-            yamllint_check_enabled: false
+  soundness:
+    name: Soundness
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    with:
+      api_breakage_check_enabled: false
+      license_header_check_project_name: "SwiftOpenAPIGenerator"
+      yamllint_check_enabled: false
 
-    unit-tests:
-        name: Unit tests
-        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
-        with:
-            linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+  unit-tests:
+    name: Unit tests
+    uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+    with:
+      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
-    integration-test:
-        name: Integration test
-        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
-        with:
-            name: "Integration test"
-            matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
-            matrix_linux_nightly_main_enabled: false
+  integration-test:
+    name: Integration test
+    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    with:
+      name: "Integration test"
+      matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
+      matrix_linux_nightly_main_enabled: false
 
-    compatibility-test:
-      name: Compatibility test
-      runs-on: ubuntu-latest
-      container:
-          image: swift:latest
-      steps:
-          - name: Checkout repository
-            uses: actions/checkout@v4
-            with:
-                persist-credentials: false
-          - name: Run OpenAPI document compatibilty test
-            env:
-              SWIFT_OPENAPI_COMPATIBILITY_TEST_ENABLE: "true"
-              SWIFT_OPENAPI_COMPATIBILITY_TEST_SKIP_BUILD: "true"
-              SWIFT_OPENAPI_COMPATIBILITY_TEST_FILTER: OpenAPIGeneratorReferenceTests.CompatibilityTest
-              SWIFT_OPENAPI_COMPATIBILITY_TEST_PARALLEL_CODEGEN: "true"
-              SWIFT_OPENAPI_COMPATIBILITY_TEST_NUM_BUILD_JOBS: 1
-            run: swift test --filter ${SWIFT_OPENAPI_COMPATIBILITY_TEST_FILTER}
-
-    example-packages:
-        name: Example packages
-        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+  compatibility-test:
+    name: Compatibility test
+    runs-on: ubuntu-latest
+    container:
+      image: swift:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-            name: "Example packages"
-            matrix_linux_command: "./scripts/test-examples.sh"
-            matrix_linux_nightly_main_enabled: false
+          persist-credentials: false
+      - name: Run OpenAPI document compatibilty test
+        env:
+          SWIFT_OPENAPI_COMPATIBILITY_TEST_ENABLE: "true"
+          SWIFT_OPENAPI_COMPATIBILITY_TEST_SKIP_BUILD: "true"
+          SWIFT_OPENAPI_COMPATIBILITY_TEST_FILTER: OpenAPIGeneratorReferenceTests.CompatibilityTest
+          SWIFT_OPENAPI_COMPATIBILITY_TEST_PARALLEL_CODEGEN: "true"
+          SWIFT_OPENAPI_COMPATIBILITY_TEST_NUM_BUILD_JOBS: 1
+        run: swift test --filter ${SWIFT_OPENAPI_COMPATIBILITY_TEST_FILTER}
+
+  example-packages:
+    name: Example packages
+    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    with:
+      name: "Example packages"
+      matrix_linux_command: "./scripts/test-examples.sh"
+      matrix_linux_nightly_main_enabled: false
 
   macos-tests:
     name: macOS tests


### PR DESCRIPTION
Motivation:

* Improve test coverage

Modifications:

Enable macOS CI to be run on pull request commits and make the use of the nightly runner pool for main.yml jobs explicit.

Result:

Improved test coverage.
