### PR TITLE
Server: model */* response body as UndocumentedPayload

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
+++ b/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
@@ -28,6 +28,12 @@
 public enum FeatureFlag: String, Hashable, Codable, CaseIterable, Sendable {
     // needs to be here for the enum to compile
     case empty
+
+    /// Represent wildcard response bodies as content-typed payloads.
+    ///
+    /// Generates response bodies for `*/*` as `OpenAPIContentTypedBody`
+    /// instead of plain `HTTPBody`.
+    case concreteWildcardResponseBodies
 }
 
 /// A set of enabled feature flags.

--- a/Sources/_OpenAPIGeneratorCore/Translator/FileTranslator+FeatureFlags.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/FileTranslator+FeatureFlags.swift
@@ -14,5 +14,8 @@
 import OpenAPIKit
 
 extension FileTranslator {
-    // Add helpers for reading feature flags below.
+    /// Whether wildcard response bodies should use content-typed payloads.
+    var hasConcreteWildcardResponseBodies: Bool {
+        config.featureFlags.contains(.concreteWildcardResponseBodies)
+    }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponse.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponse.swift
@@ -143,8 +143,8 @@ extension TypesFileTranslator {
         let contentType = typedContent.content.contentType
         let identifier = context.safeNameGenerator.swiftContentTypeName(for: contentType)
         let associatedType: TypeUsage
-        if contentType.lowercasedTypeAndSubtype == "*/*" {
-            associatedType = TypeName.undocumentedPayload.asUsage
+        if contentType.lowercasedTypeAndSubtype == "*/*" && hasConcreteWildcardResponseBodies {
+            associatedType = TypeName.contentTypedBody.asUsage
         } else {
             associatedType = typedContent.resolvedTypeUsage
         }

--- a/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseOutcome.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Responses/translateResponseOutcome.swift
@@ -242,8 +242,91 @@ extension ClientFileTranslator {
                 let codingStrategy = contentType.codingStrategy
 
                 let caseName = context.safeNameGenerator.swiftContentTypeName(for: contentType)
+                let usesConcreteWildcardResponseBodies = contentType.lowercasedTypeAndSubtype == "*/*"
+                    && hasConcreteWildcardResponseBodies
+
+                var caseCodeBlocks: [CodeBlock] = []
                 let transformExpr: Expression
-                if contentType.lowercasedTypeAndSubtype == "*/*" {
+
+                if usesConcreteWildcardResponseBodies {
+                    let concreteContentTypeDecl: Declaration = .variable(
+                        kind: .let,
+                        left: "concreteContentType",
+                        type: .init(TypeName.concreteMIMEType)
+                    )
+                    caseCodeBlocks.append(.declaration(concreteContentTypeDecl))
+
+                    let defaultContentTypeExpr: Expression = .try(
+                        .dot("init")
+                            .call([
+                                .init(label: "type", expression: .literal("application")),
+                                .init(label: "subtype", expression: .literal("octet-stream")),
+                            ])
+                    )
+                    let parsedContentTypeSwitchExpr: Expression = .switch(
+                        switchedExpression: .identifierPattern("contentType"),
+                        cases: [
+                            .init(
+                                kind: .case(.dot("some"), ["contentTypeValue"]),
+                                body: [
+                                    .expression(
+                                        .switch(
+                                            switchedExpression: .identifierPattern("contentTypeValue").dot("kind"),
+                                            cases: [
+                                                .init(
+                                                    kind: .case(.dot("concrete"), ["type", "subtype"]),
+                                                    body: [
+                                                        .expression(
+                                                            .assignment(
+                                                                left: .identifierPattern("concreteContentType"),
+                                                                right: .try(
+                                                                    .dot("init")
+                                                                        .call([
+                                                                            .init(
+                                                                                label: "type",
+                                                                                expression: .identifierPattern("type")
+                                                                            ),
+                                                                            .init(
+                                                                                label: "subtype",
+                                                                                expression: .identifierPattern("subtype")
+                                                                            ),
+                                                                        ])
+                                                                )
+                                                            )
+                                                        )
+                                                    ]
+                                                ),
+                                                .init(
+                                                    kind: .default,
+                                                    body: [
+                                                        .expression(
+                                                            .assignment(
+                                                                left: .identifierPattern("concreteContentType"),
+                                                                right: defaultContentTypeExpr
+                                                            )
+                                                        )
+                                                    ]
+                                                ),
+                                            ]
+                                        )
+                                    )
+                                ]
+                            ),
+                            .init(
+                                kind: .default,
+                                body: [
+                                    .expression(
+                                        .assignment(
+                                            left: .identifierPattern("concreteContentType"),
+                                            right: defaultContentTypeExpr
+                                        )
+                                    )
+                                ]
+                            ),
+                        ]
+                    )
+                    caseCodeBlocks.append(.expression(parsedContentTypeSwitchExpr))
+
                     transformExpr = .closureInvocation(
                         argumentNames: ["value"],
                         body: [
@@ -255,8 +338,8 @@ extension ClientFileTranslator {
                                             expression: .dot("init")
                                                 .call([
                                                     .init(
-                                                        label: "headerFields",
-                                                        expression: .identifierPattern("response").dot("headerFields")
+                                                        label: "contentType",
+                                                        expression: .identifierPattern("concreteContentType")
                                                     ),
                                                     .init(label: "body", expression: .identifierPattern("value")),
                                                 ])
@@ -302,9 +385,10 @@ extension ClientFileTranslator {
                     bodyExpr = .try(converterExpr)
                 }
                 let bodyAssignExpr: Expression = .assignment(left: .identifierPattern("body"), right: bodyExpr)
+                caseCodeBlocks.append(.expression(bodyAssignExpr))
                 return .init(
                     kind: .case(.literal(typedContent.content.contentType.headerValueForValidation)),
-                    body: [.expression(bodyAssignExpr)]
+                    body: caseCodeBlocks
                 )
             }
             let cases = try typedContents.map(makeCase)
@@ -431,45 +515,46 @@ extension ServerFileTranslator {
 
                 let contentType = typedContent.content.contentType
                 let isWildcardAnyContentType = contentType.lowercasedTypeAndSubtype == "*/*"
+                let usesConcreteWildcardResponseBodies = isWildcardAnyContentType
+                    && hasConcreteWildcardResponseBodies
 
-                if isWildcardAnyContentType {
-                    caseCodeBlocks.append(
-                        .expression(
-                            .identifierPattern("response").dot("headerFields").dot("append")
+                if usesConcreteWildcardResponseBodies {
+                    let validateAcceptHeader: Expression = .try(
+                        .identifierPattern("converter").dot("validateAcceptIfPresent")
+                            .call([
+                                .init(
+                                    label: nil,
+                                    expression: .identifierPattern("value").dot("contentType").dot("headerValue")
+                                ),
+                                .init(label: "in", expression: .identifierPattern("request").dot("headerFields")),
+                            ])
+                    )
+                    caseCodeBlocks.append(.expression(validateAcceptHeader))
+
+                    let assignBodyExpr: Expression = .assignment(
+                        left: .identifierPattern("body"),
+                        right: .try(
+                            .identifierPattern("converter").dot("setResponseBodyAsBinary")
                                 .call([
+                                    .init(label: nil, expression: .identifierPattern("value").dot("body")),
                                     .init(
-                                        label: "contentsOf",
-                                        expression: .identifierPattern("value").dot("headerFields")
-                                    )
+                                        label: "headerFields",
+                                        expression: .inOut(.identifierPattern("response").dot("headerFields"))
+                                    ),
+                                    .init(
+                                        label: "contentType",
+                                        expression: .identifierPattern("value").dot("contentType").dot("headerValue")
+                                    ),
                                 ])
                         )
                     )
-                    caseCodeBlocks.append(
-                        .expression(
-                            .assignment(
-                                left: .identifierPattern("body"),
-                                right: .try(
-                                    .identifierPattern("converter").dot("getResponseBodyAsBinary")
-                                        .call([
-                                            .init(
-                                                label: nil,
-                                                expression: .identifierType(TypeName.body.asUsage).dot("self")
-                                            ),
-                                            .init(label: "from", expression: .identifierPattern("value").dot("body")),
-                                            .init(
-                                                label: "transforming",
-                                                expression: .closureInvocation(
-                                                    argumentNames: ["value"],
-                                                    body: [.expression(.identifierPattern("value"))]
-                                                )
-                                            ),
-                                        ])
-                                )
-                            )
-                        )
-                    )
+                    caseCodeBlocks.append(.expression(assignBodyExpr))
                 } else {
-                    let contentTypeHeaderValue = contentType.headerValueForValidation
+                    let contentTypeForServer = isWildcardAnyContentType
+                        ? ContentType.applicationOctetStream
+                        : contentType
+
+                    let contentTypeHeaderValue = contentTypeForServer.headerValueForValidation
                     let validateAcceptHeader: Expression = .try(
                         .identifierPattern("converter").dot("validateAcceptIfPresent")
                             .call([
@@ -480,7 +565,7 @@ extension ServerFileTranslator {
                     caseCodeBlocks.append(.expression(validateAcceptHeader))
 
                     let extraBodyAssignArgs: [FunctionArgumentDescription]
-                    if contentType.isMultipart {
+                    if contentTypeForServer.isMultipart {
                         extraBodyAssignArgs = try translateMultipartSerializerExtraArgumentsInServer(typedContent)
                     } else {
                         extraBodyAssignArgs = []
@@ -489,7 +574,7 @@ extension ServerFileTranslator {
                         left: .identifierPattern("body"),
                         right: .try(
                             .identifierPattern("converter")
-                                .dot("setResponseBodyAs\(contentType.codingStrategy.runtimeName)")
+                                .dot("setResponseBodyAs\(contentTypeForServer.codingStrategy.runtimeName)")
                                 .call(
                                     [
                                         .init(label: nil, expression: .identifierPattern("value")),
@@ -499,7 +584,7 @@ extension ServerFileTranslator {
                                         ),
                                         .init(
                                             label: "contentType",
-                                            expression: .literal(contentType.headerValueForSending)
+                                            expression: .literal(contentTypeForServer.headerValueForSending)
                                         ),
                                     ] + extraBodyAssignArgs
                                 )

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/Builtins.swift
@@ -58,6 +58,12 @@ extension TypeName {
         .runtime(Constants.Operation.Output.undocumentedCaseAssociatedValueTypeName)
     }
 
+    /// Returns the type name for the concrete MIME type.
+    static var concreteMIMEType: Self { .runtime("OpenAPIConcreteMIMEType") }
+
+    /// Returns the type name for the content-typed body payload.
+    static var contentTypedBody: Self { .runtime("OpenAPIContentTypedBody") }
+
     /// Returns the type name of generic JSON payload.
     static var valueContainer: TypeName { .runtime("OpenAPIValueContainer") }
 

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -3624,8 +3624,8 @@ final class SnippetBasedReferenceTests: XCTestCase {
                 @frozen public enum Output: Sendable, Hashable {
                     public struct Ok: Sendable, Hashable {
                         @frozen public enum Body: Sendable, Hashable {
-                            case any(OpenAPIRuntime.UndocumentedPayload)
-                            public var any: OpenAPIRuntime.UndocumentedPayload {
+                            case any(OpenAPIRuntime.HTTPBody)
+                            public var any: OpenAPIRuntime.HTTPBody {
                                 get throws {
                                     switch self {
                                     case let .any(body):
@@ -3666,13 +3666,14 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         let body: OpenAPIRuntime.HTTPBody
                         switch value.body {
                         case let .any(value):
-                            response.headerFields.append(contentsOf: value.headerFields)
-                            body = try converter.getResponseBodyAsBinary(
-                                OpenAPIRuntime.HTTPBody.self,
-                                from: value.body,
-                                transforming: { value in
-                                    value
-                                }
+                            try converter.validateAcceptIfPresent(
+                                "application/octet-stream",
+                                in: request.headerFields
+                            )
+                            body = try converter.setResponseBodyAsBinary(
+                                value,
+                                headerFields: &response.headerFields,
+                                contentType: "application/octet-stream"
                             )
                         }
                         return (response, body)
@@ -3699,8 +3700,146 @@ final class SnippetBasedReferenceTests: XCTestCase {
                                 OpenAPIRuntime.HTTPBody.self,
                                 from: responseBody,
                                 transforming: { value in
+                                    .any(value)
+                                }
+                            )
+                        default:
+                            preconditionFailure("bestContentType chose an invalid content type.")
+                        }
+                        return .ok(.init(body: body))
+                    default:
+                        return .undocumented(
+                            statusCode: response.status.code,
+                            .init(
+                                headerFields: response.headerFields,
+                                body: responseBody
+                            )
+                        )
+                    }
+                }
+                """
+        )
+    }
+
+    func testResponseWildcardContentTypeUsesContentTypedBodyWhenFeatureEnabled() throws {
+        try self.assertResponseInTypesClientServerTranslation(
+            """
+            /download:
+              get:
+                operationId: download
+                responses:
+                  '200':
+                    description: ok
+                    content:
+                      '*/*':
+                        schema:
+                          type: string
+                          format: binary
+            """,
+            featureFlags: [.concreteWildcardResponseBodies],
+            output: """
+                @frozen public enum Output: Sendable, Hashable {
+                    public struct Ok: Sendable, Hashable {
+                        @frozen public enum Body: Sendable, Hashable {
+                            case any(OpenAPIRuntime.OpenAPIContentTypedBody)
+                            public var any: OpenAPIRuntime.OpenAPIContentTypedBody {
+                                get throws {
+                                    switch self {
+                                    case let .any(body):
+                                        return body
+                                    }
+                                }
+                            }
+                        }
+                        public var body: Operations.download.Output.Ok.Body
+                        public init(body: Operations.download.Output.Ok.Body) {
+                            self.body = body
+                        }
+                    }
+                    case ok(Operations.download.Output.Ok)
+                    public var ok: Operations.download.Output.Ok {
+                        get throws {
+                            switch self {
+                            case let .ok(response):
+                                return response
+                            default:
+                                try throwUnexpectedResponseStatus(
+                                    expectedStatus: "ok",
+                                    response: self
+                                )
+                            }
+                        }
+                    }
+                    case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+                }
+                """,
+            server: """
+                { output, request in
+                    switch output {
+                    case let .ok(value):
+                        suppressUnusedWarning(value)
+                        var response = HTTPTypes.HTTPResponse(soar_statusCode: 200)
+                        suppressMutabilityWarning(&response)
+                        let body: OpenAPIRuntime.HTTPBody
+                        switch value.body {
+                        case let .any(value):
+                            try converter.validateAcceptIfPresent(
+                                value.contentType.headerValue,
+                                in: request.headerFields
+                            )
+                            body = try converter.setResponseBodyAsBinary(
+                                value.body,
+                                headerFields: &response.headerFields,
+                                contentType: value.contentType.headerValue
+                            )
+                        }
+                        return (response, body)
+                    case let .undocumented(statusCode, _):
+                        return (.init(soar_statusCode: statusCode), nil)
+                    }
+                }
+                """,
+            client: """
+                { response, responseBody in
+                    switch response.status.code {
+                    case 200:
+                        let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                        let body: Operations.download.Output.Ok.Body
+                        let chosenContentType = try converter.bestContentType(
+                            received: contentType,
+                            options: [
+                                "*/*"
+                            ]
+                        )
+                        switch chosenContentType {
+                        case "*/*":
+                            let concreteContentType: OpenAPIRuntime.OpenAPIConcreteMIMEType
+                            switch contentType {
+                            case let .some(contentTypeValue):
+                                switch contentTypeValue.kind {
+                                case let .concrete(type, subtype):
+                                    concreteContentType = try .init(
+                                        type: type,
+                                        subtype: subtype
+                                    )
+                                default:
+                                    concreteContentType = try .init(
+                                        type: "application",
+                                        subtype: "octet-stream"
+                                    )
+                                }
+                            default:
+                                concreteContentType = try .init(
+                                    type: "application",
+                                    subtype: "octet-stream"
+                                )
+                            }
+                            body = try converter.getResponseBodyAsBinary(
+                                OpenAPIRuntime.HTTPBody.self,
+                                from: responseBody,
+                                transforming: { value in
                                     .any(.init(
-                                        headerFields: response.headerFields,
+                                        contentType: concreteContentType,
                                         body: value
                                     ))
                                 }
@@ -6518,6 +6657,7 @@ extension SnippetBasedReferenceTests {
     func assertResponseInTypesClientServerTranslation(
         _ pathsYAML: String,
         _ componentsYAML: String? = nil,
+        featureFlags: FeatureFlags = [],
         output expectedOutputSwift: String,
         schemas expectedSchemasSwift: String? = nil,
         responses expectedResponsesSwift: String? = nil,
@@ -6531,7 +6671,7 @@ extension SnippetBasedReferenceTests {
             try componentsYAML.flatMap { componentsYAML in
                 try YAMLDecoder().decode(OpenAPI.Components.self, from: componentsYAML)
             } ?? OpenAPI.Components.noComponents
-        let (types, client, server) = try makeTranslators(components: components)
+        let (types, client, server) = try makeTranslators(components: components, featureFlags: featureFlags)
         let paths = try YAMLDecoder().decode(OpenAPI.PathItem.Map.self, from: pathsYAML)
         let document = OpenAPI.Document(
             openAPIVersion: .v3_1_0,


### PR DESCRIPTION
### Motivation

Follow-up to #860.

`responses.content['*/*']` is often used to represent a dynamic/unconstrained payload where the server chooses the actual response `Content-Type` at runtime.

PR #860 fixes the immediate incorrect behavior by skipping `Accept` validation and not emitting `Content-Type: */*`.

This PR takes the next step by allowing the handler to provide dynamic response headers (especially `Content-Type`) for the `*/*` case by modeling the `any` body as `OpenAPIRuntime.UndocumentedPayload` (which carries `headerFields` + `body`). This is source-breaking for generated APIs that used `any(HTTPBody)`.

Related: #859 (kept open; this improves dynamic header plumbing but there may still be follow-up design discussion).

### Modifications

- Generate the `*/*` response body case as `case any(OpenAPIRuntime.UndocumentedPayload)`.
- Update generated server serializer for the `*/*` case to:
  - skip `validateAcceptIfPresent`,
  - append `value.headerFields` onto the response headers, and
  - require `value.body` (throws `RuntimeError.missingRequiredResponseBody` if absent).
- Update generated client deserializer for the `*/*` case to wrap the received `HTTPBody` and `response.headerFields` into `UndocumentedPayload`.
- Update the snippet-based regression test accordingly.

### Result

Generated servers can return `*/*` responses with a real, runtime-chosen `Content-Type` (and other headers) without middleware hacks, while still avoiding `Accept` validation and avoiding `Content-Type: */*`.

### Test Plan

- `swift test`
