### PR TITLE
Add command plugin generation step to integration test

### DIFF
--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -45,4 +45,8 @@ swift package --package-path "${INTEGRATION_TEST_PACKAGE_PATH}" \
 log "Building integration test package: ${INTEGRATION_TEST_PACKAGE_PATH}"
 swift build --package-path "${INTEGRATION_TEST_PACKAGE_PATH}"
 
+log "Running command plugin on integration test package: ${INTEGRATION_TEST_PACKAGE_PATH}"
+swift package --package-path "${INTEGRATION_TEST_PACKAGE_PATH}" \
+ --allow-writing-to-package-directory generate-code-from-openapi
+
 log "✅ Successfully built integration test package."


### PR DESCRIPTION
### Motivation

In #795 we adjusted the logic of the command plugin because errors were not propagating properly. As a result, we regressed behaviour when the command plugin was run without any `--target` argument. In this mode, the plugin runs on all targets. When it detects a misconfigured target it errors, as it should. However, the classification of misconfigured target included targets that were not intended for code generation at all, resulting in errors running the command plugin on packages with others targets.

### Modifications

- Add command plugin generation step to integration test
- If the command plugin is running without a `--target` argument and cannot find _any_ of the required files, skip that target.

### Result

- Manual code generation with the command plugin fixed for packages with other targets.
- Fixes #797.

### Test Plan

This PR includes two commits. The first adds a step to the integration test, which runs the command plugin on the integration test package. This will fail in CI. Then the second commit will provide the fix, which should pass in CI. The commits will then be squash merged.
