### PR TITLE
Update generator version in manual cli example

### DIFF
--- a/Examples/manual-generation-generator-cli-example/Makefile
+++ b/Examples/manual-generation-generator-cli-example/Makefile
@@ -4,7 +4,7 @@
 
 # The following values can be changed here, or passed on the command line.
 SWIFT_OPENAPI_GENERATOR_GIT_URL ?= https://github.com/apple/swift-openapi-generator
-SWIFT_OPENAPI_GENERATOR_GIT_TAG ?= 1.6.0
+SWIFT_OPENAPI_GENERATOR_GIT_TAG ?= 1.10.2
 SWIFT_OPENAPI_GENERATOR_CLONE_DIR ?= $(CURRENT_MAKEFILE_DIR)/.swift-openapi-generator
 SWIFT_OPENAPI_GENERATOR_BUILD_CONFIGURATION ?= debug
 OPENAPI_YAML_PATH ?= $(CURRENT_MAKEFILE_DIR)/openapi.yaml

--- a/Examples/manual-generation-generator-cli-example/Package.swift
+++ b/Examples/manual-generation-generator-cli-example/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     name: "manual-generation-generator-cli-example",
     platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.7.0"),
-        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.8.2"),
+        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.1.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
### Motivation

This solves the missing import issue described in https://github.com/apple/swift-openapi-generator/issues/755

### Modifications

Update the version of generator in`Makefile`
Updated runtime versions to latest released version

### Result

Solved the `is not available due to missing import of defining module 'Foundation'` issue

### Test Plan

Passed locally, `make generate` and `swift run`.