### PR TITLE
Drop Swift 5.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
+      linux_5_10_enabled: false
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -43,6 +44,7 @@ jobs:
           MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator/.git && git config --global --add safe.directory /swift-openapi-generator
           MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${workspace} ./scripts/run-integration-test.sh
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+          MATRIX_LINUX_5_10_ENABLED: false
 
   integration-test:
     name: Integration test
@@ -68,6 +70,7 @@ jobs:
           MATRIX_LINUX_SETUP_COMMAND: git config --global --add safe.directory /swift-openapi-generator
           MATRIX_LINUX_COMMAND: ./scripts/test-examples.sh
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+          MATRIX_LINUX_5_10_ENABLED: false
 
   example-packages:
     name: Example packages
@@ -92,6 +95,7 @@ jobs:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
     with:
+      linux_5_10_enabled: false
       windows_6_0_enabled: true
       windows_6_1_enabled: true
       windows_6_2_enabled: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,7 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
+      linux_5_10_enabled: false
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
@@ -68,6 +69,7 @@ jobs:
           MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq jq && git config --global --add safe.directory /swift-openapi-generator/.git && git config --global --add safe.directory /swift-openapi-generator
           MATRIX_LINUX_COMMAND: SWIFT_OPENAPI_GENERATOR_REPO_URL=file://${workspace} ./scripts/run-integration-test.sh
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+          MATRIX_LINUX_5_10_ENABLED: false
 
   integration-test:
     name: Integration test
@@ -93,6 +95,7 @@ jobs:
           MATRIX_LINUX_SETUP_COMMAND: git config --global --add safe.directory /swift-openapi-generator
           MATRIX_LINUX_COMMAND: ./scripts/test-examples.sh
           MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+          MATRIX_LINUX_5_10_ENABLED: false
 
   example-packages:
     name: Example packages
@@ -101,7 +104,6 @@ jobs:
     with:
       name: "Example packages"
       matrix_string: '${{ needs.construct-example-packages-matrix.outputs.example-packages-matrix }}'
-
 
   macos-tests:
     name: macOS tests
@@ -118,6 +120,7 @@ jobs:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
     with:
+      linux_5_10_enabled: false
       windows_6_0_enabled: true
       windows_6_1_enabled: true
       windows_6_2_enabled: true

--- a/Examples/auth-client-middleware-example/Package.swift
+++ b/Examples/auth-client-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/auth-server-middleware-example/Package.swift
+++ b/Examples/auth-server-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/bidirectional-event-streams-client-example/Package.swift
+++ b/Examples/bidirectional-event-streams-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/bidirectional-event-streams-server-example/Package.swift
+++ b/Examples/bidirectional-event-streams-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/bidirectional-event-streams-server-example/Package.swift
+++ b/Examples/bidirectional-event-streams-server-example/Package.swift
@@ -16,7 +16,7 @@ import PackageDescription
 
 let package = Package(
     name: "bidirectional-event-streams-server-example",
-    platforms: [.macOS(.v14)],
+    platforms: [.macOS(.v15)],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.7.0"),

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/BidirectionalEventStreamsServer.swift
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/BidirectionalEventStreamsServer.swift
@@ -21,7 +21,7 @@ struct Handler: APIProtocol {
     func getGreetingsStream(_ input: Operations.GetGreetingsStream.Input) async throws
         -> Operations.GetGreetingsStream.Output
     {
-        let eventStream = await self.storage.makeStream(input: input)
+        let eventStream = self.storage.makeStream(input: input)
         /// To keep it simple, using JSON Lines, as it most straightforward and easy way to have streams.
         /// For SSE and JSON Sequences cases please check `event-streams-server-example`.
         let responseBody = Operations.GetGreetingsStream.Output.Ok.Body.applicationJsonl(

--- a/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
+++ b/Examples/bidirectional-event-streams-server-example/Sources/BidirectionalEventStreamsServer/GreetingStream.swift
@@ -13,35 +13,46 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 
-actor StreamStorage: Sendable {
+final class StreamStorage: Sendable {
     private typealias StreamType = AsyncStream<Components.Schemas.Greeting>
-    private var streams: [String: Task<Void, any Error>] = [:]
-    init() {}
+    private let streams: Mutex<[String: Task<Void, any Error>]>
+    init() { self.streams = .init([:]) }
     private func finishedStream(id: String) {
-        guard self.streams[id] != nil else { return }
-        self.streams.removeValue(forKey: id)
+        self.streams.withLock { streams in
+            guard streams[id] != nil else { return }
+            streams.removeValue(forKey: id)
+        }
     }
     private func cancelStream(id: String) {
-        guard let task = self.streams[id] else { return }
-        self.streams.removeValue(forKey: id)
+        let task: Task<Void, any Error>? = self.streams.withLock { streams in
+            guard let task = streams[id] else { return nil }
+            streams.removeValue(forKey: id)
+            return task
+        }
+        guard let task else { return }
         task.cancel()
         print("Canceled stream \(id)")
     }
+
+    private func handleTermination(
+        _ termination: AsyncStream<Components.Schemas.Greeting>.Continuation.Termination,
+        id: String
+    ) {
+        switch termination {
+        case .cancelled: self.cancelStream(id: id)
+        case .finished: self.finishedStream(id: id)
+        @unknown default: self.finishedStream(id: id)
+        }
+    }
+
     func makeStream(input: Operations.GetGreetingsStream.Input) -> AsyncStream<Components.Schemas.Greeting> {
         let name = input.query.name ?? "Stranger"
         let id = UUID().uuidString
         print("Creating stream \(id) for name: \(name)")
         let (stream, continuation) = StreamType.makeStream()
-        continuation.onTermination = { termination in
-            Task { [weak self] in
-                switch termination {
-                case .cancelled: await self?.cancelStream(id: id)
-                case .finished: await self?.finishedStream(id: id)
-                @unknown default: await self?.finishedStream(id: id)
-                }
-            }
-        }
+        continuation.onTermination = { termination in self.handleTermination(termination, id: id) }
         let inputStream =
             switch input.body {
             case .applicationJsonl(let body): body.asDecodedJSONLines(of: Components.Schemas.Greeting.self)
@@ -56,7 +67,7 @@ actor StreamStorage: Sendable {
             }
             continuation.finish()
         }
-        self.streams[id] = task
+        self.streams.withLock { streams in streams[id] = task }
         return stream
     }
 }

--- a/Examples/command-line-client-example/Package.swift
+++ b/Examples/command-line-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/command-line-client-example/Sources/CommandLineClient/CommandLineClient.swift
+++ b/Examples/command-line-client-example/Sources/CommandLineClient/CommandLineClient.swift
@@ -17,7 +17,7 @@ import Foundation
 import ArgumentParser
 
 @main struct CommandLineClient: AsyncParsableCommand {
-    static var configuration: CommandConfiguration = .init(
+    static let configuration: CommandConfiguration = .init(
         commandName: "CommandLineClient",
         subcommands: [GreetCommand.self]
     )
@@ -25,7 +25,7 @@ import ArgumentParser
 
 struct GreetCommand: AsyncParsableCommand {
 
-    static var configuration: CommandConfiguration = .init(commandName: "greet")
+    static let configuration: CommandConfiguration = .init(commandName: "greet")
 
     @Option var name: String
 

--- a/Examples/curated-client-library-example/Package.swift
+++ b/Examples/curated-client-library-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/event-streams-client-example/Package.swift
+++ b/Examples/event-streams-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/event-streams-server-example/Package.swift
+++ b/Examples/event-streams-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/hello-world-async-http-client-example/Package.swift
+++ b/Examples/hello-world-async-http-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/hello-world-hummingbird-server-example/Package.swift
+++ b/Examples/hello-world-hummingbird-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/hello-world-urlsession-client-example/Package.swift
+++ b/Examples/hello-world-urlsession-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/hello-world-vapor-server-example/Package.swift
+++ b/Examples/hello-world-vapor-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/logging-middleware-oslog-example/Package.swift
+++ b/Examples/logging-middleware-oslog-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/logging-middleware-oslog-example/Sources/LoggingMiddleware/LoggingMiddleware.swift
+++ b/Examples/logging-middleware-oslog-example/Sources/LoggingMiddleware/LoggingMiddleware.swift
@@ -59,7 +59,8 @@ extension LoggingMiddleware: ServerMiddleware {
         body: OpenAPIRuntime.HTTPBody?,
         metadata: OpenAPIRuntime.ServerRequestMetadata,
         operationID: String,
-        next: @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata)
+        next:
+            @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata)
             async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
     ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         let (requestBodyToLog, requestBodyForNext) = try await bodyLoggingPolicy.process(body)

--- a/Examples/logging-middleware-swift-log-example/Package.swift
+++ b/Examples/logging-middleware-swift-log-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/logging-middleware-swift-log-example/Sources/LoggingMiddleware/LoggingMiddleware.swift
+++ b/Examples/logging-middleware-swift-log-example/Sources/LoggingMiddleware/LoggingMiddleware.swift
@@ -56,7 +56,8 @@ extension LoggingMiddleware: ServerMiddleware {
         body: OpenAPIRuntime.HTTPBody?,
         metadata: OpenAPIRuntime.ServerRequestMetadata,
         operationID: String,
-        next: @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata)
+        next:
+            @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata)
             async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
     ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?) {
         let (requestBodyToLog, requestBodyForNext) = try await bodyLoggingPolicy.process(body)

--- a/Examples/manual-generation-generator-cli-example/Package.swift
+++ b/Examples/manual-generation-generator-cli-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/manual-generation-package-plugin-example/Package.swift
+++ b/Examples/manual-generation-package-plugin-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/metrics-middleware-example/Package.swift
+++ b/Examples/metrics-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/postgres-database-example/Package.swift
+++ b/Examples/postgres-database-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/retrying-middleware-example/Package.swift
+++ b/Examples/retrying-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/shared-types-client-server-example/Package.swift
+++ b/Examples/shared-types-client-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/streaming-chatgpt-proxy/Package.swift
+++ b/Examples/streaming-chatgpt-proxy/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(

--- a/Examples/streaming-chatgpt-proxy/Sources/ClientCLI/main.swift
+++ b/Examples/streaming-chatgpt-proxy/Sources/ClientCLI/main.swift
@@ -11,6 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+// https://github.com/swiftlang/swift/issues/77866
+#if canImport(Glibc)
+@preconcurrency import Glibc
+#endif
 import OpenAPIRuntime
 import OpenAPIURLSession
 import Foundation

--- a/Examples/swagger-ui-endpoint-example/Package.swift
+++ b/Examples/swagger-ui-endpoint-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/tracing-middleware-example/Package.swift
+++ b/Examples/tracing-middleware-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/type-overrides-example/Package.swift
+++ b/Examples/type-overrides-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/various-content-types-client-example/Package.swift
+++ b/Examples/various-content-types-client-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Examples/various-content-types-server-example/Package.swift
+++ b/Examples/various-content-types-server-example/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/IntegrationTest/Package.swift
+++ b/IntegrationTest/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/IntegrationTest/Sources/MockTransportServer/Server.swift
+++ b/IntegrationTest/Sources/MockTransportServer/Server.swift
@@ -24,9 +24,9 @@ actor SimpleAPIImpl: APIProtocol {
 }
 
 class MockServerTransport: ServerTransport {
-    typealias Handler = @Sendable (
-        HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata
-    ) async throws -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
+    typealias Handler =
+        @Sendable (HTTPTypes.HTTPRequest, OpenAPIRuntime.HTTPBody?, OpenAPIRuntime.ServerRequestMetadata) async throws
+        -> (HTTPTypes.HTTPResponse, OpenAPIRuntime.HTTPBody?)
 
     func register(_ handler: @escaping Handler, method: HTTPTypes.HTTPRequest.Method, path: String) throws {
         // noop.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,9 @@ var swiftSettings: [SwiftSetting] = [
     // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
     // Require `any` for existential types.
     .enableUpcomingFeature("ExistentialAny"), .enableExperimentalFeature("StrictConcurrency=complete"),
+
+    // Use Swift 5 language mode until Swift 6.1 tools are the minimum version.
+    .swiftLanguageMode(.v5),
 ]
 
 let package = Package(

--- a/Plugins/PluginsShared/PluginError.swift
+++ b/Plugins/PluginsShared/PluginError.swift
@@ -58,7 +58,7 @@ enum PluginError: Swift.Error, Equatable, CustomStringConvertible, LocalizedErro
 struct FileError: Swift.Error, Equatable, CustomStringConvertible, LocalizedError {
 
     /// The kind of the file.
-    enum Kind: Equatable, CaseIterable {
+    enum Kind: Equatable, CaseIterable, Sendable {
         /// Config file.
         case config
         /// OpenAPI document file.
@@ -73,7 +73,7 @@ struct FileError: Swift.Error, Equatable, CustomStringConvertible, LocalizedErro
     }
 
     /// Encountered issue.
-    enum Issue: Equatable {
+    enum Issue: Equatable, Sendable {
         /// File wasn't found.
         case noFilesFound
         /// More than 1 file found.

--- a/Plugins/PluginsShared/PluginError.swift
+++ b/Plugins/PluginsShared/PluginError.swift
@@ -77,7 +77,7 @@ struct FileError: Swift.Error, Equatable, CustomStringConvertible, LocalizedErro
         /// File wasn't found.
         case noFilesFound
         /// More than 1 file found.
-        case multipleFilesFound(files: [Path])
+        case multipleFilesFound(files: [String])
 
         /// The error is definitely due to misconfiguration of a target.
         var isMisconfigurationError: Bool {
@@ -101,7 +101,7 @@ struct FileError: Swift.Error, Equatable, CustomStringConvertible, LocalizedErro
                     "No config file found in the target named '\(targetName)'. Add a file called 'openapi-generator-config.yaml' or 'openapi-generator-config.yml' to the target's source directory. See documentation for details."
             case .multipleFilesFound(let files):
                 return
-                    "Multiple config files found in the target named '\(targetName)', but exactly one is expected. Found \(files.map(\.description).joined(separator: " "))."
+                    "Multiple config files found in the target named '\(targetName)', but exactly one is expected. Found \(files.joined(separator: " "))."
             }
         case .document:
             switch issue {

--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -71,7 +71,7 @@ enum PluginUtils {
         }
         guard matchedConfigs.count == 1 else {
             return .failure(
-                FileError(targetName: targetName, fileKind: .config, issue: .multipleFilesFound(files: matchedConfigs))
+                FileError(targetName: targetName, fileKind: .config, issue: .multipleFilesFound(files: matchedConfigs.map(\.description)))
             )
         }
         return .success(matchedConfigs[0])
@@ -85,7 +85,7 @@ enum PluginUtils {
         }
         guard matchedDocs.count == 1 else {
             return .failure(
-                FileError(targetName: targetName, fileKind: .document, issue: .multipleFilesFound(files: matchedDocs))
+                FileError(targetName: targetName, fileKind: .document, issue: .multipleFilesFound(files: matchedDocs.map(\.description)))
             )
         }
         return .success(matchedDocs[0])

--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -71,7 +71,11 @@ enum PluginUtils {
         }
         guard matchedConfigs.count == 1 else {
             return .failure(
-                FileError(targetName: targetName, fileKind: .config, issue: .multipleFilesFound(files: matchedConfigs.map(\.description)))
+                FileError(
+                    targetName: targetName,
+                    fileKind: .config,
+                    issue: .multipleFilesFound(files: matchedConfigs.map(\.description))
+                )
             )
         }
         return .success(matchedConfigs[0])
@@ -85,7 +89,11 @@ enum PluginUtils {
         }
         guard matchedDocs.count == 1 else {
             return .failure(
-                FileError(targetName: targetName, fileKind: .document, issue: .multipleFilesFound(files: matchedDocs.map(\.description)))
+                FileError(
+                    targetName: targetName,
+                    fileKind: .document,
+                    issue: .multipleFilesFound(files: matchedDocs.map(\.description))
+                )
             )
         }
         return .success(matchedDocs[0])

--- a/Sources/PetstoreConsumerTestCore/TestClientTransport.swift
+++ b/Sources/PetstoreConsumerTestCore/TestClientTransport.swift
@@ -33,9 +33,8 @@ import HTTPTypes
 public struct TestClientTransport: ClientTransport {
 
     /// A typealias representing a call handler closure for processing client requests.
-    public typealias CallHandler = @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (
-        HTTPResponse, HTTPBody?
-    )
+    public typealias CallHandler =
+        @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
 
     /// The call handler responsible for processing client requests.
     public let callHandler: CallHandler

--- a/Sources/PetstoreConsumerTestCore/TestServerTransport.swift
+++ b/Sources/PetstoreConsumerTestCore/TestServerTransport.swift
@@ -50,9 +50,8 @@ public final class TestServerTransport: ServerTransport {
     }
 
     /// A typealias representing a handler closure for processing server requests.
-    public typealias Handler = @Sendable (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (
-        HTTPResponse, HTTPBody?
-    )
+    public typealias Handler =
+        @Sendable (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (HTTPResponse, HTTPBody?)
 
     /// Represents an operation with its inputs and associated handler.
     public struct Operation {
@@ -86,9 +85,10 @@ public final class TestServerTransport: ServerTransport {
     ///   - path: The path components of the operation.
     /// - Throws: An error if there's an issue registering the operation.
     public func register(
-        _ handler: @Sendable @escaping (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (
-            HTTPResponse, HTTPBody?
-        ),
+        _ handler:
+            @Sendable @escaping (HTTPRequest, HTTPBody?, ServerRequestMetadata) async throws -> (
+                HTTPResponse, HTTPBody?
+            ),
         method: HTTPRequest.Method,
         path: String
     ) throws { registered.append(Operation(inputs: .init(method: method, path: path), closure: handler)) }

--- a/Tests/PetstoreConsumerTests/TestClient.swift
+++ b/Tests/PetstoreConsumerTests/TestClient.swift
@@ -29,8 +29,8 @@ struct TestClient: APIProtocol {
         return try await block(input)
     }
 
-    typealias CreatePetWithFormSignature = @Sendable (Operations.CreatePetWithForm.Input) async throws ->
-        Operations.CreatePetWithForm.Output
+    typealias CreatePetWithFormSignature =
+        @Sendable (Operations.CreatePetWithForm.Input) async throws -> Operations.CreatePetWithForm.Output
     var createPetWithFormBlock: CreatePetWithFormSignature?
     func createPetWithForm(_ input: Operations.CreatePetWithForm.Input) async throws
         -> Operations.CreatePetWithForm.Output
@@ -67,8 +67,8 @@ struct TestClient: APIProtocol {
         return try await block(input)
     }
 
-    typealias UploadAvatarForPetSignature = @Sendable (Operations.UploadAvatarForPet.Input) async throws ->
-        Operations.UploadAvatarForPet.Output
+    typealias UploadAvatarForPetSignature =
+        @Sendable (Operations.UploadAvatarForPet.Input) async throws -> Operations.UploadAvatarForPet.Output
     var uploadAvatarForPetBlock: UploadAvatarForPetSignature?
     func uploadAvatarForPet(_ input: Operations.UploadAvatarForPet.Input) async throws
         -> Operations.UploadAvatarForPet.Output
@@ -76,8 +76,8 @@ struct TestClient: APIProtocol {
         guard let block = uploadAvatarForPetBlock else { throw UnspecifiedBlockError() }
         return try await block(input)
     }
-    typealias MultipartDownloadTypedSignature = @Sendable (Operations.MultipartDownloadTyped.Input) async throws ->
-        Operations.MultipartDownloadTyped.Output
+    typealias MultipartDownloadTypedSignature =
+        @Sendable (Operations.MultipartDownloadTyped.Input) async throws -> Operations.MultipartDownloadTyped.Output
     var multipartDownloadTypedBlock: MultipartDownloadTypedSignature?
     func multipartDownloadTyped(_ input: Operations.MultipartDownloadTyped.Input) async throws
         -> Operations.MultipartDownloadTyped.Output
@@ -85,8 +85,8 @@ struct TestClient: APIProtocol {
         guard let block = multipartDownloadTypedBlock else { throw UnspecifiedBlockError() }
         return try await block(input)
     }
-    typealias MultipartUploadTypedSignature = @Sendable (Operations.MultipartUploadTyped.Input) async throws ->
-        Operations.MultipartUploadTyped.Output
+    typealias MultipartUploadTypedSignature =
+        @Sendable (Operations.MultipartUploadTyped.Input) async throws -> Operations.MultipartUploadTyped.Output
     var multipartUploadTypedBlock: MultipartUploadTypedSignature?
     func multipartUploadTyped(_ input: Operations.MultipartUploadTyped.Input) async throws
         -> Operations.MultipartUploadTyped.Output


### PR DESCRIPTION
Motivation:

Swift 5.10 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.0
* Remove Swift 5.10 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
