### PR TITLE
Update OpenAPIKit dependency to 4.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,8 +45,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.4"),
 
         // Read OpenAPI documents
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "3.3.0"),
-        .package(url: "https://github.com/jpsim/Yams", "4.0.0"..<"7.0.0"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "4.0.0"),
+        .package(url: "https://github.com/jpsim/Yams", from: "5.1.0"),
 
         // CLI Tool
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),


### PR DESCRIPTION
## Summary
- Updates OpenAPIKit dependency from 3.3.0 to 4.0.0
- Updates Yams minimum version to 5.1.0 as required by OpenAPIKit v4
- Existing codebase is already compatible with OpenAPIKit v4 breaking changes

## Changes Made
- **Package.swift**: Updated OpenAPIKit dependency from `from: "3.3.0"` to `from: "4.0.0"`
- **Package.swift**: Updated Yams dependency from `"4.0.0"..<"7.0.0"` to `from: "5.1.0"`

## Compatibility Analysis
The codebase analysis shows existing code is already compatible with OpenAPIKit v4:

✅ **Error Types**: Already using `GenericError` (not the renamed `InconsistencyError`)
✅ **OpenAPI Versions**: Already supports v3.0.4 and v3.1.1 version cases
✅ **Content Types**: Already using `contentTypes` (plural) property where applicable  
✅ **AnyCodable**: Usage patterns are compatible with v4 requirements
✅ **Swift Version**: Meets Swift 5.8+ requirement

## Test Plan
- [ ] CI pipeline should validate compilation with new dependencies
- [ ] Existing tests should continue passing without modification
- [ ] Package resolution should succeed with OpenAPIKit 4.x and Yams 5.1+

This addresses the dependency update requested in issue #821, following the migration guide provided by the OpenAPIKit maintainer.

Fixes #821