### PR TITLE
Update CI scripts to support dependency overrides where traits are used

### DIFF
--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -39,8 +39,20 @@ log "Extracting name for Swift package: ${PACKAGE_PATH}"
 PACKAGE_NAME=$(swift package --package-path "${PACKAGE_PATH}" describe --type json | "${JQ_BIN}" -r .name)
 
 log "Overriding dependency in ${INTEGRATION_TEST_PACKAGE_PATH} on ${PACKAGE_NAME} to use ${PACKAGE_PATH}"
-swift package --package-path "${INTEGRATION_TEST_PACKAGE_PATH}" \
-    edit "${PACKAGE_NAME}" --path "${PACKAGE_PATH}"
+cat >> "${INTEGRATION_TEST_PACKAGE_PATH}/Package.swift" << EOF
+// BEGIN: Local override for integration testing
+guard let dependencyToOverride = package.dependencies.firstIndex(where: { dependency in
+    switch dependency.kind {
+        case .sourceControl(_, let location, _) where location.hasSuffix("/${PACKAGE_NAME}"): true
+        case .registry("${PACKAGE_NAME}", _): true
+        case .fileSystem("${PACKAGE_NAME}", _): true
+        default: false
+    }
+}) else { fatalError("Failed to find dependency to override") }
+package.dependencies.remove(at: dependencyToOverride)
+package.dependencies.append(.package(name: "${PACKAGE_NAME}", path: "${PACKAGE_PATH}"))
+// END: Local override for integration testing
+EOF
 
 log "Building integration test package: ${INTEGRATION_TEST_PACKAGE_PATH}"
 swift build --package-path "${INTEGRATION_TEST_PACKAGE_PATH}"

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -51,26 +51,26 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
     log "Updating mtime of example contents..."
     find "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" -print0 | xargs -0 -n1 touch -m
 
-    log "Re-overriding dependency in ${EXAMPLE_PACKAGE_NAME} to use ${PACKAGE_PATH}"
-    "${SWIFT_BIN}" package \
-        --package-path "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" \
-        --cache-path "${SHARED_PACKAGE_CACHE_PATH}" \
-        --skip-update \
-        --scratch-path "${SHARED_PACKAGE_SCRATCH_PATH}" \
-        unedit swift-openapi-generator || :
-    "${SWIFT_BIN}" package \
-        --package-path "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" \
-        --cache-path "${SHARED_PACKAGE_CACHE_PATH}" \
-        --skip-update \
-        --scratch-path "${SHARED_PACKAGE_SCRATCH_PATH}" \
-        edit swift-openapi-generator \
-        --path "${PACKAGE_PATH}"
+    log "Overriding swift-openapi-generator dependency in ${EXAMPLE_PACKAGE_NAME} to use ${PACKAGE_PATH}"
+    cat >> "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}/Package.swift" << EOF
+// BEGIN: Local override for example package testing
+guard let dependencyToOverride = package.dependencies.firstIndex(where: { dependency in
+    switch dependency.kind {
+        case .sourceControl(_, let location, _) where location.hasSuffix("/swift-openapi-generator"): true
+        case .registry("swift-openapi-generator", _): true
+        case .fileSystem("swift-openapi-generator", _): true
+        default: false
+    }
+}) else { fatalError("Failed to find dependency to override") }
+package.dependencies.remove(at: dependencyToOverride)
+package.dependencies.append(.package(name: "swift-openapi-generator", path: "${PACKAGE_PATH}"))
+// END: Local override for example package testing
+EOF
 
     log "Building example package: ${EXAMPLE_PACKAGE_NAME}"
     "${SWIFT_BIN}" build --build-tests \
         --package-path "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" \
         --cache-path "${SHARED_PACKAGE_CACHE_PATH}" \
-        --skip-update \
         --scratch-path "${SHARED_PACKAGE_SCRATCH_PATH}"
     log "✅ Successfully built the example package ${EXAMPLE_PACKAGE_NAME}."
 
@@ -79,7 +79,6 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
         "${SWIFT_BIN}" test \
             --package-path "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" \
             --cache-path "${SHARED_PACKAGE_CACHE_PATH}" \
-            --skip-update \
             --scratch-path "${SHARED_PACKAGE_SCRATCH_PATH}"
         log "✅ Passed the tests for the example package ${EXAMPLE_PACKAGE_NAME}."
     fi

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -54,16 +54,17 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
     log "Overriding swift-openapi-generator dependency in ${EXAMPLE_PACKAGE_NAME} to use ${PACKAGE_PATH}"
     cat >> "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}/Package.swift" << EOF
 // BEGIN: Local override for example package testing
-guard let dependencyToOverride = package.dependencies.firstIndex(where: { dependency in
+if let dependencyToOverride = package.dependencies.firstIndex(where: { dependency in
     switch dependency.kind {
         case .sourceControl(_, let location, _) where location.hasSuffix("/swift-openapi-generator"): true
         case .registry("swift-openapi-generator", _): true
         case .fileSystem("swift-openapi-generator", _): true
         default: false
     }
-}) else { fatalError("Failed to find dependency to override") }
-package.dependencies.remove(at: dependencyToOverride)
-package.dependencies.append(.package(name: "swift-openapi-generator", path: "${PACKAGE_PATH}"))
+}) {
+    package.dependencies.remove(at: dependencyToOverride)
+    package.dependencies.append(.package(name: "swift-openapi-generator", path: "${PACKAGE_PATH}"))
+}
 // END: Local override for example package testing
 EOF
 


### PR DESCRIPTION
### Motivation

This project has CI for example projects and an integration test. These use a standalone package with a dependency on
`swift-openapi-generator`. The scripts driving this CI used `swift package edit` to override this dependency to the
checkout of the PR under test.

Unfortunately this does not work in the presence of package traits. In open PR #875 the OpenAPIKit dependency is being
bumped and is switched to disabling default traits. However, the CI is failing to perform the `swift package edit`
command. The root cause is that `swift package edit` performs dependency resolution in order to edit the dependency.
This resolves OpenAPIKit to a version satisfying the constraints on main -- a version of OpenAPIKit that has no traits.
After the override, the build fails because SwiftPM forbids disabling traits on a package that has no declared traits.
This is because OpenAPIKit is not re-resolved to the version declared in the local PR branch, even though it has been
bumped. After quite some investigation, it appears there's no way to influence this behaviour or to defer resolution
until after the dependency edit. This thesis aligns with the open SwiftPM issue tracking support for traits for `swift
package edit`[^1]

### Modifications

Workaround the lack of trait-aware `swift package edit` by updating the examples and integration test CI scripts to
instead inject an override block into the package manifest.

### Result

The scripts should now work as intended, even when the minimum version of a transitive dependency is bumped and/or when
transitive dependencies make use of package traits.

### Test Plan

Reproduced the original error in #875:

```console
% git rev-parse --symbolic-full-name HEAD
refs/heads/update-openapi-kit-to-v5

% SINGLE_EXAMPLE_PACKAGE=hello-world-urlsession-client-example ./scripts/test-examples.sh
...
error: Disabled default traits by package 'swift-openapi-generator' (swift-openapi-generator) on package 'openapikit' (OpenAPIKit) that declares no traits. This is prohibited to allow packages to adopt traits initially without causing an API break.
```

With this patch applied we can run the script fine on the PR branch:

```console
% git cherry-pick sb/fix-package-override-in-ci-scripts
[update-openapi-kit-to-v5 2544c13] Update CI scripts to support dependency overrides where traits are used
 Date: Tue May 5 14:55:35 2026 +0100
 2 files changed, 29 insertions(+), 18 deletions(-)

% SINGLE_EXAMPLE_PACKAGE=hello-world-urlsession-client-example ./scripts/test-examples.sh
...
** Overriding swift-openapi-generator dependency in hello-world-urlsession-client-example to use /Users/Si/work/code/swift-openapi-generator
** Building example package: hello-world-urlsession-client-example
...
Computing version for https://github.com/mattpolzin/OpenAPIKit
Computed https://github.com/mattpolzin/OpenAPIKit at 6.0.0 (14.10s)
...
Creating working copy for https://github.com/mattpolzin/OpenAPIKit
Working copy of https://github.com/mattpolzin/OpenAPIKit resolved at 6.0.0
...
Build complete! (44.22s)
** ✅ Successfully built the example package hello-world-urlsession-client-example.
```

[^1]: https://github.com/swiftlang/swift-package-manager/issues/8354
