### PR TITLE
Allow substituting types

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateSchema.swift
@@ -87,6 +87,21 @@ extension TypesFileTranslator {
                 )
             )
         }
+        if let substituteTypeName = schema.vendorExtensions["x-swift-open-api-substitute-type"]?.value
+            as? String
+        {
+            try diagnostics.emit(.note(message: "Substituting type \(typeName) with \(substituteTypeName)"))
+            let substitutedType = TypeName(swiftKeyPath: substituteTypeName.components(separatedBy: ".")).asUsage
+            
+            let typealiasDecl = try translateTypealias(
+                named: typeName,
+                userDescription: overrides.userDescription ?? schema.description,
+                to: substitutedType.withOptional(
+                    overrides.isOptional ?? typeMatcher.isOptional(schema, components: components)
+                )
+            )
+            return [typealiasDecl]
+        }
 
         // If this type maps to a referenceable schema, define a typealias
         if let builtinType = try typeMatcher.tryMatchReferenceableType(for: schema, components: components) {


### PR DESCRIPTION
### Motivation

Picking up after some time from this issue https://github.com/apple/swift-openapi-generator/issues/375

There are some usecases described here that i think could be addressed by this.

I suspect there are some "bigger picture" decisions (maybe proposals) needing to happen so i wanted to get the ball rolling :) 


### Modifications

I made a small change allowing to "swap in" any type instead of generating one, by using a vendor-extension (`x-swift-open-api-substitute-type`)

### Result

The following spec 

```yaml
openapi: 3.1.0
info:
  title: api
  version: 1.0.0
components:
  schemas:
    MyCustomString:
      type: string
      x-swift-open-api-substitute-type: MyLibrary.MyCustomString
```
would generate code like this (abbreviated)
```swift
public enum Components {
    public enum Schemas {
        /// - Remark: Generated from `#/components/schemas/MyCustomString`.
        public typealias MyCustomString = MyLibrary.MyCustomString
    }
}
```


### Test Plan

I did write a test but suspect theres, other parts affected that i missed
