### PR TITLE
Migrate `nightly_6_*` inputs to `nightly_next`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,12 @@ jobs:
       windows_6_1_enabled: true
       windows_6_2_enabled: true
       windows_6_3_enabled: true
-      windows_nightly_6_1_enabled: true
+      windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
       windows_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_3_arguments_override: "--explicit-target-dependency-import-check error"
-      windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   construct-integration-test-matrix:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,12 +28,12 @@ jobs:
       windows_6_1_enabled: true
       windows_6_2_enabled: true
       windows_6_3_enabled: true
-      windows_nightly_6_1_enabled: true
+      windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
       windows_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_3_arguments_override: "--explicit-target-dependency-import-check error"
-      windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   compatibility-test:


### PR DESCRIPTION
Motivation

* The `linux_nightly_6_0/6_1` and `windows_nightly_6_1` inputs in the
  shared workflows are deprecated. `nightly_6_1` is aliased to
  `nightly_next` and `nightly_6_0` no longer runs.

Modifications

* Rename all `nightly_6_*` references to `nightly_next`.

Result

* Uses the canonical input names, no longer references deprecated
  inputs.
