### PR TITLE
Improve missing document error in filter command

### DIFF
--- a/Sources/swift-openapi-generator/FilterCommand.swift
+++ b/Sources/swift-openapi-generator/FilterCommand.swift
@@ -44,7 +44,9 @@ struct _FilterCommand: AsyncParsableCommand {
             let configData = try Data(contentsOf: config)
             return try YAMLDecoder().decode(_UserConfig.self, from: configData)
         }
-        let documentInput = try InMemoryInputFile(absolutePath: docPath, contents: Data(contentsOf: docPath))
+        let documentInput = try handleFileOperation(at: docPath, fileDescription: "OpenAPI document") {
+            try InMemoryInputFile(absolutePath: docPath, contents: Data(contentsOf: docPath))
+        }
         let document = try timing(
             "Parsing document",
             YamsParser.parseOpenAPIDocument(documentInput, diagnostics: StdErrPrintingDiagnosticCollector())


### PR DESCRIPTION
## Summary

- Use the existing file-operation helper when the `filter` command loads the OpenAPI document.
- Report missing filter input documents as a friendly `ValidationError` instead of surfacing the raw Foundation file-not-found error.

## Validation

- `swift test --filter Test_GenerateOptions`

Related to #855.
