### PR TITLE
Remove validations selectively

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.4"),
 
         // Read OpenAPI documents
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "6.0.0", traits: []),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "6.1.0", traits: []),
         .package(url: "https://github.com/jpsim/Yams", "4.0.0"..<"7.0.0"),
 
         // CLI Tool

--- a/Sources/_OpenAPIGeneratorCore/Parser/validateDoc.swift
+++ b/Sources/_OpenAPIGeneratorCore/Parser/validateDoc.swift
@@ -318,24 +318,11 @@ func validateDoc(_ doc: ParsedOpenAPIRepresentation, config: Config) throws -> [
 
 extension OpenAPIKit.Validator {
     static var swiftOpenAPICustomValidator: Validator {
-        // Start with blank.
-        .blank
-            // Add defaults as of OpenAPIKit 6.0.0
-            // https://github.com/mattpolzin/OpenAPIKit/blob/118d039/Sources/OpenAPIKit/Validator/Validator.swift#L184-L186
-            .validating(.documentTagNamesAreUnique).validating(.documentServerNamesAreUnique)
-            .validating(.pathItemParametersAreUnique).validating(.operationParametersAreUnique)
-            .validating(.querystringParametersAreCompatible).validating(.operationIdsAreUnique)
-            .validating(.serverVariableEnumIsValid).validating(.serverVariableDefaultExistsInEnum)
-            // Without this one to be backwards compatible with previous versions of Swift OpenAPI Generator.
+        Validator()
+            .validating(\.operationsContainResponses)
+            // Skip this one to be backwards compatible with previous versions of Swift OpenAPI Generator.
             // Even when run with strict=false, this one will cause OpenAPIKit to throw an error. Previous verions were more
             // lenient and Swift OpenAPI Generator would later emit a warning that it's unsupported.
-            // .validating(.parameterStyleAndLocationAreCompatible)
-            .validating(.schemaReferencesAreValid).validating(.jsonSchemaReferencesAreValid)
-            .validating(.responseReferencesAreValid).validating(.parameterReferencesAreValid)
-            .validating(.exampleReferencesAreValid).validating(.requestReferencesAreValid)
-            .validating(.headerReferencesAreValid).validating(.linkReferencesAreValid)
-            .validating(.callbacksReferencesAreValid).validating(.pathItemReferencesAreValid)
-            // And also add in this one.
-            .validating(.operationsContainResponses)
+            .withoutValidating(\.parameterStyleAndLocationAreCompatible)
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Parser/validateDoc.swift
+++ b/Sources/_OpenAPIGeneratorCore/Parser/validateDoc.swift
@@ -318,8 +318,7 @@ func validateDoc(_ doc: ParsedOpenAPIRepresentation, config: Config) throws -> [
 
 extension OpenAPIKit.Validator {
     static var swiftOpenAPICustomValidator: Validator {
-        Validator()
-            .validating(\.operationsContainResponses)
+        Validator().validating(\.operationsContainResponses)
             // Skip this one to be backwards compatible with previous versions of Swift OpenAPI Generator.
             // Even when run with strict=false, this one will cause OpenAPIKit to throw an error. Previous verions were more
             // lenient and Swift OpenAPI Generator would later emit a warning that it's unsupported.

--- a/Tests/OpenAPIGeneratorCoreTests/Parser/Test_validateDoc.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Parser/Test_validateDoc.swift
@@ -17,6 +17,33 @@ import OpenAPIKit
 
 final class Test_validateDoc: Test_Core {
 
+    func testExpectedValidationsAreUsed() {
+        let validator = Validator.swiftOpenAPICustomValidator
+
+        XCTAssertEqual(
+            validator.validationDescriptions,
+            [
+                "The names of Tags in the Document are unique", "The names of Servers in the Document are unique",
+                "Path Item parameters are unique (identity is defined by the \'name\' and \'location\')",
+                "Operation parameters are unique (identity is defined by the \'name\' and \'location\')",
+                "Querystring parameters are unique and do not coexist with query parameters",
+                "All Operation Ids in Document are unique",
+                "Server Variable\'s enum is either not defined or is non-empty (if defined).",
+                "Server Variable\'s default must exist in enum, if enum is defined.",
+                "JSONSchema reference can be found in components/schemas",
+                "JSONSchema reference can be found in components/schemas",
+                "Response reference can be found in components/responses",
+                "Parameter reference can be found in components/parameters",
+                "Example reference can be found in components/examples",
+                "Request reference can be found in components/requestBodies",
+                "Header reference can be found in components/headers",
+                "Link reference can be found in components/links",
+                "Callbacks reference can be found in components/callbacks",
+                "PathItem reference can be found in components/pathItems", "Operations contain at least one response",
+            ]
+        )
+    }
+
     func testSchemaWarningIsNotFatal() throws {
         let schemaWithWarnings = try loadSchemaFromYAML(
             #"""


### PR DESCRIPTION
### Motivation

When it recently became important for the Swift OpenAPI Generator to omit exactly one builtin OpenAPIKit validation, it felt like high time OpenAPIKit added the ability to selectively remove default-on validations. This PR moves to a new OpenAPIKit version with that support and it uses the new method to reduce the amount of code the generator needs to maintain.

### Modifications

Swap out full enumeration of validations for selective removal.

### Result

This is just about reducing overhead in the codebase.

### Test Plan

A unit test has been added and all existing unit tests are passing.
