### PR TITLE
Fix extended string delimiter selection in `renderLiteral`

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -446,9 +446,17 @@ struct TextBasedRenderer: RendererProtocol {
         func write(_ string: String) { writer.writeLine(string) }
         switch literal {
         case let .string(string):
-            // Use a raw literal if the string contains a quote/backslash.
+            // Use a raw literal if the string contains a quote or backslash.
+            // Pick the minimum number of `#` delimiters so that neither the
+            // closing delimiter (`"` + N×`#`) nor the escape prefix
+            // (`\` + N×`#`) appears in the string content.
             if string.contains("\"") || string.contains("\\") {
-                write("#\"\(string)\"#")
+                var hashCount = 1
+                while string.contains("\"" + String(repeating: "#", count: hashCount))
+                    || string.contains("\\" + String(repeating: "#", count: hashCount))
+                { hashCount += 1 }
+                let hashes = String(repeating: "#", count: hashCount)
+                write("\(hashes)\"\(string)\"\(hashes)")
             } else {
                 write("\"\(string)\"")
             }

--- a/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
@@ -197,6 +197,44 @@ final class Test_TextBasedRenderer: XCTestCase {
         )
     }
 
+    // MARK: - Extended string delimiter edge cases
+
+    func testStringLiteral_contentContainsQuoteHash() throws {
+        // When the string contains `"#`, a single-hash raw literal `#"..."#`
+        // would be terminated early. The renderer must use `##"..."##`.
+        try _test(
+            .string(##"foo"# + unexpected + #""##),
+            renderedBy: TextBasedRenderer.renderLiteral,
+            rendersAs: ##"""
+                ##"foo"# + unexpected + #""##
+                """##
+        )
+    }
+
+    func testStringLiteral_contentContainsBackslashHash() throws {
+        // When the string contains `\#(`, a single-hash raw literal would
+        // treat it as string interpolation. The renderer must use `##"..."##`.
+        try _test(
+            .string(##"hello\#(unexpected)world"##),
+            renderedBy: TextBasedRenderer.renderLiteral,
+            rendersAs: ##"""
+                ##"hello\#(unexpected)world"##
+                """##
+        )
+    }
+
+    func testStringLiteral_multipleHashesNeeded() throws {
+        // When the string contains both `"#` and `"##`, the renderer must
+        // use three hashes.
+        try _test(
+            .string(###"a"# b"## c"###),
+            renderedBy: TextBasedRenderer.renderLiteral,
+            rendersAs: ###"""
+                ###"a"# b"## c"###
+                """###
+        )
+    }
+
     func testExpression() throws {
         try _test(
             .literal(.nil),


### PR DESCRIPTION
Dynamically pick the minimum number of `#` delimiters so that neither the closing sequence nor the escape prefix appears in the content.

### Motivation

When the string content contains `"#` or `\#`, a single-hash raw literal (`#"..."#`) produces unexpected Swift code.

### Modifications

- Dynamically pick the minimum number of `#` delimiters so that neither the closing sequence nor the escape prefix appears in the content.
- Add test verifying correct handling of string delimiters.

### Result

No unexpected Swift code is generated.

### Test Plan

Unit tests.
