### PR TITLE
Increase the upper version on Yams to include the new 6.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
 
         // Read OpenAPI documents
         .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "3.3.0"),
-        .package(url: "https://github.com/jpsim/Yams", "4.0.0"..<"6.0.0"),
+        .package(url: "https://github.com/jpsim/Yams", "4.0.0"..<"7.0.0"),
 
         // CLI Tool
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),


### PR DESCRIPTION
### Motivation

Yams released a mostly compatible version 6.0.0.

OpenAPIKit just did the same: https://github.com/mattpolzin/OpenAPIKit/pull/410

### Modifications

Increased the upper bound for the Yams dependency, so that our common adopters can use it.

### Result

Ability to resolve Yams 6.0.0 when Swift OpenAPI Generator is also in a dependency graph.

### Test Plan

PR CI.
