### PR TITLE
Stop boxing types that recurse only through an array or dictionary

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/Recursion/DeclarationRecursionDetector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Recursion/DeclarationRecursionDetector.swift
@@ -155,13 +155,15 @@ fileprivate extension Array where Element == String {
 
 extension ExistingTypeDescription {
 
-    /// The name in the `Components.Schemas.` namespace, if the type can appear
-    /// there. Nil otherwise.
+    /// The name in the `Components.Schemas.` namespace this type references
+    /// without an intervening array or dictionary, if any. Nil otherwise.
     var referencedSchemaComponentName: String? {
         switch self {
         case .member(let components): return components.nameIfTopLevelSchemaComponent
-        case .array(let desc), .dictionaryValue(let desc), .any(let desc), .optional(let desc):
-            return desc.referencedSchemaComponentName
+        case .any(let desc), .optional(let desc): return desc.referencedSchemaComponentName
+        // Arrays and dictionaries provide heap indirection, so a reference reached
+        // only through them cannot form a value-type cycle that needs boxing.
+        case .array, .dictionaryValue: return nil
         case .generic: return nil
         }
     }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1685,6 +1685,172 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testComponentsSchemasRecursive_directAndThroughArray() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              Node:
+                type: object
+                properties:
+                  parent:
+                    $ref: '#/components/schemas/Node'
+                  children:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Node'
+            """,
+            """
+            public enum Schemas {
+                public struct Node: Codable, Hashable, Sendable {
+                    public var parent: Components.Schemas.Node? {
+                        get  {
+                            self.storage.value.parent
+                        }
+                        _modify {
+                            yield &self.storage.value.parent
+                        }
+                    }
+                    public var children: [Components.Schemas.Node]? {
+                        get  {
+                            self.storage.value.children
+                        }
+                        _modify {
+                            yield &self.storage.value.children
+                        }
+                    }
+                    public init(
+                        parent: Components.Schemas.Node? = nil,
+                        children: [Components.Schemas.Node]? = nil
+                    ) {
+                        self.storage = .init(value: .init(
+                            parent: parent,
+                            children: children
+                        ))
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case parent
+                        case children
+                    }
+                    public init(from decoder: any Swift.Decoder) throws {
+                        self.storage = try .init(from: decoder)
+                    }
+                    public func encode(to encoder: any Swift.Encoder) throws {
+                        try self.storage.encode(to: encoder)
+                    }
+                    private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
+                    private struct Storage: Codable, Hashable, Sendable {
+                        var parent: Components.Schemas.Node?
+                        var children: [Components.Schemas.Node]?
+                        init(
+                            parent: Components.Schemas.Node? = nil,
+                            children: [Components.Schemas.Node]? = nil
+                        ) {
+                            self.parent = parent
+                            self.children = children
+                        }
+                        typealias CodingKeys = Components.Schemas.Node.CodingKeys
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsSchemasRecursive_directAndThroughDictionary() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              Node:
+                type: object
+                properties:
+                  parent:
+                    $ref: '#/components/schemas/Node'
+                  children:
+                    type: object
+                    additionalProperties:
+                      $ref: '#/components/schemas/Node'
+            """,
+            """
+            public enum Schemas {
+                public struct Node: Codable, Hashable, Sendable {
+                    public var parent: Components.Schemas.Node? {
+                        get  {
+                            self.storage.value.parent
+                        }
+                        _modify {
+                            yield &self.storage.value.parent
+                        }
+                    }
+                    public struct childrenPayload: Codable, Hashable, Sendable {
+                        public var additionalProperties: [String: Components.Schemas.Node]
+                        public init(additionalProperties: [String: Components.Schemas.Node] = .init()) {
+                            self.additionalProperties = additionalProperties
+                        }
+                        public init(from decoder: any Swift.Decoder) throws {
+                            additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
+                        }
+                        public func encode(to encoder: any Swift.Encoder) throws {
+                            try encoder.encodeAdditionalProperties(additionalProperties)
+                        }
+                    }
+                    public var children: Components.Schemas.Node.childrenPayload? {
+                        get  {
+                            self.storage.value.children
+                        }
+                        _modify {
+                            yield &self.storage.value.children
+                        }
+                    }
+                    public init(
+                        parent: Components.Schemas.Node? = nil,
+                        children: Components.Schemas.Node.childrenPayload? = nil
+                    ) {
+                        self.storage = .init(value: .init(
+                            parent: parent,
+                            children: children
+                        ))
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case parent
+                        case children
+                    }
+                    public init(from decoder: any Swift.Decoder) throws {
+                        self.storage = try .init(from: decoder)
+                    }
+                    public func encode(to encoder: any Swift.Encoder) throws {
+                        try self.storage.encode(to: encoder)
+                    }
+                    private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
+                    private struct Storage: Codable, Hashable, Sendable {
+                        var parent: Components.Schemas.Node?
+                        struct childrenPayload: Codable, Hashable, Sendable {
+                            public var additionalProperties: [String: Components.Schemas.Node]
+                            public init(additionalProperties: [String: Components.Schemas.Node] = .init()) {
+                                self.additionalProperties = additionalProperties
+                            }
+                            public init(from decoder: any Swift.Decoder) throws {
+                                additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
+                            }
+                            public func encode(to encoder: any Swift.Encoder) throws {
+                                try encoder.encodeAdditionalProperties(additionalProperties)
+                            }
+                        }
+                        var children: Components.Schemas.Node.childrenPayload?
+                        init(
+                            parent: Components.Schemas.Node? = nil,
+                            children: Components.Schemas.Node.childrenPayload? = nil
+                        ) {
+                            self.parent = parent
+                            self.children = children
+                        }
+                        typealias CodingKeys = Components.Schemas.Node.CodingKeys
+                    }
+                }
+            }
+            """
+        )
+    }
+
     func testComponentsSchemasRecursive_objectNested() throws {
         try self.assertSchemasTranslation(
             """

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1617,6 +1617,74 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testComponentsSchemasRecursive_throughArray() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              Node:
+                type: object
+                properties:
+                  children:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Node'
+            """,
+            """
+            public enum Schemas {
+                public struct Node: Codable, Hashable, Sendable {
+                    public var children: [Components.Schemas.Node]?
+                    public init(children: [Components.Schemas.Node]? = nil) {
+                        self.children = children
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case children
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsSchemasRecursive_throughDictionary() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              Node:
+                type: object
+                properties:
+                  children:
+                    type: object
+                    additionalProperties:
+                      $ref: '#/components/schemas/Node'
+            """,
+            """
+            public enum Schemas {
+                public struct Node: Codable, Hashable, Sendable {
+                    public struct childrenPayload: Codable, Hashable, Sendable {
+                        public var additionalProperties: [String: Components.Schemas.Node]
+                        public init(additionalProperties: [String: Components.Schemas.Node] = .init()) {
+                            self.additionalProperties = additionalProperties
+                        }
+                        public init(from decoder: any Swift.Decoder) throws {
+                            additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [])
+                        }
+                        public func encode(to encoder: any Swift.Encoder) throws {
+                            try encoder.encodeAdditionalProperties(additionalProperties)
+                        }
+                    }
+                    public var children: Components.Schemas.Node.childrenPayload?
+                    public init(children: Components.Schemas.Node.childrenPayload? = nil) {
+                        self.children = children
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case children
+                    }
+                }
+            }
+            """
+        )
+    }
+
     func testComponentsSchemasRecursive_objectNested() throws {
         try self.assertSchemasTranslation(
             """


### PR DESCRIPTION
### Motivation

The generator boxes a type whose only self-reference is reached through an array or dictionary. Swift arrays and dictionaries keep their elements in heap-allocated storage, so a reference reached only through them cannot form a value-type cycle and the type does not need a `CopyOnWriteBox`. `Supporting-recursive-types.md` already notes that arrays and dictionaries can be considered boxed, so the containing type does not require boxing. Fixes #682.

### Modifications

- In `ExistingTypeDescription.referencedSchemaComponentName`, return `nil` for `.array` and `.dictionaryValue` instead of recursing into them. `.optional` and `.any` still recurse.

### Result

A type that recurses only through an array or dictionary is generated as a plain struct with stored properties, not a boxed type.

### Test Plan

Added two snippet reference tests covering recursion through an array and through a dictionary.
