### PR TITLE
Add swift-okhttp client transport reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The Swift OpenAPI Generator project is split across multiple repositories to ena
 | [apple/swift-openapi-runtime][repo-runtime]                | Runtime library used by the generated code         |
 | [apple/swift-openapi-urlsession][repo-urlsession]          | `ClientTransport` using [URLSession][urlsession]   |
 | [swift-server/swift-openapi-async-http-client][repo-ahc]   | `ClientTransport` using [AsyncHTTPClient][ahc]     |
+| [frameo-net/swift-okhttp][repo-swift-okhttp]               | `ClientTransport` using [OkHttp][okhttp]           |
 | [vapor/swift-openapi-vapor][repo-vapor]                    | `ServerTransport` using [Vapor][vapor]             |
 | [hummingbird-project/swift-openapi-hummingbird][repo-hb]   | `ServerTransport` using [Hummingbird][hb]          |
 | [awslabs/swift-openapi-lambda][repo-lambda]                | `ServerTransport` using [AWS Lambda][lambda]       |
@@ -137,6 +138,8 @@ Generator](https://developer.apple.com/wwdc23/10171) from WWDC23.
 [hb]: https://github.com/hummingbird-project/hummingbird
 [repo-lambda]: https://github.com/awslabs/swift-openapi-lambda
 [lambda]: https://docs.aws.amazon.com/lambda/latest/dg/welcome.html
+[repo-swift-okhttp]: https://github.com/frameo-net/swift-okhttp
+[okhttp]: https://square.github.io/okhttp/
 [^example-openapi-yaml]: <details><summary>Example OpenAPI document (click to expand)</summary>
 
     ```yaml


### PR DESCRIPTION
Added link to swift-okhttp repository and documentation.

This can be used on platforms such as Android or other Java-based platforms.
