### PR TITLE
Allow recursive schemas in multipart-based paths

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/Multipart/MultipartContentInspector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Multipart/MultipartContentInspector.swift
@@ -281,7 +281,7 @@ extension FileTranslator {
             case .string(_, let context):
                 repetitionKind = .single
                 candidateSource = try inferStringContent(context)
-            case .object(_, _), .fragment:
+            case .object, .fragment:
                 repetitionKind = .single
                 candidateSource = .infer(.complex)
             case .all(of: let schemas, _), .one(of: let schemas, _), .any(of: let schemas, _):
@@ -295,8 +295,10 @@ extension FileTranslator {
                     case .null, .not: return nil
                     case .boolean, .number, .integer: candidateSource = .infer(.primitive)
                     case .string(_, let context): candidateSource = try inferStringContent(context)
-                    case .object(_, _), .all, .one, .any, .fragment, .array(_, _): candidateSource = .infer(.complex)
-                    default: candidateSource = .infer(.complex)
+                    case .object, .all, .one, .any, .fragment, .array: candidateSource = .infer(.complex)
+                    case .reference(let ref, _):
+                        guard let source = try inferSchema(components.lookup(ref))?.1 else { return nil }
+                        candidateSource = source
                     }
                 } else {
                     candidateSource = .infer(.complex)

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -4230,6 +4230,209 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testRequestMultipartBodyReferencedSchemaRecursive() throws {
+        try self.assertRequestInTypesClientServerTranslation(
+            """
+            /foo:
+              post:
+                requestBody:
+                  required: true
+                  content:
+                    multipart/form-data:
+                      schema:
+                        $ref: '#/components/schemas/Node'
+                responses:
+                  default:
+                    description: Response
+            """,
+            """
+            schemas:
+              Node:
+                type: object
+                properties:
+                  log: 
+                    type: string
+                  parent:
+                    $ref: '#/components/schemas/Node'
+                required:
+                  - log
+            """,
+            input: """
+                public struct Input: Sendable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
+                        case multipartForm(OpenAPIRuntime.MultipartBody<Components.Schemas.Node>)
+                    }
+                    public var body: Operations.post_sol_foo.Input.Body
+                    public init(body: Operations.post_sol_foo.Input.Body) {
+                        self.body = body
+                    }
+                }
+                """,
+            schemas: """
+                public enum Schemas {
+                    @frozen public enum Node: Sendable, Hashable {
+                        public struct logPayload: Sendable, Hashable {
+                            public var body: OpenAPIRuntime.HTTPBody
+                            public init(body: OpenAPIRuntime.HTTPBody) {
+                                self.body = body
+                            }
+                        }
+                        case log(OpenAPIRuntime.MultipartPart<Components.Schemas.Node.logPayload>)
+                        public struct parentPayload: Sendable, Hashable {
+                            public var body: Components.Schemas.Node
+                            public init(body: Components.Schemas.Node) {
+                                self.body = body
+                            }
+                        }
+                        case parent(OpenAPIRuntime.MultipartPart<Components.Schemas.Node.parentPayload>)
+                        case undocumented(OpenAPIRuntime.MultipartRawPart)
+                    }
+                }
+                """,
+            client: """
+                { input in
+                    let path = try converter.renderedPath(
+                        template: "/foo",
+                        parameters: []
+                    )
+                    var request: HTTPTypes.HTTPRequest = .init(
+                        soar_path: path,
+                        method: .post
+                    )
+                    suppressMutabilityWarning(&request)
+                    let body: OpenAPIRuntime.HTTPBody?
+                    switch input.body {
+                    case let .multipartForm(value):
+                        body = try converter.setRequiredRequestBodyAsMultipart(
+                            value,
+                            headerFields: &request.headerFields,
+                            contentType: "multipart/form-data",
+                            allowsUnknownParts: true,
+                            requiredExactlyOncePartNames: [
+                                "log"
+                            ],
+                            requiredAtLeastOncePartNames: [],
+                            atMostOncePartNames: [
+                                "parent"
+                            ],
+                            zeroOrMoreTimesPartNames: [],
+                            encoding: { part in
+                                switch part {
+                                case let .log(wrapped):
+                                    var headerFields: HTTPTypes.HTTPFields = .init()
+                                    let value = wrapped.payload
+                                    let body = try converter.setRequiredRequestBodyAsBinary(
+                                        value.body,
+                                        headerFields: &headerFields,
+                                        contentType: "text/plain"
+                                    )
+                                    return .init(
+                                        name: "log",
+                                        filename: wrapped.filename,
+                                        headerFields: headerFields,
+                                        body: body
+                                    )
+                                case let .parent(wrapped):
+                                    var headerFields: HTTPTypes.HTTPFields = .init()
+                                    let value = wrapped.payload
+                                    let body = try converter.setRequiredRequestBodyAsJSON(
+                                        value.body,
+                                        headerFields: &headerFields,
+                                        contentType: "application/json; charset=utf-8"
+                                    )
+                                    return .init(
+                                        name: "parent",
+                                        filename: wrapped.filename,
+                                        headerFields: headerFields,
+                                        body: body
+                                    )
+                                case let .undocumented(value):
+                                    return value
+                                }
+                            }
+                        )
+                    }
+                    return (request, body)
+                }
+                """,
+            server: """
+                { request, requestBody, metadata in
+                    let contentType = converter.extractContentTypeIfPresent(in: request.headerFields)
+                    let body: Operations.post_sol_foo.Input.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "multipart/form-data"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "multipart/form-data":
+                        body = try converter.getRequiredRequestBodyAsMultipart(
+                            OpenAPIRuntime.MultipartBody<Components.Schemas.Node>.self,
+                            from: requestBody,
+                            transforming: { value in
+                                .multipartForm(value)
+                            },
+                            boundary: contentType.requiredBoundary(),
+                            allowsUnknownParts: true,
+                            requiredExactlyOncePartNames: [
+                                "log"
+                            ],
+                            requiredAtLeastOncePartNames: [],
+                            atMostOncePartNames: [
+                                "parent"
+                            ],
+                            zeroOrMoreTimesPartNames: [],
+                            decoding: { part in
+                                let headerFields = part.headerFields
+                                let (name, filename) = try converter.extractContentDispositionNameAndFilename(in: headerFields)
+                                switch name {
+                                case "log":
+                                    try converter.verifyContentTypeIfPresent(
+                                        in: headerFields,
+                                        matches: "text/plain"
+                                    )
+                                    let body = try converter.getRequiredRequestBodyAsBinary(
+                                        OpenAPIRuntime.HTTPBody.self,
+                                        from: part.body,
+                                        transforming: {
+                                            $0
+                                        }
+                                    )
+                                    return .log(.init(
+                                        payload: .init(body: body),
+                                        filename: filename
+                                    ))
+                                case "parent":
+                                    try converter.verifyContentTypeIfPresent(
+                                        in: headerFields,
+                                        matches: "application/json"
+                                    )
+                                    let body = try await converter.getRequiredRequestBodyAsJSON(
+                                        Components.Schemas.Node.self,
+                                        from: part.body,
+                                        transforming: {
+                                            $0
+                                        }
+                                    )
+                                    return .parent(.init(
+                                        payload: .init(body: body),
+                                        filename: filename
+                                    ))
+                                default:
+                                    return .undocumented(part)
+                                }
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return Operations.post_sol_foo.Input(body: body)
+                }
+                """
+        )
+    }
+
     func testRequestMultipartBodyReferencedSchemaWithEncoding() throws {
         try self.assertRequestInTypesClientServerTranslation(
             """


### PR DESCRIPTION
### Motivation

Fixes #769
Currently, as seen in the issue mentioned above, if a recursive schema gets referenced from a multipart-based path, a reference cycle error gets thrown. Since we support recursive type generation already, this shouldn't happen.

### Modifications

This PR removes the last `dereferenced(in:)` method call, which would throw if a reference cycle was found, replacing it with a simple lookup in the OpenAPI components tree. It also replaces `DerereferencedJSONSchema` with `JSONSchema` accordingly. 

### Result

Multipart-based paths can now reference recursive types.

### Test Plan

This also adds a test with such a case. We could probably also add a test with a multipart path referencing an _array_ of references instead of just a reference to be thorough.