### PR TITLE
Update to use OpenAPIKit 4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.4"),
 
         // Read OpenAPI documents
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "3.9.0"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "4.0.0"),
         .package(url: "https://github.com/jpsim/Yams", "4.0.0"..<"7.0.0"),
 
         // CLI Tool

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_YamsParser.swift
@@ -126,7 +126,7 @@ final class Test_YamsParser: Test_Core {
             /foo.yaml: error: Found neither a $ref nor a PathItem in Document.paths['/system']. 
 
             PathItem could not be decoded because:
-            Inconsistency encountered when parsing `Vendor Extension` for the **GET** endpoint under `/system`: Found at least one vendor extension property that does not begin with the required 'x-' prefix. Invalid properties: [ resonance ]..
+            Problem encountered when parsing `Vendor Extension` for the **GET** endpoint under `/system`: Found at least one vendor extension property that does not begin with the required 'x-' prefix. Invalid properties: [ resonance ]..
             """
         assertThrownError(try _test(yaml), expectedDiagnostic: expected)
     }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypeAssignment/Test_TypeMatcher.swift
@@ -245,7 +245,7 @@ final class Test_TypeMatcher: Test_Core {
     static let multipartElementTypeReferenceIfReferenceableTypes:
         [(UnresolvedSchema?, OrderedDictionary<String, OpenAPI.Content.Encoding>?, String?)] = [
             (nil, nil, nil), (.b(.string), nil, nil), (.a(.component(named: "Foo")), nil, "Foo"),
-            (.a(.component(named: "Foo")), ["foo": .init(contentType: .json)], nil),
+            (.a(.component(named: "Foo")), ["foo": .init(contentTypes: [.json])], nil),
         ]
     func testMultipartElementTypeReferenceIfReferenceableTypes() throws {
         for (schema, encoding, name) in Self.multipartElementTypeReferenceIfReferenceableTypes {

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
@@ -35,11 +35,10 @@ class Test_translateSchemas: Test_Core {
             (
                 schemaWithWarnings,
                 [
-                    "warning: Schema warning: Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: string. Specifically, attributes for these other types: [\"array\"]. [context: codingPath=, contextString=, subjectName=OpenAPI Schema]"
+                    "warning: Schema warning: Problem encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: string. Specifically, attributes for these other types: [\"array\"]. [context: codingPath=, contextString=, subjectName=OpenAPI Schema]"
                 ]
             ),
         ]
-
         for (schema, diagnosticDescriptions) in cases {
             let collector = AccumulatingDiagnosticCollector()
             let translator = makeTranslator(diagnostics: collector)


### PR DESCRIPTION
### Motivation

While trying to generate types for DocC, which has [multiple OpenAPI spec files](https://github.com/swiftlang/swift-docc/tree/main/Sources/SwiftDocC/SwiftDocC.docc/Resources), I ran across #25, which then led to #821, after which a holiday nerd-snipe echoed in my head "How hard could this be?

### Modifications

- updated dependency to OpenAPIKit 4.0
- Updated tests that use slightly new phrasing ("Problem" instead of "Inconsistency")
 

### Result

- (WIP) there's still a unit test that isn't passing, but I need to do more research to understand what's intended to happen here and how that delta is impacted by OpenAPIKit 4.x

### Test Plan

- unit tests
- seeing what CI shows here
