### PR TITLE
Emit a clear error instead of crashing on duplicate generated schema names

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
@@ -25,7 +25,16 @@ extension TypesFileTranslator {
     func boxRecursiveTypes(_ decls: [Declaration]) throws -> [Declaration] {
 
         let nodes = decls.compactMap(DeclarationRecursionDetector.Node.init)
-        let nodeLookup = Dictionary(uniqueKeysWithValues: nodes.map { ($0.name, $0) })
+        if let duplicateName = nodes.firstDuplicateName {
+            try diagnostics.emit(
+                .error(
+                    message:
+                        "Multiple schemas in '#/components/schemas' map to the same generated Swift type name '\(duplicateName)', which is not supported. This usually happens when the naming strategy collapses two distinct OpenAPI names into one. Switch the namingStrategy to 'defensive', or add a 'nameOverrides' entry to give one of the schemas a different name.",
+                    context: ["name": duplicateName]
+                )
+            )
+        }
+        let nodeLookup = Dictionary(nodes.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
         let container = DeclarationRecursionDetector.Container(lookupMap: nodeLookup)
 
         let boxedNames = try RecursionDetector.computeBoxedTypes(rootNodes: nodes, container: container)
@@ -215,5 +224,16 @@ extension TypesFileTranslator {
         var desc = desc
         desc.isIndirect = true
         return desc
+    }
+}
+
+extension Array where Element == DeclarationRecursionDetector.Node {
+
+    /// The name of the first node whose name was already used by an earlier
+    /// node in the array, or `nil` if all node names are unique.
+    var firstDuplicateName: String? {
+        var seen = Set<String>()
+        for node in self where !seen.insert(node.name).inserted { return node.name }
+        return nil
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
@@ -25,31 +25,11 @@ extension TypesFileTranslator {
     func boxRecursiveTypes(_ decls: [Declaration]) throws -> [Declaration] {
 
         let nodes = decls.compactMap(DeclarationRecursionDetector.Node.init)
-        var duplicateNames: Set<String> = []
-        let nodeLookup = Dictionary(
-            nodes.map { ($0.name, $0) },
-            uniquingKeysWith: { existing, _ in
-                duplicateNames.insert(existing.name)
-                return existing
-            }
-        )
-        if !duplicateNames.isEmpty {
-            let sortedNames = duplicateNames.sorted()
-            let message: String
-            let context: [String: String]
-            if sortedNames.count == 1 {
-                let duplicateName = sortedNames[0]
-                message =
-                    "Multiple schemas in '#/components/schemas' map to the same generated Swift type name '\(duplicateName)', which is not supported. This usually happens when the naming strategy collapses two distinct OpenAPI names into one. Switch the namingStrategy to 'defensive', or add a 'nameOverrides' entry to give one of the schemas a different name."
-                context = ["name": duplicateName]
-            } else {
-                let nameList = sortedNames.map { "'\($0)'" }.joined(separator: ", ")
-                message =
-                    "Multiple schemas in '#/components/schemas' map to the same generated Swift type names \(nameList), which is not supported. This usually happens when the naming strategy collapses distinct OpenAPI names into one. Switch the namingStrategy to 'defensive', or add 'nameOverrides' entries to give the schemas different names."
-                context = ["names": nameList]
-            }
-            try diagnostics.emit(.error(message: message, context: context))
-        }
+        // Duplicate generated names are detected and reported earlier, in
+        // `translateSchemas`. Keep the first node on a collision here so this
+        // step never traps even if a non-throwing diagnostic collector lets
+        // execution continue past that error.
+        let nodeLookup = Dictionary(nodes.map { ($0.name, $0) }, uniquingKeysWith: { existing, _ in existing })
         let container = DeclarationRecursionDetector.Container(lookupMap: nodeLookup)
 
         let boxedNames = try RecursionDetector.computeBoxedTypes(rootNodes: nodes, container: container)

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
@@ -25,16 +25,31 @@ extension TypesFileTranslator {
     func boxRecursiveTypes(_ decls: [Declaration]) throws -> [Declaration] {
 
         let nodes = decls.compactMap(DeclarationRecursionDetector.Node.init)
-        if let duplicateName = nodes.firstDuplicateName {
-            try diagnostics.emit(
-                .error(
-                    message:
-                        "Multiple schemas in '#/components/schemas' map to the same generated Swift type name '\(duplicateName)', which is not supported. This usually happens when the naming strategy collapses two distinct OpenAPI names into one. Switch the namingStrategy to 'defensive', or add a 'nameOverrides' entry to give one of the schemas a different name.",
-                    context: ["name": duplicateName]
-                )
-            )
+        var duplicateNames: Set<String> = []
+        let nodeLookup = Dictionary(
+            nodes.map { ($0.name, $0) },
+            uniquingKeysWith: { existing, _ in
+                duplicateNames.insert(existing.name)
+                return existing
+            }
+        )
+        if !duplicateNames.isEmpty {
+            let sortedNames = duplicateNames.sorted()
+            let message: String
+            let context: [String: String]
+            if sortedNames.count == 1 {
+                let duplicateName = sortedNames[0]
+                message =
+                    "Multiple schemas in '#/components/schemas' map to the same generated Swift type name '\(duplicateName)', which is not supported. This usually happens when the naming strategy collapses two distinct OpenAPI names into one. Switch the namingStrategy to 'defensive', or add a 'nameOverrides' entry to give one of the schemas a different name."
+                context = ["name": duplicateName]
+            } else {
+                let nameList = sortedNames.map { "'\($0)'" }.joined(separator: ", ")
+                message =
+                    "Multiple schemas in '#/components/schemas' map to the same generated Swift type names \(nameList), which is not supported. This usually happens when the naming strategy collapses distinct OpenAPI names into one. Switch the namingStrategy to 'defensive', or add 'nameOverrides' entries to give the schemas different names."
+                context = ["names": nameList]
+            }
+            try diagnostics.emit(.error(message: message, context: context))
         }
-        let nodeLookup = Dictionary(nodes.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
         let container = DeclarationRecursionDetector.Container(lookupMap: nodeLookup)
 
         let boxedNames = try RecursionDetector.computeBoxedTypes(rootNodes: nodes, container: container)
@@ -224,16 +239,5 @@ extension TypesFileTranslator {
         var desc = desc
         desc.isIndirect = true
         return desc
-    }
-}
-
-extension Array where Element == DeclarationRecursionDetector.Node {
-
-    /// The name of the first node whose name was already used by an earlier
-    /// node in the array, or `nil` if all node names are unique.
-    var firstDuplicateName: String? {
-        var seen = Set<String>()
-        for node in self where !seen.insert(node.name).inserted { return node.name }
-        return nil
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateSchemas.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateSchemas.swift
@@ -64,6 +64,7 @@ extension TypesFileTranslator {
                 isMultipartContent: multipartSchemaNames.contains(key)
             )
         }
+        try detectDuplicateGeneratedNames(in: decls)
         let declsWithBoxingApplied = try boxRecursiveTypes(decls)
         let componentsSchemasEnum = Declaration.commentable(
             JSONSchema.sectionComment(),
@@ -74,5 +75,34 @@ extension TypesFileTranslator {
             )
         )
         return componentsSchemasEnum
+    }
+
+    /// Emits a clear error if multiple generated schema declarations map to the
+    /// same Swift type name, instead of letting a later step crash on the
+    /// collision.
+    /// - Parameter decls: The declarations of `Components.Schemas.*` types.
+    /// - Throws: An error describing the colliding names.
+    private func detectDuplicateGeneratedNames(in decls: [Declaration]) throws {
+        var seenNames: Set<String> = []
+        var duplicateNames: Set<String> = []
+        for name in decls.compactMap(\.name) {
+            if !seenNames.insert(name).inserted { duplicateNames.insert(name) }
+        }
+        guard !duplicateNames.isEmpty else { return }
+        let sortedNames = duplicateNames.sorted()
+        let message: String
+        let context: [String: String]
+        if sortedNames.count == 1 {
+            let duplicateName = sortedNames[0]
+            message =
+                "Multiple schemas in '#/components/schemas' map to the same generated Swift type name '\(duplicateName)', which is not supported. This usually happens when the naming strategy collapses two distinct OpenAPI names into one. Switch the namingStrategy to 'defensive', or add a 'nameOverrides' entry to give one of the schemas a different name."
+            context = ["name": duplicateName]
+        } else {
+            let nameList = sortedNames.map { "'\($0)'" }.joined(separator: ", ")
+            message =
+                "Multiple schemas in '#/components/schemas' map to the same generated Swift type names \(nameList), which is not supported. This usually happens when the naming strategy collapses distinct OpenAPI names into one. Switch the namingStrategy to 'defensive', or add 'nameOverrides' entries to give the schemas different names."
+            context = ["names": nameList]
+        }
+        try diagnostics.emit(.error(message: message, context: context))
     }
 }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
@@ -47,4 +47,40 @@ class Test_translateSchemas: Test_Core {
             XCTAssertEqual(collector.diagnostics.map(\.description), diagnosticDescriptions)
         }
     }
+
+    func testDuplicateGeneratedNameEmitsErrorInsteadOfCrashing() throws {
+        // Two distinct OpenAPI schema names that the idiomatic naming strategy
+        // collapses to the same Swift type name ("NullTime"). Previously this
+        // trapped in `Dictionary(uniqueKeysWithValues:)` while boxing recursive
+        // types; now it should surface as a clear error diagnostic instead.
+        let components = OpenAPI.Components(schemas: [
+            "NullTime": .object(properties: ["value": .string]), "nullTime": .object(properties: ["value": .string]),
+        ])
+        let collector = AccumulatingDiagnosticCollector()
+        let translator = makeTranslator(components: components, diagnostics: collector, namingStrategy: .idiomatic)
+        _ = try translator.translateSchemas(components.schemas, multipartSchemaNames: [])
+        let errors = collector.diagnostics.filter { $0.severity == .error }
+        XCTAssertEqual(errors.count, 1)
+        let error = try XCTUnwrap(errors.first)
+        XCTAssertEqual(error.context["name"], "NullTime")
+        XCTAssertTrue(
+            error.message.contains("map to the same generated Swift type name 'NullTime'"),
+            "Unexpected error message: \(error.message)"
+        )
+    }
+
+    func testDistinctGeneratedNamesEmitNoErrorWithIdiomaticNaming() throws {
+        // Two schema names that the idiomatic naming strategy maps to distinct
+        // Swift type names must not trigger the duplicate-name error.
+        let components = OpenAPI.Components(schemas: [
+            "null_time": .object(properties: ["value": .string]), "other_time": .object(properties: ["value": .string]),
+        ])
+        let collector = AccumulatingDiagnosticCollector()
+        let translator = makeTranslator(components: components, diagnostics: collector, namingStrategy: .idiomatic)
+        _ = try translator.translateSchemas(components.schemas, multipartSchemaNames: [])
+        XCTAssertTrue(
+            collector.diagnostics.filter { $0.severity == .error }.isEmpty,
+            "Expected no error diagnostics, got: \(collector.diagnostics.map(\.description))"
+        )
+    }
 }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
@@ -69,6 +69,27 @@ class Test_translateSchemas: Test_Core {
         )
     }
 
+    func testMultipleDuplicateGeneratedNamesAreReportedInASingleError() throws {
+        // Two independent pairs of OpenAPI schema names each collapse to the
+        // same Swift type name ("FullName" and "NullTime"). A single error
+        // should list both colliding names rather than stopping at the first.
+        let components = OpenAPI.Components(schemas: [
+            "NullTime": .object(properties: ["value": .string]), "nullTime": .object(properties: ["value": .string]),
+            "FullName": .object(properties: ["value": .string]), "fullName": .object(properties: ["value": .string]),
+        ])
+        let collector = AccumulatingDiagnosticCollector()
+        let translator = makeTranslator(components: components, diagnostics: collector, namingStrategy: .idiomatic)
+        _ = try translator.translateSchemas(components.schemas, multipartSchemaNames: [])
+        let errors = collector.diagnostics.filter { $0.severity == .error }
+        XCTAssertEqual(errors.count, 1)
+        let error = try XCTUnwrap(errors.first)
+        XCTAssertEqual(error.context["names"], "'FullName', 'NullTime'")
+        XCTAssertTrue(
+            error.message.contains("map to the same generated Swift type names 'FullName', 'NullTime'"),
+            "Unexpected error message: \(error.message)"
+        )
+    }
+
     func testDistinctGeneratedNamesEmitNoErrorWithIdiomaticNaming() throws {
         // Two schema names that the idiomatic naming strategy maps to distinct
         // Swift type names must not trigger the duplicate-name error.


### PR DESCRIPTION
When the idiomatic naming strategy maps two distinct OpenAPI schema names to the same generated Swift type name, the generator crashes instead of reporting the problem. This is the crash tracked in #854: a document with both `NullTime` and `nullTime` under `#/components/schemas` produces

```
Swift/NativeDictionary.swift: Fatal error: Duplicate values for key: 'NullTime'
```

Root cause is in `boxRecursiveTypes`, which builds a name-to-node lookup for recursion detection with `Dictionary(uniqueKeysWithValues:)`. That initializer traps on duplicate keys, and the idiomatic strategy can produce two declarations sharing a name even though the OpenAPI names were distinct. The defensive strategy keeps them distinct, which is why the crash only shows up with idiomatic naming.

The fix detects the collision before building the lookup and emits an error diagnostic that names the conflicting type and points at the documented workarounds (switch `namingStrategy` to `defensive`, or add a `nameOverrides` entry). The `Configuring-the-generator` article already notes that idiomatic naming "might produce name conflicts (in that case, switch back to defensive)", so this turns an undiagnosed trap into the guidance that already exists. The lookup construction now also tolerates duplicate keys, so the error diagnostic is the failure path rather than a fatal trap, independent of which diagnostic collector is in use.

Verification: running the generator with `namingStrategy: idiomatic` on a spec containing `NullTime` and `nullTime` previously crashed; it now exits non-zero with

```
error: Multiple schemas in '#/components/schemas' map to the same generated Swift type name 'NullTime', which is not supported. ...
```

I added a regression test in `Test_translateSchemas` that translates two schemas colliding under the idiomatic strategy and asserts the error is emitted. With the previous code that test aborts with the `Duplicate values for key` trap (signal 5); with the fix it passes. A second test confirms that distinct idiomatic names emit no error. The full `OpenAPIGeneratorCoreTests` target (115 tests) and the reference tests (114 tests) pass, so generated output for valid documents is unchanged, including recursive-type boxing.


---

Note: this supersedes #907, which I closed by accident during a bulk cleanup of my stale forks and cannot reopen because the original fork was deleted. The branch is identical to the reviewed state of #907 including the uniquingKeysWith rework discussed there.
