### PR TITLE
Server: special-case */* responses (skip Accept validation, don’t emit Content-Type: */*)

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseOutcome.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseOutcome.swift
@@ -402,54 +402,46 @@ extension ServerFileTranslator {
                 var caseCodeBlocks: [CodeBlock] = []
 
                 let contentType = typedContent.content.contentType
-                let isWildcardAnyContentType = contentType.lowercasedTypeAndSubtype == "*/*"
+                let contentTypeForServer = contentType.lowercasedTypeAndSubtype == "*/*"
+                    ? ContentType.applicationOctetStream
+                    : contentType
 
-                if !isWildcardAnyContentType {
-                    let contentTypeHeaderValue = contentType.headerValueForValidation
-                    let validateAcceptHeader: Expression = .try(
-                        .identifierPattern("converter").dot("validateAcceptIfPresent")
-                            .call([
-                                .init(label: nil, expression: .literal(contentTypeHeaderValue)),
-                                .init(label: "in", expression: .identifierPattern("request").dot("headerFields")),
-                            ])
-                    )
-                    caseCodeBlocks.append(.expression(validateAcceptHeader))
-                }
+                let contentTypeHeaderValue = contentTypeForServer.headerValueForValidation
+                let validateAcceptHeader: Expression = .try(
+                    .identifierPattern("converter").dot("validateAcceptIfPresent")
+                        .call([
+                            .init(label: nil, expression: .literal(contentTypeHeaderValue)),
+                            .init(label: "in", expression: .identifierPattern("request").dot("headerFields")),
+                        ])
+                )
+                caseCodeBlocks.append(.expression(validateAcceptHeader))
 
-                let assignBodyExpr: Expression
-                if isWildcardAnyContentType {
-                    assignBodyExpr = .assignment(
-                        left: .identifierPattern("body"),
-                        right: .identifierPattern("value")
-                    )
+                let extraBodyAssignArgs: [FunctionArgumentDescription]
+                if contentTypeForServer.isMultipart {
+                    extraBodyAssignArgs = try translateMultipartSerializerExtraArgumentsInServer(typedContent)
                 } else {
-                    let extraBodyAssignArgs: [FunctionArgumentDescription]
-                    if contentType.isMultipart {
-                        extraBodyAssignArgs = try translateMultipartSerializerExtraArgumentsInServer(typedContent)
-                    } else {
-                        extraBodyAssignArgs = []
-                    }
-                    assignBodyExpr = .assignment(
-                        left: .identifierPattern("body"),
-                        right: .try(
-                            .identifierPattern("converter")
-                                .dot("setResponseBodyAs\(contentType.codingStrategy.runtimeName)")
-                                .call(
-                                    [
-                                        .init(label: nil, expression: .identifierPattern("value")),
-                                        .init(
-                                            label: "headerFields",
-                                            expression: .inOut(.identifierPattern("response").dot("headerFields"))
-                                        ),
-                                        .init(
-                                            label: "contentType",
-                                            expression: .literal(contentType.headerValueForSending)
-                                        ),
-                                    ] + extraBodyAssignArgs
-                                )
-                        )
-                    )
+                    extraBodyAssignArgs = []
                 }
+                let assignBodyExpr: Expression = .assignment(
+                    left: .identifierPattern("body"),
+                    right: .try(
+                        .identifierPattern("converter")
+                            .dot("setResponseBodyAs\(contentTypeForServer.codingStrategy.runtimeName)")
+                            .call(
+                                [
+                                    .init(label: nil, expression: .identifierPattern("value")),
+                                    .init(
+                                        label: "headerFields",
+                                        expression: .inOut(.identifierPattern("response").dot("headerFields"))
+                                    ),
+                                    .init(
+                                        label: "contentType",
+                                        expression: .literal(contentTypeForServer.headerValueForSending)
+                                    ),
+                                ] + extraBodyAssignArgs
+                            )
+                    )
+                )
                 caseCodeBlocks.append(.expression(assignBodyExpr))
 
                 return .init(

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -3605,7 +3605,7 @@ final class SnippetBasedReferenceTests: XCTestCase {
     }
 
 
-    func testResponseWildcardContentTypeDoesNotValidateAcceptOrEmitWildcardContentType() throws {
+    func testResponseWildcardContentTypeUsesApplicationOctetStreamInServer() throws {
         try self.assertResponseInTypesClientServerTranslation(
             """
             /download:
@@ -3666,7 +3666,15 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         let body: OpenAPIRuntime.HTTPBody
                         switch value.body {
                         case let .any(value):
-                            body = value
+                            try converter.validateAcceptIfPresent(
+                                "application/octet-stream",
+                                in: request.headerFields
+                            )
+                            body = try converter.setResponseBodyAsBinary(
+                                value,
+                                headerFields: &response.headerFields,
+                                contentType: "application/octet-stream"
+                            )
                         }
                         return (response, body)
                     case let .undocumented(statusCode, _):


### PR DESCRIPTION
### Motivation

When an OpenAPI response uses `content: {'*/*': ...}` to indicate an intentionally unconstrained/dynamic media type, the generated server serializer currently:

- calls `converter.validateAcceptIfPresent("*/*", in: request.headerFields)`, which effectively forces clients to include `Accept: */*`, and
- emits `Content-Type: */*` (via `setResponseBodyAsBinary(..., contentType: "*/*")`).

Both behaviors are problematic in practice.

This PR is a safe first step: it fixes the immediate incorrect strictness and avoids emitting an invalid/meaningless response `Content-Type`, while keeping the generated public API unchanged.

Related: #859 (kept open; follow-up can explore a richer, potentially source-breaking solution to plumb dynamic `Content-Type`).

### Modifications

- In server response serialization, special-case response content type exactly `*/*` to:
  - skip `validateAcceptIfPresent`, and
  - assign the `HTTPBody` directly without setting `Content-Type: */*`.
- Add a snippet-based regression test verifying the generated server code for a `*/*` response does not contain `validateAcceptIfPresent("*/*")` and does not contain `contentType: "*/*"`.

### Result

Generated servers no longer reject requests that omit `Accept: */*` for wildcard responses, and no longer emit `Content-Type: */*`.

### Test Plan

- `swift test`
