### PR TITLE
examples: Update streaming ChatGPT example for Swift 6.1

### DIFF
--- a/Examples/streaming-chatgpt-proxy/.devcontainer/devcontainer.json
+++ b/Examples/streaming-chatgpt-proxy/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Swift",
-    "image": "swift:6.0",
+    "image": "swift:6.1",
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {},
         "ghcr.io/devcontainers/features/git:1": {}
@@ -16,7 +16,7 @@
                 "lldb.library": "/usr/lib/liblldb.so"
             },
             "extensions": [
-                "sswg.swift-lang",
+                "swiftlang.swift-vscode",
                 "42Crunch.vscode-openapi"
             ]
         }

--- a/Examples/streaming-chatgpt-proxy/.vscode/settings.json
+++ b/Examples/streaming-chatgpt-proxy/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    "editor.lightbulb.enabled": "off",
-    "explorer.decorations.badges": false,
-    "explorer.decorations.colors": false,
     "files.exclude": {
         "**/.build": true,
         "**/.build-linux": true,
@@ -14,18 +11,10 @@
         "*.swiftdeps": true,
         "*.swiftdeps~": true,
     },
-    "outline.problems.colors": false,
-    "outline.problems.badges": false,
     "lldb.library": "/usr/lib/liblldb.so",
     "lldb.launch.expressions": "native",
     "swift.diagnosticsStyle": "default",
     "swift.disableAutoResolve": true,
-    "swift.sourcekit-lsp.backgroundIndexing": "off",
-    "swift.sourcekit-lsp.disable": true,
     "swift.buildPath": ".build-linux",
-    "workbench.colorCustomizations": {
-        "editorError.foreground": "#00000000",
-        "editorWarning.foreground": "#00000000",
-    },
     "workbench.startupEditor": "none"
 }

--- a/Examples/streaming-chatgpt-proxy/README.md
+++ b/Examples/streaming-chatgpt-proxy/README.md
@@ -9,9 +9,10 @@ An example project using [Swift OpenAPI Generator](https://github.com/apple/swif
 A tailored API server, backed by ChatGPT, and client CLI, with end-to-end
 streaming.
 
-This package is the reference sources for the demo presented at [FOSDEM 2025:
-_Live coding a streaming ChatGPT proxy with Swift OpenAPI—from
-scratch!_][fosdem25-swift-openapi]
+This package is the reference sources for the talk, _Live coding a streaming ChatGPT proxy with Swift OpenAPI—from scratch!, presented at:
+
+- [FOSDEM 2025][fosdem25-swift-openapi]
+- [try! Swift 2025][tryswift25]
 
 > Join us as we build a ChatGPT client, from scratch, using Swift OpenAPI Generator. We’ll take advantage of Swift OpenAPI’s pluggable HTTP transports to reuse the same generated client to make upstream calls from a Linux server, providing end-to-end streaming, backed by async sequences, without buffering upstream responses.
 >
@@ -24,7 +25,7 @@ scratch!_][fosdem25-swift-openapi]
 > * Efficiently transform responses from SSE to JSON Lines, maintaining end-to-end streaming.
 
 The example provides an API for a fictitious _ChantGPT_ service, which produces
-creative chants to sing at basketball games. 🙌 🏀 🙌
+creative chants to sing at sports games. 🙌 🏟️ 🙌
 
 ## Usage
 
@@ -70,4 +71,5 @@ Containers][dev-containers].
 If you have the Dev Containers extension installed, use the `Dev Containers: Reopen in Container` command to switch to build and run for Linux.
 
 [fosdem25-swift-openapi]: https://fosdem.org/2025/schedule/event/fosdem-2025-5230-live-coding-a-streaming-chatgpt-proxy-with-swift-openapi-from-scratch-/
+[tryswift25]: https://tryswift.jp/en/
 [dev-containers]: https://code.visualstudio.com/docs/devcontainers/containers


### PR DESCRIPTION
### Motivation

The streaming ChatGPT example we have uses Swift 6.0 and the Swift VS Code extension from the SSWG. Since then, Swift 6.1 has been released, which contains fixes for indexing and editor functionality for code generated by Swift package plugins. The VS Code plugin has also been moved to the Swift project.

### Modifications

- Update the example dev container to Swift 6.1.
- Update the example dev container to use `swiftlang.swift-vscode`.
- Clean up redundant workarounds in VS Code settings.
- Link to try! Swift in addition to FOSDEM for folks looking for reference sources from conference talk.

### Result

Example represents what was most recently presented.

### Test Plan

CI will ensure the package has not regressed.