### PR TITLE
Drop Swift 5.10 and stop using deprecated PackagePlugin.Path

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project
@@ -20,6 +20,7 @@ var swiftSettings: [SwiftSetting] = [
     // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
     // Require `any` for existential types.
     .enableUpcomingFeature("ExistentialAny"), .enableExperimentalFeature("StrictConcurrency=complete"),
+    .swiftLanguageMode(.v5),
 ]
 
 let package = Package(

--- a/Plugins/OpenAPIGenerator/plugin.swift
+++ b/Plugins/OpenAPIGenerator/plugin.swift
@@ -16,7 +16,7 @@ import Foundation
 
 @main struct SwiftOpenAPIGeneratorPlugin {
     func createBuildCommands(
-        pluginWorkDirectory: Path,
+        pluginWorkDirectory: URL,
         tool: (String) throws -> PluginContext.Tool,
         sourceFiles: FileList,
         targetName: String
@@ -29,11 +29,11 @@ import Foundation
             pluginSource: .build
         )
 
-        let outputFiles: [Path] = GeneratorMode.allCases.map { inputs.genSourcesDir.appending($0.outputFileName) }
+        let outputFiles = GeneratorMode.allCases.map { inputs.genSourcesDir.appending(component: $0.outputFileName) }
         return [
             .buildCommand(
                 displayName: "Running swift-openapi-generator",
-                executable: inputs.tool.path,
+                executable: inputs.tool.url,
                 arguments: inputs.arguments,
                 environment: [:],
                 inputFiles: [inputs.config, inputs.doc],
@@ -49,7 +49,7 @@ extension SwiftOpenAPIGeneratorPlugin: BuildToolPlugin {
             throw PluginError.incompatibleTarget(name: target.name)
         }
         return try createBuildCommands(
-            pluginWorkDirectory: context.pluginWorkDirectory,
+            pluginWorkDirectory: context.pluginWorkDirectoryURL,
             tool: context.tool,
             sourceFiles: swiftTarget.sourceFiles,
             targetName: target.name
@@ -63,7 +63,7 @@ import XcodeProjectPlugin
 extension SwiftOpenAPIGeneratorPlugin: XcodeBuildToolPlugin {
     func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
         try createBuildCommands(
-            pluginWorkDirectory: context.pluginWorkDirectory,
+            pluginWorkDirectory: context.pluginWorkDirectoryURL,
             tool: context.tool,
             sourceFiles: target.inputFiles,
             targetName: target.displayName

--- a/Plugins/OpenAPIGeneratorCommand/plugin.swift
+++ b/Plugins/OpenAPIGeneratorCommand/plugin.swift
@@ -65,7 +65,7 @@ extension SwiftOpenAPIGeneratorPlugin: CommandPlugin {
 
         for target in targets {
             log("Considering target '\(target.name)':")
-            guard let swiftTarget = target as? SwiftSourceModuleTarget else {
+            guard let target = target as? SwiftSourceModuleTarget else {
                 log("- Not a swift source module. Can't generate OpenAPI code.")
                 continue
             }
@@ -74,7 +74,7 @@ extension SwiftOpenAPIGeneratorPlugin: CommandPlugin {
                 try runCommand(
                     targetWorkingDirectory: target.directoryURL,
                     tool: context.tool,
-                    sourceFiles: swiftTarget.sourceFiles,
+                    sourceFiles: target.sourceFiles,
                     targetName: target.name
                 )
                 log("- ✅ OpenAPI code generation for target '\(target.name)' successfully completed.")

--- a/Plugins/OpenAPIGeneratorCommand/plugin.swift
+++ b/Plugins/OpenAPIGeneratorCommand/plugin.swift
@@ -16,7 +16,7 @@ import Foundation
 
 @main struct SwiftOpenAPIGeneratorPlugin {
     func runCommand(
-        targetWorkingDirectory: Path,
+        targetWorkingDirectory: URL,
         tool: (String) throws -> PluginContext.Tool,
         sourceFiles: FileList,
         targetName: String
@@ -29,9 +29,8 @@ import Foundation
             pluginSource: .command
         )
 
-        let toolUrl = URL(fileURLWithPath: inputs.tool.path.string)
         let process = Process()
-        process.executableURL = toolUrl
+        process.executableURL = inputs.tool.url
         process.arguments = inputs.arguments
         process.environment = [:]
         try process.run()
@@ -73,7 +72,7 @@ extension SwiftOpenAPIGeneratorPlugin: CommandPlugin {
             do {
                 log("- Trying OpenAPI code generation.")
                 try runCommand(
-                    targetWorkingDirectory: target.directory,
+                    targetWorkingDirectory: target.directoryURL,
                     tool: context.tool,
                     sourceFiles: swiftTarget.sourceFiles,
                     targetName: target.name

--- a/Plugins/PluginsShared/PluginError.swift
+++ b/Plugins/PluginsShared/PluginError.swift
@@ -77,9 +77,7 @@ struct FileError: Swift.Error, Equatable, CustomStringConvertible, LocalizedErro
         /// File wasn't found.
         case noFilesFound
         /// More than 1 file found.
-        case multipleFilesFound(files: [String])
-
-        static func multipleFilesFound(files: [Path]) -> Self { .multipleFilesFound(files: files.map(\.description)) }
+        case multipleFilesFound(files: [URL])
 
         /// The error is definitely due to misconfiguration of a target.
         var isMisconfigurationError: Bool {

--- a/Plugins/PluginsShared/PluginError.swift
+++ b/Plugins/PluginsShared/PluginError.swift
@@ -100,7 +100,8 @@ struct FileError: Swift.Error, Equatable, CustomStringConvertible, LocalizedErro
                 return
                     "No config file found in the target named '\(targetName)'. Add a file called 'openapi-generator-config.yaml' or 'openapi-generator-config.yml' to the target's source directory. See documentation for details."
             case .multipleFilesFound(let files):
-                return "Multiple config files found in the target named '\(targetName)', but exactly one is expected. Found \(files.map { $0.path() }.joined(separator: " "))."
+                return
+                    "Multiple config files found in the target named '\(targetName)', but exactly one is expected. Found \(files.map { $0.path() }.joined(separator: " "))."
             }
         case .document:
             switch issue {
@@ -108,7 +109,8 @@ struct FileError: Swift.Error, Equatable, CustomStringConvertible, LocalizedErro
                 return
                     "No OpenAPI document found in the target named '\(targetName)'. Add a file called 'openapi.yaml', 'openapi.yml' or 'openapi.json' (can also be a symlink) to the target's source directory. See documentation for details."
             case .multipleFilesFound(let files):
-                return "Multiple OpenAPI documents found in the target named '\(targetName)', but exactly one is expected. Found \(files.map { $0.path() }.joined(separator: " "))."
+                return
+                    "Multiple OpenAPI documents found in the target named '\(targetName)', but exactly one is expected. Found \(files.map { $0.path() }.joined(separator: " "))."
             }
         }
     }

--- a/Plugins/PluginsShared/PluginError.swift
+++ b/Plugins/PluginsShared/PluginError.swift
@@ -100,8 +100,7 @@ struct FileError: Swift.Error, Equatable, CustomStringConvertible, LocalizedErro
                 return
                     "No config file found in the target named '\(targetName)'. Add a file called 'openapi-generator-config.yaml' or 'openapi-generator-config.yml' to the target's source directory. See documentation for details."
             case .multipleFilesFound(let files):
-                return
-                    "Multiple config files found in the target named '\(targetName)', but exactly one is expected. Found \(files.map(\.description).joined(separator: " "))."
+                return "Multiple config files found in the target named '\(targetName)', but exactly one is expected. Found \(files.map { $0.path() }.joined(separator: " "))."
             }
         case .document:
             switch issue {
@@ -109,8 +108,7 @@ struct FileError: Swift.Error, Equatable, CustomStringConvertible, LocalizedErro
                 return
                     "No OpenAPI document found in the target named '\(targetName)'. Add a file called 'openapi.yaml', 'openapi.yml' or 'openapi.json' (can also be a symlink) to the target's source directory. See documentation for details."
             case .multipleFilesFound(let files):
-                return
-                    "Multiple OpenAPI documents found in the target named '\(targetName)', but exactly one is expected. Found \(files.map(\.description).joined(separator: " "))."
+                return "Multiple OpenAPI documents found in the target named '\(targetName)', but exactly one is expected. Found \(files.map { $0.path() }.joined(separator: " "))."
             }
         }
     }

--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -12,6 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import PackagePlugin
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.URL
+#else
+import struct Foundation.URL
+#endif
 
 enum PluginUtils {
     private static var supportedConfigFiles: Set<String> {
@@ -21,23 +26,23 @@ enum PluginUtils {
 
     /// Validated values to run a plugin with.
     struct ValidatedInputs {
-        let doc: Path
-        let config: Path
-        let genSourcesDir: Path
+        let doc: URL
+        let config: URL
+        let genSourcesDir: URL
         let arguments: [String]
         let tool: PluginContext.Tool
     }
 
     /// Validates the inputs and returns the necessary values to run a plugin.
     static func validateInputs(
-        workingDirectory: Path,
+        workingDirectory: URL,
         tool: (String) throws -> PluginContext.Tool,
         sourceFiles: FileList,
         targetName: String,
         pluginSource: PluginSource
     ) throws -> ValidatedInputs {
         let (config, doc) = try findFiles(inputFiles: sourceFiles, targetName: targetName)
-        let genSourcesDir = workingDirectory.appending("GeneratedSources")
+        let genSourcesDir = workingDirectory.appending(component: "GeneratedSources")
 
         let arguments = [
             "generate", "\(doc)", "--config", "\(config)", "--output-directory", "\(genSourcesDir)", "--plugin-source",
@@ -51,7 +56,7 @@ enum PluginUtils {
 
     /// Finds the OpenAPI config and document files or throws an error including both possible
     /// previous errors from the process of finding the config and document files.
-    private static func findFiles(inputFiles: FileList, targetName: String) throws -> (config: Path, doc: Path) {
+    private static func findFiles(inputFiles: FileList, targetName: String) throws -> (config: URL, doc: URL) {
         let config = findConfig(inputFiles: inputFiles, targetName: targetName)
         let doc = findDocument(inputFiles: inputFiles, targetName: targetName)
         switch (config, doc) {
@@ -63,9 +68,8 @@ enum PluginUtils {
     }
 
     /// Find the config file.
-    private static func findConfig(inputFiles: FileList, targetName: String) -> Result<Path, FileError> {
-        let matchedConfigs = inputFiles.filter { supportedConfigFiles.contains($0.path.lastComponent_fixed) }
-            .map(\.path)
+    private static func findConfig(inputFiles: FileList, targetName: String) -> Result<URL, FileError> {
+        let matchedConfigs = inputFiles.map(\.url).filter { supportedConfigFiles.contains($0.lastPathComponent) }
         guard matchedConfigs.count > 0 else {
             return .failure(FileError(targetName: targetName, fileKind: .config, issue: .noFilesFound))
         }
@@ -78,8 +82,8 @@ enum PluginUtils {
     }
 
     /// Find the document file.
-    private static func findDocument(inputFiles: FileList, targetName: String) -> Result<Path, FileError> {
-        let matchedDocs = inputFiles.filter { supportedDocFiles.contains($0.path.lastComponent_fixed) }.map(\.path)
+    private static func findDocument(inputFiles: FileList, targetName: String) -> Result<URL, FileError> {
+        let matchedDocs = inputFiles.map(\.url).filter { supportedDocFiles.contains($0.lastPathComponent) }
         guard matchedDocs.count > 0 else {
             return .failure(FileError(targetName: targetName, fileKind: .document, issue: .noFilesFound))
         }
@@ -96,26 +100,5 @@ extension Array where Element == String {
     func joined(separator: String, lastSeparator: String) -> String {
         guard count > 1 else { return self.joined(separator: separator) }
         return "\(self.dropLast().joined(separator: separator))\(lastSeparator)\(self.last!)"
-    }
-}
-
-extension PackagePlugin.Path {
-    /// Workaround for the ``lastComponent`` property being broken on Windows
-    /// due to hardcoded assumptions about the path separator being forward slash.
-    @available(_PackageDescription, deprecated: 6.0, message: "Use `URL` type instead of `Path`.") public
-        var lastComponent_fixed: String
-    {
-        #if !os(Windows)
-        lastComponent
-        #else
-        // Find the last path separator.
-        guard let idx = string.lastIndex(where: { $0 == "/" || $0 == "\\" }) else {
-            // No path separators, so the basename is the whole string.
-            return self.string
-        }
-        // Otherwise, it's the string from (but not including) the last path
-        // separator.
-        return String(self.string.suffix(from: self.string.index(after: idx)))
-        #endif
     }
 }

--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -45,8 +45,8 @@ enum PluginUtils {
         let genSourcesDir = workingDirectory.appending(component: "GeneratedSources")
 
         let arguments = [
-            "generate", doc.path(), "--config", config.path(), "--output-directory", genSourcesDir.path(), "--plugin-source",
-            "\(pluginSource.rawValue)",
+            "generate", doc.path(), "--config", config.path(), "--output-directory", genSourcesDir.path(),
+            "--plugin-source", "\(pluginSource.rawValue)",
         ]
 
         let tool = try tool("swift-openapi-generator")

--- a/Plugins/PluginsShared/PluginUtils.swift
+++ b/Plugins/PluginsShared/PluginUtils.swift
@@ -45,7 +45,7 @@ enum PluginUtils {
         let genSourcesDir = workingDirectory.appending(component: "GeneratedSources")
 
         let arguments = [
-            "generate", "\(doc)", "--config", "\(config)", "--output-directory", "\(genSourcesDir)", "--plugin-source",
+            "generate", doc.path(), "--config", config.path(), "--output-directory", genSourcesDir.path(), "--plugin-source",
             "\(pluginSource.rawValue)",
         ]
 

--- a/Sources/swift-openapi-generator/GenerateOptions.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions.swift
@@ -73,11 +73,11 @@ func handleFileOperation<T>(at url: URL, fileDescription: String = "Configuratio
             let isCocoaFileNotFound = nsError.domain == NSCocoaErrorDomain && nsError.code == 260
             if isPOSIXFileNotFound || isCocoaFileNotFound {
                 throw ValidationError(
-                    "\(fileDescription) not found at path: \(url.path). Please ensure the file exists and the path is correct."
+                    "\(fileDescription) not found at path: \(url.path()). Please ensure the file exists and the path is correct."
                 )
             }
         }
-        throw ValidationError("Failed to load \(fileDescription.lowercased()) at path \(url.path), error: \(error)")
+        throw ValidationError("Failed to load \(fileDescription.lowercased()) at path \(url.path()), error: \(error)")
     }
 }
 
@@ -186,3 +186,9 @@ extension _GenerateOptions {
         return userConfig
     }
 }
+
+#if swift(<6.1)
+extension URL {
+    func path() -> String { self.path }
+}
+#endif

--- a/Sources/swift-openapi-generator/GenerateOptions.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions.swift
@@ -187,6 +187,12 @@ extension _GenerateOptions {
     }
 }
 
-#if swift(<6.1)
-extension URL { func path() -> String { self.path } }
-#endif
+extension URL {
+    func path() -> String {
+        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+            self.path(percentEncoded: false)
+        } else {
+            self.path
+        }
+    }
+}

--- a/Sources/swift-openapi-generator/GenerateOptions.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions.swift
@@ -188,7 +188,5 @@ extension _GenerateOptions {
 }
 
 #if swift(<6.1)
-extension URL {
-    func path() -> String { self.path }
-}
+extension URL { func path() -> String { self.path } }
 #endif


### PR DESCRIPTION
### Motivation

In #878 we split the manifest for this project so we could have the 6.1+ manifest declare a dependency on swift-openapi-runtime without default traits to support projects that want to avoid linking the full Foundation transitive dependency. 

The consequence of this is that the newer manifest lifted the `swift-tools-version`. There was an attempt to mitigate that by marking the Swift language version as v5 to decouple it from moving to 6. However, what this meant was we started getting warnings in the plugin code because plugin targets cannot have `swiftSettings` applied to them so they started complaining about the use of the deprecated `PackagePlugin.Path` APIs.

We previously could not move to URL, as requested by the deprecation warning, because we were still supporting Swift 5.10. But 5.10 dropped out of our support window 6 months ago. We haven't been CI'ing it, but we never lifted the tools version in the package manifest.

We can do that now, and then move to using `URL` in the plugin code, which should get rid of the warnings.

### Modifications

Bump the minimum version of Swift to 6.0. However, we still retain a split manifest because traits are only supported in 6.1+.

Then move to using URL instead of PackagePlugin.Path APIs.

### Result

Plugin should stop generating warnings for adopters on 6.1+.

### Test Plan

Integration tests still pass. Built locally and no longer see the warnings.

### Related

Expect this to fix #881 