### PR TITLE
Disable OpenAPIKit parameterStyleAndLocationAreCompatible validator

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Parser/validateDoc.swift
+++ b/Sources/_OpenAPIGeneratorCore/Parser/validateDoc.swift
@@ -303,7 +303,7 @@ func validateDoc(_ doc: ParsedOpenAPIRepresentation, config: Config) throws -> [
     // block the generator from running.
     // Validation errors continue to be fatal, such as
     // structural issues, like non-unique operationIds, etc.
-    let warnings = try doc.validate(using: Validator().validating(.operationsContainResponses), strict: false)
+    let warnings = try doc.validate(using: .swiftOpenAPICustomValidator, strict: false)
     let diagnostics: [Diagnostic] = warnings.map { warning in
         .warning(
             message: "Validation warning: \(warning.description)",
@@ -314,4 +314,28 @@ func validateDoc(_ doc: ParsedOpenAPIRepresentation, config: Config) throws -> [
         )
     }
     return typeOverrideDiagnostics + diagnostics
+}
+
+extension OpenAPIKit.Validator {
+    static var swiftOpenAPICustomValidator: Validator {
+        // Start with blank.
+        .blank
+            // Add defaults as of OpenAPIKit 6.0.0
+            // https://github.com/mattpolzin/OpenAPIKit/blob/118d039/Sources/OpenAPIKit/Validator/Validator.swift#L184-L186
+            .validating(.documentTagNamesAreUnique).validating(.documentServerNamesAreUnique)
+            .validating(.pathItemParametersAreUnique).validating(.operationParametersAreUnique)
+            .validating(.querystringParametersAreCompatible).validating(.operationIdsAreUnique)
+            .validating(.serverVariableEnumIsValid).validating(.serverVariableDefaultExistsInEnum)
+            // Without this one to be backwards compatible with previous versions of Swift OpenAPI Generator.
+            // Even when run with strict=false, this one will cause OpenAPIKit to throw an error. Previous verions were more
+            // lenient and Swift OpenAPI Generator would later emit a warning that it's unsupported.
+            // .validating(.parameterStyleAndLocationAreCompatible)
+            .validating(.schemaReferencesAreValid).validating(.jsonSchemaReferencesAreValid)
+            .validating(.responseReferencesAreValid).validating(.parameterReferencesAreValid)
+            .validating(.exampleReferencesAreValid).validating(.requestReferencesAreValid)
+            .validating(.headerReferencesAreValid).validating(.linkReferencesAreValid)
+            .validating(.callbacksReferencesAreValid).validating(.pathItemReferencesAreValid)
+            // And also add in this one.
+            .validating(.operationsContainResponses)
+    }
 }

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_validateDoc.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_validateDoc.swift
@@ -480,6 +480,38 @@ final class Test_validateDoc: Test_Core {
             )
         }
     }
+    func testParameterStyleLocationMismatchIsNotFatal() throws {
+        let yaml = """
+            openapi: "3.0.0"
+            info:
+              title: "Test"
+              version: "1.0.0"
+            paths:
+              /foo:
+                parameters:
+                  - name: foo
+                    in: query
+                    style: simple
+                    explode: false
+                    schema:
+                      type: string
+            """
+        let doc = try YamsParser.parseOpenAPIDocument(
+            .init(absolutePath: URL(fileURLWithPath: "/foo.yaml"), contents: Data(yaml.utf8)),
+            diagnostics: PrintingDiagnosticCollector()
+        )
+        XCTAssertNoThrow(
+            try validateDoc(
+                doc,
+                config: .init(
+                    mode: .types,
+                    access: Config.defaultAccessModifier,
+                    namingStrategy: Config.defaultNamingStrategy
+                )
+            )
+        )
+    }
+
     func testValidateTypeOverrides() throws {
         let schema = try loadSchemaFromYAML(
             #"""


### PR DESCRIPTION
### Motivation

After updating to OpenAPIKit 6.0 (#875), the generator fails on OpenAPI documents that use `style: simple` on query parameters. While this is technically invalid per the OpenAPI specification, it was previously tolerated -- the generator would skip the unsupported parameter with a warning diagnostic and continue generation.

The new OpenAPIKit 6.0 brings a new default built-in validation (`.parameterStyleAndLocationAreCompatible`) that rejects documents with this combination at validation time. Because this fires as a validation error (not a warning), it is thrown even with `strict: false`, before the translator gets a chance to handle the parameter gracefully.

This is a regression for users with documents that have this common spec violation, which we do have examples of in our extended compatibility test suite).

### Modifications

Replace the use of `Validator()` (which includes all OpenAPIKit defaults) with a custom validator built from `Validator.blank`. This explicitly lists all default validations from OpenAPIKit 6.0.0 except `.parameterStyleAndLocationAreCompatible`, restoring the previous behaviour where the generator tolerates these documents.

We might want to revisit how lenient we are for this, but this patch is the most expeditious way to getting a release out with the OpenAPIKit update.

### Result

Documents with `style: simple` on query parameters are no longer rejected at validation time. The translator continues to emit an "unsupported" diagnostic and skip the parameter, as it did before the OpenAPIKit upgrade:

```
'Feature "Query params of style simple, explode: false" is not supported, skipping'
```
