### PR TITLE
Fix PR CI - formatting

### DIFF
--- a/Examples/type-overrides-example/Sources/TypeOverrides/CustomPrimeNumber.swift
+++ b/Examples/type-overrides-example/Sources/TypeOverrides/CustomPrimeNumber.swift
@@ -14,14 +14,14 @@
 
 /// Example struct to be used instead of the default generated type.
 /// This illustrates how to introduce a type performing additional validation during Decoding that cannot be expressed with OpenAPI
-public struct CustomPrimeNumber: Codable, Hashable, RawRepresentable, Sendable {
-    public let rawValue: Int
-    public init?(rawValue: Int) {
+struct CustomPrimeNumber: Codable, Hashable, RawRepresentable, Sendable {
+    let rawValue: Int
+    init?(rawValue: Int) {
         if !rawValue.isPrime { return nil }
         self.rawValue = rawValue
     }
 
-    public init(from decoder: any Decoder) throws {
+    init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let number = try container.decode(Int.self)
         guard let value = Self(rawValue: number) else {
@@ -30,7 +30,7 @@ public struct CustomPrimeNumber: Codable, Hashable, RawRepresentable, Sendable {
         self = value
     }
 
-    public func encode(to encoder: any Encoder) throws {
+    func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(self.rawValue)
     }

--- a/Sources/PetstoreConsumerTestCore/Common.swift
+++ b/Sources/PetstoreConsumerTestCore/Common.swift
@@ -15,6 +15,7 @@ import OpenAPIRuntime
 import Foundation
 import HTTPTypes
 
+/// An error used by Petstore tests.
 public enum TestError: Swift.Error, LocalizedError, CustomStringConvertible, Sendable {
     case noHandlerFound(method: HTTPRequest.Method, path: String)
     case invalidURLString(String)


### PR DESCRIPTION
At some point recently (I only noticed it in https://github.com/apple/swift-openapi-generator/actions/runs/17734822822/job/50426205189?pr=816) we started getting failures in PR CI due to formatting issues in a test and in example projects.

This PR fixes them up.