### PR TITLE
Add configurable Swift attributes for generated APIProtocol

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/AttributeConfiguration.swift
+++ b/Sources/_OpenAPIGeneratorCore/AttributeConfiguration.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Configuration for Swift attributes to add to generated API protocol declarations.
+public struct AttributeConfiguration: Sendable, Equatable, Codable {
+
+    /// Attributes applied to the generated `APIProtocol` declaration.
+    public var protocolAttributes: [AttributeDescription]
+
+    /// Attributes applied to each method requirement in `APIProtocol`.
+    public var methodAttributes: [AttributeDescription]
+
+    /// The default attribute configuration, with no attributes.
+    public static let `default`: Self = .init()
+
+    enum CodingKeys: String, CodingKey {
+        case protocolAttributes = "protocol"
+        case methodAttributes = "methods"
+    }
+
+    /// Creates an attribute configuration.
+    /// - Parameters:
+    ///   - protocolAttributes: Attributes applied to the generated `APIProtocol` declaration.
+    ///   - methodAttributes: Attributes applied to each method requirement in `APIProtocol`.
+    public init(protocolAttributes: [AttributeDescription] = [], methodAttributes: [AttributeDescription] = []) {
+        self.protocolAttributes = protocolAttributes
+        self.methodAttributes = methodAttributes
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.protocolAttributes =
+            try container.decodeIfPresent([AttributeDescription].self, forKey: .protocolAttributes) ?? []
+        self.methodAttributes = try container.decodeIfPresent([AttributeDescription].self, forKey: .methodAttributes) ?? []
+    }
+}

--- a/Sources/_OpenAPIGeneratorCore/Config.swift
+++ b/Sources/_OpenAPIGeneratorCore/Config.swift
@@ -68,6 +68,9 @@ public struct Config: Sendable {
     /// Additional pre-release features to enable.
     public var featureFlags: FeatureFlags
 
+    /// Swift attributes to add to generated API protocol declarations.
+    public var attributes: AttributeConfiguration
+
     /// Creates a configuration with the specified generator mode and imports.
     /// - Parameters:
     ///   - mode: The mode to use for generation.
@@ -81,6 +84,7 @@ public struct Config: Sendable {
     ///     of the naming strategy.
     ///   - typeOverrides: A map of OpenAPI schema names to desired custom type names.
     ///   - featureFlags: Additional pre-release features to enable.
+    ///   - attributes: Swift attributes to add to generated API protocol declarations.
     public init(
         mode: GeneratorMode,
         access: AccessModifier,
@@ -90,7 +94,8 @@ public struct Config: Sendable {
         namingStrategy: NamingStrategy,
         nameOverrides: [String: String] = [:],
         typeOverrides: TypeOverrides = .init(),
-        featureFlags: FeatureFlags = []
+        featureFlags: FeatureFlags = [],
+        attributes: AttributeConfiguration = .default
     ) {
         self.mode = mode
         self.access = access
@@ -101,5 +106,6 @@ public struct Config: Sendable {
         self.nameOverrides = nameOverrides
         self.typeOverrides = typeOverrides
         self.featureFlags = featureFlags
+        self.attributes = attributes
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -652,8 +652,11 @@ indirect enum Declaration: Equatable, Codable {
     /// A declaration that adds a comment on top of the provided declaration.
     case commentable(Comment?, Declaration)
 
-    /// A declaration that adds a comment on top of the provided declaration.
+    /// A declaration that adds a deprecation annotation on top of the provided declaration.
     case deprecated(DeprecationDescription, Declaration)
+
+    /// A declaration that adds Swift attributes on top of the provided declaration.
+    case attributes([AttributeDescription], Declaration)
 
     /// A variable declaration.
     case variable(VariableDescription)
@@ -678,6 +681,35 @@ indirect enum Declaration: Equatable, Codable {
 
     /// An enum case declaration.
     case enumCase(EnumCaseDescription)
+}
+
+/// A description of a Swift attribute applied to a generated declaration.
+///
+/// For example: `@MainActor` or `@Mockable`.
+public struct AttributeDescription: Sendable, Equatable, Codable {
+
+    /// The attribute name and arguments without the leading `@` character.
+    ///
+    /// For example, `"MainActor"` or `"Mockable"`.
+    public var name: String
+
+    /// Creates a new attribute description.
+    /// - Parameter name: The attribute name and arguments without the leading `@` character.
+    public init(name: String) { self.name = name }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.name = try container.decode(String.self)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(name)
+    }
+}
+
+extension AttributeDescription: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) { self.init(name: value) }
 }
 
 /// A description of a deprecation notice.
@@ -1651,6 +1683,12 @@ extension Declaration {
         return self
     }
 
+    /// Returns a new variant of the declaration with the provided attributes applied.
+    func withAttributes(_ attributes: [AttributeDescription]) -> Self {
+        guard !attributes.isEmpty else { return self }
+        return .attributes(attributes, self)
+    }
+
     /// Returns the declaration one level deeper, nested inside the commentable
     /// declaration, if present.
     var strippingTopComment: Self {
@@ -1667,6 +1705,7 @@ extension Declaration {
             switch self {
             case .commentable(_, let declaration): return declaration.accessModifier
             case .deprecated(_, let declaration): return declaration.accessModifier
+            case .attributes(_, let declaration): return declaration.accessModifier
             case .variable(let variableDescription): return variableDescription.accessModifier
             case .extension(let extensionDescription): return extensionDescription.accessModifier
             case .struct(let structDescription): return structDescription.accessModifier
@@ -1685,6 +1724,9 @@ extension Declaration {
             case .deprecated(let deprecationDescription, var declaration):
                 declaration.accessModifier = newValue
                 self = .deprecated(deprecationDescription, declaration)
+            case .attributes(let attributes, var declaration):
+                declaration.accessModifier = newValue
+                self = .attributes(attributes, declaration)
             case .variable(var variableDescription):
                 variableDescription.accessModifier = newValue
                 self = .variable(variableDescription)

--- a/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
+++ b/Sources/_OpenAPIGeneratorCore/Renderer/TextBasedRenderer.swift
@@ -713,6 +713,8 @@ struct TextBasedRenderer: RendererProtocol {
             renderCommentableDeclaration(comment: comment, declaration: nestedDeclaration)
         case let .deprecated(deprecation, nestedDeclaration):
             renderDeprecatedDeclaration(deprecation: deprecation, declaration: nestedDeclaration)
+        case let .attributes(attributes, nestedDeclaration):
+            renderAttributesDeclaration(attributes: attributes, declaration: nestedDeclaration)
         case .variable(let variableDescription): renderVariable(variableDescription)
         case .extension(let extensionDescription): renderExtension(extensionDescription)
         case .struct(let structDescription): renderStruct(structDescription)
@@ -831,6 +833,12 @@ struct TextBasedRenderer: RendererProtocol {
     /// Renders the specified declaration with a deprecation annotation.
     func renderDeprecatedDeclaration(deprecation: DeprecationDescription, declaration: Declaration) {
         renderDeprecation(deprecation)
+        renderDeclaration(declaration)
+    }
+
+    /// Renders the specified declaration with Swift attributes.
+    func renderAttributesDeclaration(attributes: [AttributeDescription], declaration: Declaration) {
+        for attribute in attributes { writer.writeLine("@\(attribute.name)") }
         renderDeclaration(declaration)
     }
 

--- a/Sources/_OpenAPIGeneratorCore/Translator/Recursion/DeclarationRecursionDetector.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/Recursion/DeclarationRecursionDetector.swift
@@ -89,7 +89,7 @@ extension Declaration {
         case .struct(let desc): return desc.name
         case .enum(let desc): return desc.name
         case .typealias(let desc): return desc.name
-        case .commentable(_, let decl), .deprecated(_, let decl): return decl.name
+        case .commentable(_, let decl), .deprecated(_, let decl), .attributes(_, let decl): return decl.name
         case .variable, .extension, .protocol, .function, .enumCase: return nil
         }
     }
@@ -98,7 +98,7 @@ extension Declaration {
     var isBoxable: Bool {
         switch self {
         case .struct, .enum: return true
-        case .commentable(_, let decl), .deprecated(_, let decl): return decl.isBoxable
+        case .commentable(_, let decl), .deprecated(_, let decl), .attributes(_, let decl): return decl.isBoxable
         case .typealias, .variable, .extension, .protocol, .function, .enumCase: return false
         }
     }
@@ -126,7 +126,7 @@ extension Declaration {
                     return member.schemaComponentNamesOfUnbreakableReferences
                 }
                 .flatMap { $0 }
-        case .commentable(_, let decl), .deprecated(_, let decl):
+        case .commentable(_, let decl), .deprecated(_, let decl), .attributes(_, let decl):
             return decl.schemaComponentNamesOfUnbreakableReferences
         case .typealias(let desc): return desc.existingType.referencedSchemaComponentName.map { [$0] } ?? []
         case .variable(let desc): return desc.type?.referencedSchemaComponentName.map { [$0] } ?? []

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateAPIProtocol.swift
@@ -33,7 +33,8 @@ extension TypesFileTranslator {
         )
         let protocolComment: Comment = .doc("A type that performs HTTP operations defined by the OpenAPI document.")
 
-        return .commentable(protocolComment, .protocol(protocolDescription))
+        let protocolDecl: Declaration = .protocol(protocolDescription)
+        return .commentable(protocolComment, protocolDecl.withAttributes(config.attributes.protocolAttributes))
     }
 
     /// Returns an extension to the `APIProtocol` protocol, with some syntactic sugar APIs.
@@ -102,6 +103,11 @@ extension TypesFileTranslator {
         let operationComment = description.comment
         let signature = description.protocolSignatureDescription
         let function = FunctionDescription(signature: signature)
-        return .commentable(operationComment, .function(function).deprecate(if: description.operation.deprecated))
+        let functionDecl: Declaration = .function(function)
+        return .commentable(
+            operationComment,
+            functionDecl.withAttributes(config.attributes.methodAttributes)
+                .deprecate(if: description.operation.deprecated)
+        )
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
@@ -53,6 +53,8 @@ extension TypesFileTranslator {
         case .commentable(let comment, let declaration): return .commentable(comment, boxedType(declaration))
         case .deprecated(let deprecationDescription, let declaration):
             return .deprecated(deprecationDescription, boxedType(declaration))
+        case .attributes(let attributes, let declaration):
+            return .attributes(attributes, boxedType(declaration))
         case .struct(let structDescription): return .struct(boxedStruct(structDescription))
         case .enum(let enumDescription): return .enum(boxedEnum(enumDescription))
         case .variable, .extension, .typealias, .protocol, .function, .enumCase:

--- a/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
@@ -37,6 +37,7 @@ extension _GenerateOptions {
         let resolvedNameOverrides = resolvedNameOverrides(config)
         let resolvedTypeOverrides = resolvedTypeOverrides(config)
         let resolvedFeatureFlags = resolvedFeatureFlags(config)
+        let resolvedAttributes = resolvedAttributes(config)
         let configs: [Config] = sortedModes.map {
             .init(
                 mode: $0,
@@ -47,7 +48,8 @@ extension _GenerateOptions {
                 namingStrategy: resolvedNamingStragy,
                 nameOverrides: resolvedNameOverrides,
                 typeOverrides: resolvedTypeOverrides,
-                featureFlags: resolvedFeatureFlags
+                featureFlags: resolvedFeatureFlags,
+                attributes: resolvedAttributes
             )
         }
         let (diagnostics, finalizeDiagnostics) = preparedDiagnosticsCollector(outputPath: diagnosticsOutputPath)

--- a/Sources/swift-openapi-generator/GenerateOptions.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions.swift
@@ -151,6 +151,11 @@ extension _GenerateOptions {
         return config?.featureFlags ?? []
     }
 
+    /// Returns the attribute configuration requested by the user.
+    /// - Parameter config: The configuration specified by the user.
+    /// - Returns: The attribute configuration requested by the user.
+    func resolvedAttributes(_ config: _UserConfig?) -> AttributeConfiguration { config?.attributes ?? .default }
+
     /// Validates a collection of keys against a predefined set of allowed keys.
     ///
     /// - Parameter keys: A collection of keys to be validated.

--- a/Sources/swift-openapi-generator/UserConfig.swift
+++ b/Sources/swift-openapi-generator/UserConfig.swift
@@ -51,6 +51,9 @@ struct _UserConfig: Codable {
     /// A set of features to explicitly enable.
     var featureFlags: FeatureFlags?
 
+    /// Swift attributes to add to generated API protocol declarations.
+    var attributes: AttributeConfiguration?
+
     /// A set of raw values corresponding to the coding keys of this struct.
     static let codingKeysRawValues = Set(CodingKeys.allCases.map({ $0.rawValue }))
 
@@ -64,6 +67,7 @@ struct _UserConfig: Codable {
         case nameOverrides
         case typeOverrides
         case featureFlags
+        case attributes
     }
 
     /// A container of type overrides.

--- a/Tests/OpenAPIGeneratorCoreTests/StructureHelpers.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/StructureHelpers.swift
@@ -16,6 +16,7 @@ import Foundation
 
 enum DeclKind: String, Equatable, CustomStringConvertible {
     case deprecated
+    case attributes
     case variable
     case `extension`
     case `struct`
@@ -101,6 +102,7 @@ extension Declaration {
     var info: DeclInfo {
         switch strippingTopComment {
         case .deprecated: return .init(kind: .deprecated)
+        case .attributes: return .init(kind: .attributes)
         case let .variable(description):
             return .init(name: TextBasedRenderer.renderedExpressionAsString(description.left), kind: .variable)
         case let .`extension`(description): return .init(name: description.onType, kind: .`extension`)

--- a/Tests/OpenAPIGeneratorCoreTests/Test_AttributeConfiguration.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Test_AttributeConfiguration.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import Yams
+@testable import _OpenAPIGeneratorCore
+
+final class Test_AttributeConfiguration: Test_Core {
+    func testAttributeConfigurationDecoding() throws {
+        let yaml = """
+            protocol:
+              - MainActor
+            methods:
+              - MainActor
+            """
+        let decoded = try YAMLDecoder().decode(AttributeConfiguration.self, from: yaml)
+        XCTAssertEqual(decoded.protocolAttributes, ["MainActor"])
+        XCTAssertEqual(decoded.methodAttributes, ["MainActor"])
+    }
+
+    func testAttributeConfigurationDecodingWithQuotedArguments() throws {
+        let yaml = """
+            methods:
+              - "Mockable(visibility: .public)"
+            """
+        let decoded = try YAMLDecoder().decode(AttributeConfiguration.self, from: yaml)
+        XCTAssertEqual(decoded.methodAttributes, ["Mockable(visibility: .public)"])
+    }
+}

--- a/Tests/OpenAPIGeneratorCoreTests/Test_Config.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Test_Config.swift
@@ -30,4 +30,9 @@ final class Test_Config: Test_Core {
         let config = Config(mode: .types, access: .public, namingStrategy: .defensive)
         XCTAssertEqual(config.additionalFileComments, [])
     }
+
+    func testDefaultAttributeConfiguration() {
+        let config = Config(mode: .types, access: .public, namingStrategy: .defensive)
+        XCTAssertEqual(config.attributes, .default)
+    }
 }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -2368,6 +2368,35 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testPaths_withConfiguredAttributes() throws {
+        let paths = """
+            /health:
+              get:
+                operationId: getHealth
+                responses:
+                  '200':
+                    description: A success response with a greeting.
+                    content:
+                      text/plain:
+                        schema:
+                          type: string
+            """
+        try self.assertPathsTranslation(
+            paths,
+            attributes: AttributeConfiguration(
+                protocolAttributes: ["MainActor"],
+                methodAttributes: ["MainActor"]
+            ),
+            """
+            @MainActor
+            public protocol APIProtocol: Sendable {
+                @MainActor
+                func getHealth(_ input: Operations.getHealth.Input) async throws -> Operations.getHealth.Output
+            }
+            """
+        )
+    }
+
     func testSynthesizedOperationId_defensive() throws {
         let paths = """
             /pets/{petId}/notifications:
@@ -6253,6 +6282,7 @@ extension SnippetBasedReferenceTests {
         nameOverrides: [String: String] = [:],
         typeOverrides: TypeOverrides = .init(),
         featureFlags: FeatureFlags = [],
+        attributes: AttributeConfiguration = .default,
         ignoredDiagnosticMessages: Set<String> = [],
         componentsYAML: String
     ) throws -> TypesFileTranslator {
@@ -6264,7 +6294,8 @@ extension SnippetBasedReferenceTests {
                 namingStrategy: namingStrategy,
                 nameOverrides: nameOverrides,
                 typeOverrides: typeOverrides,
-                featureFlags: featureFlags
+                featureFlags: featureFlags,
+                attributes: attributes
             ),
             diagnostics: XCTestDiagnosticCollector(test: self, ignoredDiagnosticMessages: ignoredDiagnosticMessages),
             components: components
@@ -6530,11 +6561,16 @@ extension SnippetBasedReferenceTests {
         _ pathsYAML: String,
         componentsYAML: String = "{}",
         namingStrategy: NamingStrategy = .defensive,
+        attributes: AttributeConfiguration = .default,
         _ expectedSwift: String,
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
-        let translator = try makeTypesTranslator(namingStrategy: namingStrategy, componentsYAML: componentsYAML)
+        let translator = try makeTypesTranslator(
+            namingStrategy: namingStrategy,
+            attributes: attributes,
+            componentsYAML: componentsYAML
+        )
         let paths = try YAMLDecoder().decode(OpenAPI.PathItem.Map.self, from: pathsYAML)
         let translation = try translator.translateAPIProtocol(paths)
         try XCTAssertSwiftEquivalent(translation, expectedSwift, file: file, line: line)
@@ -6672,6 +6708,7 @@ fileprivate extension Declaration {
         switch decl {
         case let .commentable(_, d): return stripComments(d)
         case let .deprecated(a, b): return .deprecated(a, stripComments(b))
+        case let .attributes(a, b): return .attributes(a, stripComments(b))
         case var .protocol(p):
             p.members = p.members.map(stripComments(_:))
             return .protocol(p)


### PR DESCRIPTION
### Motivation

Generated client and server code often needs Swift attributes on the `APIProtocol` type and its operation requirements—for example `@MainActor` for concurrency isolation or macro-driven attributes such as `@Mockable`. Today there is no supported way to express those attributes in generator configuration, so adopters must post-process generated `Types.swift` or maintain local forks.

### Modifications

- Add `AttributeConfiguration` and `AttributeDescription` to model optional Swift attributes in config.
- Extend `Config`, `_UserConfig`, and CLI `GenerateOptions` with an `attributes` field.
- Decode YAML `attributes:` using `protocol` and `methods` keys (each a list of attribute names or quoted strings with arguments).
- Extend the structured Swift representation and text renderer to emit attribute declarations.
- Apply configured attributes when translating `APIProtocol` and its method requirements in `Types.swift`; OpenAPI-driven `@available(*, deprecated, …)` remains unchanged and is still applied from operation metadata.
- Document that consumers remain responsible for wiring any required dependencies in `Package.swift`, macro plugins, and `additionalImports` when attributes reference external types or macros.

### Result

Adopters can configure attributes in `openapi-generator-config.yaml` (or equivalent) and regenerate `Types.swift` with the requested `@` attributes on `APIProtocol` and each operation requirement, without manual edits to generated output.

Example:

```yaml
attributes:
  protocol:
    - MainActor
  methods:
    - MainActor
```

### Test Plan

- Added `Test_AttributeConfiguration` for YAML decoding of `protocol` / `methods`, including quoted attribute arguments.
- Extended `Test_Config` to cover the new configuration surface.
- Added `testPaths_withConfiguredAttributes` snippet reference test for generated `APIProtocol` output.
- Ran `swift test --filter OpenAPIGeneratorCoreTests` (116 tests, all passing).

### Related issues

- https://github.com/apple/swift-openapi-generator/issues/383 — Request to attach macros (and similar attributes) to generated types and methods; this change adds configuration-driven attributes on `APIProtocol` and its operation requirements.
- https://github.com/apple/swift-openapi-generator/issues/796 — Build failures under Xcode 26 default `MainActor` isolation; configuring `@MainActor` on generated `APIProtocol` and methods is a supported way to align generated code with project concurrency settings.