### PR TITLE
Fix final layer of error handling in command plugin

### DIFF
--- a/Plugins/OpenAPIGeneratorCommand/plugin.swift
+++ b/Plugins/OpenAPIGeneratorCommand/plugin.swift
@@ -82,10 +82,11 @@ extension SwiftOpenAPIGeneratorPlugin: CommandPlugin {
                 hadASuccessfulRun = true
             } catch let error as PluginError {
                 if error.isMisconfigurationError {
-                    print("- OpenAPI code generation failed with error.")
+                    print("- Stopping because target isn't configured for OpenAPI code generation.")
                     throw error
                 } else {
-                    print("- Stopping because target isn't configured for OpenAPI code generation.")
+                    print("- OpenAPI code generation failed with error.")
+                    throw error
                 }
             }
         }

--- a/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
@@ -52,7 +52,7 @@ extension _GenerateOptions {
         }
         let (diagnostics, finalizeDiagnostics) = preparedDiagnosticsCollector(outputPath: diagnosticsOutputPath)
         let doc = self.docPath
-        print(
+        FileHandle.standardError.write(
             """
             Swift OpenAPI Generator is running with the following configuration:
             - OpenAPI document path: \(doc.path)


### PR DESCRIPTION
### Motivation

When the generator is run as a command plugin on a correctly configured target but there are problems generating, there's a layer of error handling which is incorrect resulting in a poor user experience. For example, if the OpenAPI document contains a bad type like this...

```yaml
components:
  schemas:
    BadIntHolder:
      type: object
      description: A value that has a bad typed int.
      properties:
        int:
          type: int
          description: A bad type
```

...then the command plugin shows the following output:

```
Considering target 'HelloWorldURLSessionClient':
- Trying OpenAPI code generation.
/Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/openapi.yaml: error: Found neither a JSONType nor a Arr
ay<JSONType> in Document.components.schemas.Greeting.properties.i.type.

JSONType could not be decoded because:
Inconsistency encountered when parsing `[unknown object]`: Cannot initialize JSONType from invalid String value int.

Array<JSONType> could not be decoded because:
Expected value to be parsable as Sequence but it was not..
Error: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/openapi.yaml: error: Found neither a JSONType no
r a Array<JSONType> in Document.components.schemas.Greeting.properties.i.type.

JSONType could not be decoded because:
Inconsistency encountered when parsing `[unknown object]`: Cannot initialize JSONType from invalid String value int.

Array<JSONType> could not be decoded because:
Expected value to be parsable as Sequence but it was not..
Swift OpenAPI Generator is running with the following configuration:
- OpenAPI document path: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/openapi.yaml
- Configuration path: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/openapi-generator-config.yaml
- Generator modes: types, client
- Access modifier: internal
- Naming strategy: idiomatic
- Name overrides: <none>
- Type overrides: <none>
- Feature flags: <none>
- Output file names: Types.swift, Client.swift
- Output directory: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/GeneratedSources
- Diagnostics output path: <none - logs to stderr>
- Current directory: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example
- Plugin source: command
- Is dry run: false
- Additional imports: <none>
- Additional file comments: <none>
- Stopping because target isn't configured for OpenAPI code generation.
error: Targets with names HelloWorldURLSessionClient don't contain any config or OpenAPI document files with expected names. See documentation for details.
```

There are two issues with this:

1. The final error is just plain wrong.
2. Because the diagnostics are printed to stderr and the big info message to stdout they are ordered wrongly—you get the diagnostics _before_ the message saying how the generator will run.

### Modifications

- Fix the categorisation of errors in the command plugin.
- Print the big info message to stderr.

### Result

- Command plugin now correctly categorises misconfiguration errors vs other errors and provides more appropriate output on failure.

The above example now results in:

```
Considering target 'HelloWorldURLSessionClient':
- Trying OpenAPI code generation.
Swift OpenAPI Generator is running with the following configuration:
- OpenAPI document path: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/openapi.yaml
- Configuration path: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/openapi-generator-config.yaml
- Generator modes: types, client
- Access modifier: internal
- Naming strategy: idiomatic
- Name overrides: <none>
- Type overrides: <none>
- Feature flags: <none>
- Output file names: Types.swift, Client.swift
- Output directory: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/GeneratedSources
- Diagnostics output path: <none - logs to stderr>
- Current directory: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example
- Plugin source: command
- Is dry run: false
- Additional imports: <none>
- Additional file comments: <none>/Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/openapi.yaml: error: Found neither a JSONType nor a Array<JSONType> in Document.components.schemas.Greeting.properties.int.type.

JSONType could not be decoded because:
Inconsistency encountered when parsing `[unknown object]`: Cannot initialize JSONType from invalid String value int.

Array<JSONType> could not be decoded because:
Expected value to be parsable as Sequence but it was not..
Error: /Users/Si/work/code/swift-openapi-workspace/packages/swift-openapi-generator/Examples/hello-world-urlsession-client-example/Sources/HelloWorldURLSessionClient/openapi.yaml: error: Found neither a JSONType nor a Array<JSONType> in Document.components.schemas.Greeting.properties.int.type.

JSONType could not be decoded because:
Inconsistency encountered when parsing `[unknown object]`: Cannot initialize JSONType from invalid String value int.

Array<JSONType> could not be decoded because:
Expected value to be parsable as Sequence but it was not..
- OpenAPI code generation failed with error.
error: The generator failed to generate OpenAPI files for target 'HelloWorldURLSessionClient'.
```

## Related issues

- Fixes #794 

