### PR TITLE
Switch integration tests & examples to new matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator
-          MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh
+          MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${workspace} ./scripts/run-integration-test.sh
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
 
   integration-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - id: generate-matrix
         run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
-          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator/.git && git config --global --add safe.directory /swift-openapi-generator
           MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${workspace} ./scripts/run-integration-test.sh
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,19 +23,55 @@ jobs:
       windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
+  construct-integration-test-matrix:
+    name: Construct integration matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-test-matrix: '${{ steps.generate-matrix.outputs.integration-test-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator
+          MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+
   integration-test:
     name: Integration test
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-integration-test-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Integration test"
-      matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
+      matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
+
+  construct-example-packages-matrix:
+    name: Construct example packages matrix
+    runs-on: ubuntu-latest
+    outputs:
+      example-packages-matrix: '${{ steps.generate-matrix.outputs.example-packages-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "example-packages-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: git config --global --add safe.directory /swift-openapi-generator
+          MATRIX_LINUX_COMMAND: ./scripts/test-examples.sh
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
 
   example-packages:
     name: Example packages
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-example-packages-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Example packages"
-      matrix_linux_command: "./scripts/test-examples.sh"
+      matrix_string: '${{ needs.construct-example-packages-matrix.outputs.example-packages-matrix }}'
 
   macos-tests:
     name: macOS tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
         run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
           MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator
-          MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh
+          MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${workspace} ./scripts/run-integration-test.sh
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
 
   integration-test:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -61,7 +61,7 @@ jobs:
       - id: generate-matrix
         run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
         env:
-          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator/.git && git config --global --add safe.directory /swift-openapi-generator
           MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${workspace} ./scripts/run-integration-test.sh
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,14 +29,6 @@ jobs:
       windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
-  integration-test:
-    name: Integration test
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
-    with:
-      name: "Integration test"
-      matrix_linux_command: "apt-get update -yq && apt-get install -yq jq && SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh"
-      matrix_linux_nightly_main_enabled: false
-
   compatibility-test:
     name: Compatibility test
     runs-on: ubuntu-latest
@@ -56,13 +48,56 @@ jobs:
           SWIFT_OPENAPI_COMPATIBILITY_TEST_NUM_BUILD_JOBS: 1
         run: swift test --filter ${SWIFT_OPENAPI_COMPATIBILITY_TEST_FILTER}
 
+  construct-integration-test-matrix:
+    name: Construct integration matrix
+    runs-on: ubuntu-latest
+    outputs:
+      integration-test-matrix: '${{ steps.generate-matrix.outputs.integration-test-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator
+          MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${GITHUB_WORKSPACE} ./scripts/run-integration-test.sh
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+
+  integration-test:
+    name: Integration test
+    needs: construct-integration-test-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: "Integration test"
+      matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
+
+  construct-example-packages-matrix:
+    name: Construct example packages matrix
+    runs-on: ubuntu-latest
+    outputs:
+      example-packages-matrix: '${{ steps.generate-matrix.outputs.example-packages-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "example-packages-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_SETUP_COMMAND: git config --global --add safe.directory /swift-openapi-generator
+          MATRIX_LINUX_COMMAND: ./scripts/test-examples.sh
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+
   example-packages:
     name: Example packages
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-example-packages-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Example packages"
-      matrix_linux_command: "./scripts/test-examples.sh"
-      matrix_linux_nightly_main_enabled: false
+      matrix_string: '${{ needs.construct-example-packages-matrix.outputs.example-packages-matrix }}'
+
 
   macos-tests:
     name: macOS tests


### PR DESCRIPTION
### Motivation:

To remove all uses of the older workflow so it can be removed to simplify the workflows.

### Modifications:

* Switch integration tests and examples to use the newer Swift test matrix workflow, `swift_test_matrix.yml`

### Result:

This should make no difference to the running of integration tests or example package checks
