### PR TITLE
Drop Swift 5.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/Examples/auth-client-middleware-example/Package.swift
+++ b/Examples/auth-client-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/auth-server-middleware-example/Package.swift
+++ b/Examples/auth-server-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/bidirectional-event-streams-client-example/Package.swift
+++ b/Examples/bidirectional-event-streams-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/bidirectional-event-streams-server-example/Package.swift
+++ b/Examples/bidirectional-event-streams-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/command-line-client-example/Package.swift
+++ b/Examples/command-line-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/curated-client-library-example/Package.swift
+++ b/Examples/curated-client-library-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/event-streams-client-example/Package.swift
+++ b/Examples/event-streams-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/event-streams-server-example/Package.swift
+++ b/Examples/event-streams-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/hello-world-async-http-client-example/Package.swift
+++ b/Examples/hello-world-async-http-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/hello-world-hummingbird-server-example/Package.swift
+++ b/Examples/hello-world-hummingbird-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9.2
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/hello-world-urlsession-client-example/Package.swift
+++ b/Examples/hello-world-urlsession-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/hello-world-vapor-server-example/Package.swift
+++ b/Examples/hello-world-vapor-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9.2
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/logging-middleware-oslog-example/Package.swift
+++ b/Examples/logging-middleware-oslog-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/logging-middleware-swift-log-example/Package.swift
+++ b/Examples/logging-middleware-swift-log-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/manual-generation-generator-cli-example/Package.swift
+++ b/Examples/manual-generation-generator-cli-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/manual-generation-package-plugin-example/Package.swift
+++ b/Examples/manual-generation-package-plugin-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/metrics-middleware-example/Package.swift
+++ b/Examples/metrics-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/postgres-database-example/Package.swift
+++ b/Examples/postgres-database-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/retrying-middleware-example/Package.swift
+++ b/Examples/retrying-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/shared-types-client-server-example/Package.swift
+++ b/Examples/shared-types-client-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/streaming-chatgpt-proxy/Package.swift
+++ b/Examples/streaming-chatgpt-proxy/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(

--- a/Examples/swagger-ui-endpoint-example/Package.swift
+++ b/Examples/swagger-ui-endpoint-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/tracing-middleware-example/Package.swift
+++ b/Examples/tracing-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/various-content-types-client-example/Package.swift
+++ b/Examples/various-content-types-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/various-content-types-server-example/Package.swift
+++ b/Examples/various-content-types-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9.2
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/IntegrationTest/Package.swift
+++ b/IntegrationTest/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project


### PR DESCRIPTION
Motivation:

Swift 5.9 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 5.10
* Remove Swift 5.9 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
