### PR TITLE
Escape string literals that contain line breaks

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -446,11 +446,16 @@ struct TextBasedRenderer: RendererProtocol {
         func write(_ string: String) { writer.writeLine(string) }
         switch literal {
         case let .string(string):
-            // Use a raw literal if the string contains a quote or backslash.
-            // Pick the minimum number of `#` delimiters so that neither the
-            // closing delimiter (`"` + N×`#`) nor the escape prefix
-            // (`\` + N×`#`) appears in the string content.
-            if string.contains("\"") || string.contains("\\") {
+            // A single-line string literal, raw or not, cannot contain a line
+            // break. When the content has one, fall back to an escaped regular
+            // literal that represents the line break with `\n` or `\r`.
+            if string.contains(where: \.isNewlineForStringLiteral) {
+                write("\"\(string.escapedForSwiftStringLiteral)\"")
+            } else if string.contains("\"") || string.contains("\\") {
+                // Use a raw literal if the string contains a quote or backslash.
+                // Pick the minimum number of `#` delimiters so that neither the
+                // closing delimiter (`"` + N×`#`) nor the escape prefix
+                // (`\` + N×`#`) appears in the string content.
                 var hashCount = 1
                 while string.contains("\"" + String(repeating: "#", count: hashCount))
                     || string.contains("\\" + String(repeating: "#", count: hashCount))
@@ -894,6 +899,35 @@ fileprivate extension String {
     /// - Parameter work: The closure that transforms each line.
     /// - Returns: A new string where each line has been transformed using the given closure.
     func transformingLines(_ work: (String) -> String) -> [String] { asLines().map(work) }
+
+    /// The string with characters escaped so it can be embedded inside a
+    /// regular (non-raw) single-line Swift string literal.
+    ///
+    /// Backslashes and double quotes are escaped, and line breaks are turned
+    /// into their `\n` and `\r` escape sequences, so a value containing a line
+    /// break can be represented on a single line.
+    var escapedForSwiftStringLiteral: String {
+        var result = ""
+        result.reserveCapacity(count)
+        for character in self {
+            switch character {
+            case "\\": result += #"\\"#
+            case "\"": result += #"\""#
+            case "\n": result += #"\n"#
+            case "\r": result += #"\r"#
+            case "\t": result += #"\t"#
+            default: result.append(character)
+            }
+        }
+        return result
+    }
+}
+
+fileprivate extension Character {
+
+    /// Whether the character is a line break that cannot appear in a
+    /// single-line Swift string literal, namely line feed or carriage return.
+    var isNewlineForStringLiteral: Bool { self == "\n" || self == "\r" }
 }
 
 extension TextBasedRenderer {

--- a/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Renderer/Test_TextBasedRenderer.swift
@@ -235,6 +235,54 @@ final class Test_TextBasedRenderer: XCTestCase {
         )
     }
 
+    // MARK: - Line breaks in string literals
+
+    func testStringLiteral_contentContainsNewline() throws {
+        // A single-line literal cannot contain a line break, so the renderer
+        // must escape it rather than emit an unterminated string literal.
+        try _test(
+            .string("first line\nsecond line"),
+            renderedBy: TextBasedRenderer.renderLiteral,
+            rendersAs: #"""
+                "first line\nsecond line"
+                """#
+        )
+    }
+
+    func testStringLiteral_contentContainsNewlineAndQuote() throws {
+        // When the content has both a quote and a line break, escaping is
+        // required because a raw literal still cannot span lines.
+        try _test(
+            .string("a\"b\nc"),
+            renderedBy: TextBasedRenderer.renderLiteral,
+            rendersAs: #"""
+                "a\"b\nc"
+                """#
+        )
+    }
+
+    func testStringLiteral_contentContainsCarriageReturn() throws {
+        try _test(
+            .string("a\rb"),
+            renderedBy: TextBasedRenderer.renderLiteral,
+            rendersAs: #"""
+                "a\rb"
+                """#
+        )
+    }
+
+    func testStringLiteral_contentContainsBackslashAndNewline() throws {
+        // The backslash must be escaped too, otherwise it would consume the
+        // escaped newline that follows it.
+        try _test(
+            .string("a\\\nb"),
+            renderedBy: TextBasedRenderer.renderLiteral,
+            rendersAs: #"""
+                "a\\\nb"
+                """#
+        )
+    }
+
     func testExpression() throws {
         try _test(
             .literal(.nil),


### PR DESCRIPTION
When the renderer emits a string literal, it currently picks between a raw literal and a plain literal based only on whether the content contains a quote or a backslash. But neither a raw nor a plain single-line literal can contain a line break, so any string value with a newline or carriage return is rendered across multiple lines and produces an unterminated string literal that does not compile.

### Motivation

A string enum whose value contains a newline triggers this. For example:

```yaml
components:
  schemas:
    Mode:
      type: string
      enum:
        - "first line\nsecond line"
        - normal
```

generates:

```swift
@frozen public enum Mode: String, Codable, Hashable, Sendable, CaseIterable {
    case first_space_line_xA_second_space_line = "first line
second line"
    case normal = "normal"
}
```

which fails to compile with `error: unterminated string literal`. The same applies anywhere a `.string` literal carries a line break, including a string with both a quote and a newline, where the existing raw-literal path is chosen but still cannot span lines.

### Modifications

`renderLiteral` now checks for a line feed or carriage return first. When the content has one, it emits an escaped regular literal that represents the break with `\n` or `\r` (also escaping backslashes and quotes so the value round-trips). Every other string keeps the existing raw-literal behavior, so no current output changes.

The example above now renders as a single valid line:

```swift
case first_space_line_xA_second_space_line = "first line\nsecond line"
```

### Result

Specs with line breaks in string values, such as enum cases, now generate compiling Swift whose values match the input byte for byte.

### Test Plan

Added unit tests in `Test_TextBasedRenderer` covering a newline, a newline combined with a quote, a carriage return, and a backslash followed by a newline. They fail before the change and pass after. The existing reference and Petstore suites are unchanged.