### PR TITLE
Emit per-operation security metadata behind a feature flag (SOAR-0015)

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
+++ b/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift
@@ -26,8 +26,14 @@
 /// 0.2 is tagged. (This is for pre-1.0 versioning, would be 1.0 and 2.0 after
 /// 1.0 is released.)
 public enum FeatureFlag: String, Hashable, Codable, CaseIterable, Sendable {
-    // needs to be here for the enum to compile
-    case empty
+    /// Emit per-operation OpenAPI security requirements as generated metadata.
+    ///
+    /// When enabled, each `Operations.<Name>` namespace gains a
+    /// `securityRequirements` property, and a top-level `OperationSecurity`
+    /// namespace exposes a `requirementsByOperationID` map, both typed as
+    /// `OpenAPIRuntime.SecurityRequirement`. A client middleware can consume
+    /// these to apply authentication only to the operations that require it.
+    case securityMetadata
 }
 
 /// A set of enabled feature flags.

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTypes/Constants.swift
@@ -183,6 +183,15 @@ enum Constants {
 
         /// The name of the namespace.
         static let namespace: String = "Operations"
+
+        /// The name of the per-operation security requirements property.
+        static let securityRequirementsPropertyName: String = "securityRequirements"
+
+        /// The name of the namespace that exposes the operation-security lookup.
+        static let securityNamespace: String = "OperationSecurity"
+
+        /// The name of the operationID-keyed security requirements map.
+        static let requirementsByOperationIDPropertyName: String = "requirementsByOperationID"
     }
 
     /// Constants related to the generated protocol that contains one

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
@@ -46,16 +46,17 @@ struct TypesFileTranslator: FileTranslator {
         let components = try translateComponents(doc.components, multipartSchemaNames: multipartSchemaNames)
 
         let operationDescriptions = try OperationDescription.all(from: doc.paths, in: doc.components, context: context)
-        let operations = try translateOperations(operationDescriptions)
+        let operations = try translateOperations(operationDescriptions, documentSecurity: doc.security)
 
-        let typesFile = FileDescription(
-            topComment: topComment,
-            imports: imports,
-            codeBlocks: [
-                .declaration(apiProtocol), .declaration(apiProtocolExtension), .declaration(serversDecl), components,
-                operations,
-            ]
-        )
+        var codeBlocks: [CodeBlock] = [
+            .declaration(apiProtocol), .declaration(apiProtocolExtension), .declaration(serversDecl), components,
+            operations,
+        ]
+        if config.featureFlags.contains(.securityMetadata) {
+            codeBlocks.append(.declaration(translateOperationSecurityNamespace(operationDescriptions)))
+        }
+
+        let typesFile = FileDescription(topComment: topComment, imports: imports, codeBlocks: codeBlocks)
 
         return StructuredSwiftRepresentation(file: .init(name: GeneratorMode.types.outputFileName, contents: typesFile))
     }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperationSecurity.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperationSecurity.swift
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import OpenAPIKit
+
+extension TypesFileTranslator {
+
+    /// The Swift type `[OpenAPIRuntime.SecurityRequirement]`.
+    private var securityRequirementsArrayType: ExistingTypeDescription {
+        .array(.init(TypeName.runtime("SecurityRequirement")))
+    }
+
+    /// Returns the security requirements that apply to the operation.
+    ///
+    /// An operation that does not declare `security` inherits the document-level
+    /// requirements; an operation that declares `security: []` is explicitly
+    /// public and returns an empty array.
+    /// - Parameters:
+    ///   - operation: The operation whose requirements to resolve.
+    ///   - documentSecurity: The document-level security requirements.
+    /// - Returns: The effective OR-list of security requirements.
+    private func effectiveSecurityRequirements(
+        for operation: OperationDescription,
+        documentSecurity: [OpenAPI.SecurityRequirement]
+    ) -> [OpenAPI.SecurityRequirement] {
+        operation.operation.security ?? documentSecurity
+    }
+
+    /// Returns an expression constructing the `[OpenAPIRuntime.SecurityRequirement]`
+    /// value for the provided OpenAPI security requirements.
+    ///
+    /// The outer array is an OR-list of alternatives; each requirement is an
+    /// AND-group of schemes.
+    /// - Parameters:
+    ///   - requirements: The OpenAPI security requirements (OR-list).
+    ///   - components: The components used to resolve security scheme references.
+    /// - Returns: An array-literal expression.
+    /// - Throws: If a scheme reference cannot be resolved or uses an unsupported type.
+    private func translateSecurityRequirements(
+        _ requirements: [OpenAPI.SecurityRequirement],
+        components: OpenAPI.Components
+    ) throws -> Expression {
+        let requirementExprs = try requirements.map { requirement in
+            try translateSecurityRequirement(requirement, components: components)
+        }
+        return .literal(.array(requirementExprs))
+    }
+
+    /// Returns an expression constructing a single `SecurityRequirement` value
+    /// (an AND-group of schemes).
+    private func translateSecurityRequirement(
+        _ requirement: OpenAPI.SecurityRequirement,
+        components: OpenAPI.Components
+    ) throws -> Expression {
+        // Security requirements are a dictionary keyed by an (unordered) scheme
+        // reference, so sort by scheme name to keep generated output stable.
+        let schemes =
+            try requirement
+            .map { reference, scopes -> (name: String, scheme: OpenAPI.SecurityScheme, scopes: [String]) in
+                guard let name = reference.name else {
+                    throw GenericError(message: "Security scheme reference has no name: \(reference.absoluteString)")
+                }
+                guard let scheme = components[reference] else {
+                    throw GenericError(message: "Undefined security scheme: \(reference.absoluteString)")
+                }
+                return (name, scheme, scopes)
+            }
+            .sorted { $0.name < $1.name }
+        let schemeExprs = try schemes.map { entry in
+            try translateSecurityScheme(name: entry.name, scheme: entry.scheme, scopes: entry.scopes)
+        }
+        return .dot("init").call([.init(label: "schemes", expression: .literal(.array(schemeExprs)))])
+    }
+
+    /// Returns an expression constructing a single `SecurityRequirement.Scheme` value.
+    private func translateSecurityScheme(
+        name: String,
+        scheme: OpenAPI.SecurityScheme,
+        scopes: [String]
+    ) throws -> Expression {
+        try .dot("init")
+            .call([
+                .init(label: "name", expression: .literal(name)),
+                .init(label: "kind", expression: translateSecuritySchemeKind(scheme.type)),
+                .init(label: "scopes", expression: .literal(.array(scopes.map { .literal($0) }))),
+            ])
+    }
+
+    /// Returns an expression constructing a `SecurityRequirement.Scheme.Kind` value.
+    private func translateSecuritySchemeKind(_ type: OpenAPI.SecurityScheme.SecurityType) throws -> Expression {
+        switch type {
+        case .apiKey(let name, let location):
+            return .dot("apiKey")
+                .call([
+                    .init(label: "name", expression: .literal(name)),
+                    .init(label: "location", expression: .dot(location.rawValue)),
+                ])
+        case .http(let scheme, let bearerFormat):
+            return .dot("http")
+                .call([
+                    .init(label: "scheme", expression: .literal(scheme.lowercased())),
+                    .init(label: "bearerFormat", expression: bearerFormat.map { .literal($0) } ?? .literal(.nil)),
+                ])
+        case .oauth2:
+            return .dot("oauth2")
+        case .openIdConnect(let url):
+            return .dot("openIdConnect").call([.init(label: "url", expression: .literal(url.absoluteString))])
+        case .mutualTLS:
+            throw GenericError(message: "mutualTLS security schemes are not supported by the securityMetadata feature.")
+        }
+    }
+
+    /// Returns the per-operation `securityRequirements` static property declaration.
+    /// - Parameters:
+    ///   - operation: The operation to translate.
+    ///   - documentSecurity: The document-level security requirements.
+    /// - Returns: A variable declaration.
+    /// - Throws: If a scheme reference cannot be resolved or uses an unsupported type.
+    func translateOperationSecurityRequirements(
+        _ operation: OperationDescription,
+        documentSecurity: [OpenAPI.SecurityRequirement]
+    ) throws -> Declaration {
+        let requirements = effectiveSecurityRequirements(for: operation, documentSecurity: documentSecurity)
+        let value = try translateSecurityRequirements(requirements, components: operation.components)
+        return .variable(
+            accessModifier: config.access,
+            isStatic: true,
+            kind: .let,
+            left: Constants.Operations.securityRequirementsPropertyName,
+            type: securityRequirementsArrayType,
+            right: value
+        )
+    }
+
+    /// Returns the `OperationSecurity` namespace declaration, exposing a map
+    /// from operation ID to the operation's security requirements.
+    /// - Parameter operations: The operations defined in the OpenAPI document.
+    /// - Returns: An enum declaration.
+    func translateOperationSecurityNamespace(_ operations: [OperationDescription]) -> Declaration {
+        let entries: [Expression] = operations.map { operation in
+            let operationRef = Expression.identifierPattern(Constants.Operations.namespace)
+                .dot(operation.operationNamespace.shortSwiftName)
+            return .tuple([
+                .literal(operation.operationID),
+                operationRef.dot(Constants.Operations.securityRequirementsPropertyName),
+            ])
+        }
+        let mapDecl = Declaration.variable(
+            accessModifier: config.access,
+            isStatic: true,
+            kind: .let,
+            left: Constants.Operations.requirementsByOperationIDPropertyName,
+            type: .dictionaryValue(securityRequirementsArrayType),
+            right: .identifierPattern("Dictionary")
+                .call([.init(label: "uniqueKeysWithValues", expression: .literal(.array(entries)))])
+        )
+        return .commentable(
+            .doc("The security requirements of each operation, keyed by operation ID."),
+            .enum(accessModifier: config.access, name: Constants.Operations.securityNamespace, members: [mapDecl])
+        )
+    }
+}

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateOperations.swift
@@ -215,11 +215,17 @@ extension TypesFileTranslator {
     ///
     /// The namespace type is the parent type of the operation's Input and
     /// Output types, and ties the two types together.
-    /// - Parameter operation: The OpenAPI operation.
+    /// - Parameters:
+    ///   - operation: The OpenAPI operation.
+    ///   - documentSecurity: The document-level security requirements, inherited
+    ///     by operations that do not declare their own.
     /// - Returns: An enum declaration that represents the operation's
     /// namespace.
     /// - Throws: An error if there's an issue during translation of the operation's namespace.
-    func translateOperation(_ operation: OperationDescription) throws -> Declaration {
+    func translateOperation(
+        _ operation: OperationDescription,
+        documentSecurity: [OpenAPI.SecurityRequirement]
+    ) throws -> Declaration {
 
         let idPropertyDecl: Declaration = .variable(
             accessModifier: config.access,
@@ -229,6 +235,10 @@ extension TypesFileTranslator {
             type: .init(TypeName.string),
             right: .literal(operation.operationID)
         )
+
+        let securityDecl: Declaration? =
+            config.featureFlags.contains(.securityMetadata)
+            ? try translateOperationSecurityRequirements(operation, documentSecurity: documentSecurity) : nil
 
         let inputDecl: Declaration = try translateOperationInput(operation)
         let outputDecl: Declaration = try translateOperationOutput(operation)
@@ -240,7 +250,8 @@ extension TypesFileTranslator {
             .enum(
                 accessModifier: config.access,
                 name: operationNamespace.shortSwiftName,
-                members: [idPropertyDecl, inputDecl, outputDecl] + (acceptDecl.flatMap { [$0] } ?? [])
+                members: [idPropertyDecl] + (securityDecl.flatMap { [$0] } ?? []) + [inputDecl, outputDecl]
+                    + (acceptDecl.flatMap { [$0] } ?? [])
             )
         )
         return operationEnumDecl
@@ -248,13 +259,21 @@ extension TypesFileTranslator {
 
     /// Returns a declaration of a code block that contains the namespace
     /// for all the operations defined in the OpenAPI document.
-    /// - Parameter operations: The operations defined in the OpenAPI document.
+    /// - Parameters:
+    ///   - operations: The operations defined in the OpenAPI document.
+    ///   - documentSecurity: The document-level security requirements, inherited
+    ///     by operations that do not declare their own.
     /// - Returns: A code block that contains an enum declaration with a
     /// separate namespace type for each operation.
     /// - Throws: An error if there is an issue during operation translation.
-    func translateOperations(_ operations: [OperationDescription]) throws -> CodeBlock {
+    func translateOperations(
+        _ operations: [OperationDescription],
+        documentSecurity: [OpenAPI.SecurityRequirement]
+    ) throws -> CodeBlock {
 
-        let operationDecls = try operations.map(translateOperation)
+        let operationDecls = try operations.map { operation in
+            try translateOperation(operation, documentSecurity: documentSecurity)
+        }
 
         let operationsEnum = CodeBlock(
             comment: .operationsNamespace(),

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Supported-OpenAPI-features.md
@@ -35,7 +35,7 @@ For any other formats, the payload is provided as raw bytes (using the `HTTPBody
 - [x] servers
 - [x] paths
 - [x] components
-- [ ] security
+- [x] security (with the `securityMetadata` feature flag)
 - [ ] tags
 - [ ] externalDocs
 
@@ -96,7 +96,7 @@ For any other formats, the payload is provided as raw bytes (using the `HTTPBody
 - [x] responses
 - [ ] callbacks
 - [x] deprecated
-- [ ] security
+- [x] security (with the `securityMetadata` feature flag)
 - [ ] servers
 
 #### Request Body Object
@@ -114,7 +114,7 @@ For any other formats, the payload is provided as raw bytes (using the `HTTPBody
 
 #### Security Requirement Object
 
-- [ ] map from name pattern to a list of strings
+- [x] map from name pattern to a list of strings (with the `securityMetadata` feature flag)
 
 #### Responses Object
 
@@ -260,7 +260,7 @@ For any other formats, the payload is provided as raw bytes (using the `HTTPBody
 - [ ] examples
 - [x] requestBodies (always inlined)
 - [x] headers
-- [ ] securitySchemes
+- [x] securitySchemes (with the `securityMetadata` feature flag)
 - [ ] links
 - [ ] callbacks
 
@@ -281,14 +281,16 @@ For any other formats, the payload is provided as raw bytes (using the `HTTPBody
 
 #### Security Scheme Object
 
-- [ ] type
+The following are supported with the `securityMetadata` feature flag.
+
+- [x] type
 - [ ] description
-- [ ] name
-- [ ] in
-- [ ] scheme
-- [ ] bearerFormat
+- [x] name
+- [x] in
+- [x] scheme
+- [x] bearerFormat
 - [ ] flows
-- [ ] openIdConnectUrl
+- [x] openIdConnectUrl
 
 #### OAuth Flows Object
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/Proposals.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/Proposals.md
@@ -56,3 +56,4 @@ If you have any questions, tag [Honza Dvorsky](https://github.com/czechboy0) or 
 - <doc:SOAR-0012>
 - <doc:SOAR-0013>
 - <doc:SOAR-0014>
+- <doc:SOAR-0015>

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
@@ -1,0 +1,102 @@
+# SOAR-0015: Generated security metadata
+
+Emit each operation's OpenAPI security requirements as generated Swift values so client middleware can apply authentication only where it is required.
+
+## Overview
+
+- Proposal: SOAR-0015
+- Author(s): [Vikram Singh](https://github.com/vdsingh)
+- Status: **Awaiting Review**
+- Issue: [apple/swift-openapi-generator#37](https://github.com/apple/swift-openapi-generator/issues/37)
+- Implementation:
+    - Runtime: [apple/swift-openapi-runtime](https://github.com/apple/swift-openapi-runtime) — `SecurityRequirement` value types
+    - Generator: [apple/swift-openapi-generator](https://github.com/apple/swift-openapi-generator) — `securityMetadata` feature flag
+- Feature flag: `securityMetadata`
+- Affected components:
+    - generator
+    - runtime
+- Related links:
+    - [OpenAPI Security Requirement Object](https://spec.openapis.org/oas/v3.1.0#security-requirement-object)
+    - [apple/swift-openapi-generator#551](https://github.com/apple/swift-openapi-generator/issues/551)
+
+### Introduction
+
+Generate, behind a feature flag, a machine-readable description of each operation's security requirements that authentication middleware can consult at runtime.
+
+### Motivation
+
+Swift OpenAPI Generator currently discards the OpenAPI `security` and `securitySchemes` sections entirely — the generated `Types.swift` and `Client.swift` contain no reference to them. Authentication is left to a `ClientMiddleware`, which receives only the `operationID` string and has no way to learn which operations require authentication, or which scheme.
+
+As a result, adopters must either apply credentials unconditionally to every request (as the `auth-client-middleware-example` does) or hand-maintain a list of which operations require auth. The former sends credentials to endpoints that do not need them and cannot fail fast when a required credential is missing; the latter drifts out of sync with the OpenAPI document. There is no way for a middleware to apply authentication *only* to the operations that declare it (see also #551).
+
+### Proposed solution
+
+When the `securityMetadata` feature flag is enabled, the generator emits, for each operation, the security requirements declared in the OpenAPI document.
+
+Each `Operations.<Name>` namespace gains a `securityRequirements` property, and a top-level `OperationSecurity` namespace exposes a map keyed by operation ID:
+
+```swift
+public enum Operations {
+    public enum getGreeting {
+        public static let id: String = "getGreeting"
+        public static let securityRequirements: [OpenAPIRuntime.SecurityRequirement] = [
+            .init(schemes: [.init(name: "OAuth2", kind: .oauth2, scopes: ["read"])])
+        ]
+    }
+}
+
+public enum OperationSecurity {
+    public static let requirementsByOperationID: [String: [OpenAPIRuntime.SecurityRequirement]] =
+        Dictionary(uniqueKeysWithValues: [
+            ("getGreeting", Operations.getGreeting.securityRequirements)
+        ])
+}
+```
+
+The semantics mirror the OpenAPI specification exactly: the outer array is an OR-group of alternatives, each `SecurityRequirement.schemes` is an AND-group that must all be satisfied, and an empty array (`[]`) means the operation explicitly opts out of security. An operation without a `security` field inherits the document-level requirements.
+
+A middleware — supplied by the adopter, or by a future runtime addition (see Future directions) — can then look up the current `operationID`, inject the correct credential for each scheme in the right location, and fail fast before the request is sent when a required credential is unavailable:
+
+```swift
+let client = Client(
+    serverURL: url,
+    transport: transport,
+    middlewares: [
+        SecuritySchemeMiddleware(
+            requirements: OperationSecurity.requirementsByOperationID,
+            credentials: ["OAuth2": .bearer { await tokenStore.token() }]
+        )
+    ]
+)
+```
+
+This is opt-in and purely additive: with the flag off, generated output is unchanged.
+
+### Detailed design
+
+Two pieces land independently:
+
+1. **Runtime.** `swift-openapi-runtime` gains value types describing a resolved security requirement — `SecurityRequirement`, its nested `Scheme` (name, kind, operation-required scopes), `Scheme.Kind` (`apiKey`, `http`, `oauth2`, `openIdConnect`, `mutualTLS`), and `Scheme.Location` (`query`/`header`/`cookie`). They are `public`, `Sendable`, and `Hashable`, and carry no behavior. They are user-facing because adopter middleware consumes them, so they are not confined to the `Generated` SPI.
+
+2. **Generator.** A new `securityMetadata` feature flag gates emission in `TypesFileTranslator`. For each operation the translator resolves the effective requirements (`operation.security ?? document.security`), dereferences each scheme against `components.securitySchemes`, maps the OpenAPIKit `SecurityScheme.SecurityType` onto the runtime `Kind`, and emits the values as Swift literals. Each AND-group is sorted by scheme name so output is deterministic (the OpenAPI requirement is an unordered map). Unsupported cases (`mutualTLS`, non-`bearer`/`basic` HTTP schemes) raise a diagnostic rather than emitting incorrect metadata.
+
+### API stability
+
+- **runtime public API:** additive. New `SecurityRequirement` value types. No changes to existing symbols.
+- **runtime "Generated" SPI:** unchanged.
+- **existing transport and middleware implementations:** unaffected; they continue to work without adopting the metadata.
+- **generator implementation affected by runtime API changes:** the generator references the new runtime types by name in emitted code; no source dependency at generation time.
+- **generator API (config file, CLI, plugin):** additive. The `securityMetadata` value becomes accepted by the existing `--feature-flag` option and `featureFlags` config key.
+- **existing and new generated adopter code:** with the flag off, generated code is byte-identical. With the flag on, only new members are added; existing members are unchanged.
+
+### Future directions
+
+- Ship a general-purpose conditional-authentication `ClientMiddleware` in the runtime (or as an example) that consumes `requirementsByOperationID`, resolving #551.
+- Model OAuth 2.0 flow details and scheme descriptions if a concrete use case emerges.
+- Graduate the flag to default-on in a future major version once the shape has proven stable.
+
+### Alternatives considered
+
+- **Generate a `Bool`/`Set<String>` of authenticated operations.** Smaller, but a consumer could not tell which scheme applies or where to place the credential, so automatic injection would be impossible.
+- **Emit the metadata types into each generated module instead of the runtime.** Avoids a runtime change but duplicates identical spec-vocabulary types across modules and prevents a shared middleware from consuming them.
+- **A `ClientMiddleware` that reads security from a side channel.** Rejected: the middleware only receives an `operationID`, and the security information is exactly what is missing today.

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
@@ -9,8 +9,8 @@ Emit each operation's OpenAPI security requirements as generated Swift values so
 - Status: **Awaiting Review**
 - Issue: [apple/swift-openapi-generator#37](https://github.com/apple/swift-openapi-generator/issues/37)
 - Implementation:
-    - Runtime: [apple/swift-openapi-runtime](https://github.com/apple/swift-openapi-runtime) — `SecurityRequirement` value types
-    - Generator: [apple/swift-openapi-generator](https://github.com/apple/swift-openapi-generator) — `securityMetadata` feature flag
+    - Runtime: [apple/swift-openapi-runtime#203](https://github.com/apple/swift-openapi-runtime/pull/203) — `SecurityRequirement` value types
+    - Generator: [apple/swift-openapi-generator#927](https://github.com/apple/swift-openapi-generator/pull/927) — `securityMetadata` feature flag
 - Feature flag: `securityMetadata`
 - Affected components:
     - generator

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -6472,6 +6472,170 @@ final class SnippetBasedReferenceTests: XCTestCase {
     }
 }
 extension SnippetBasedReferenceTests {
+
+    /// An OpenAPI document exercising document-level, operation-level, and
+    /// explicitly-public security, across apiKey / http-bearer / oauth2 schemes.
+    private static let securityMetadataDocumentYAML = """
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        security:
+          - oauth: [read]
+        paths:
+          /inherits:
+            get:
+              operationId: inheritsDocSecurity
+              responses:
+                '200': { description: ok }
+          /overrides:
+            get:
+              operationId: overridesSecurity
+              security:
+                - apiKeyAuth: []
+                  bearerAuth: []
+                - oauth: [read, write]
+              responses:
+                '200': { description: ok }
+          /public:
+            get:
+              operationId: explicitlyPublic
+              security: []
+              responses:
+                '200': { description: ok }
+        components:
+          securitySchemes:
+            apiKeyAuth:
+              type: apiKey
+              in: header
+              name: X-API-Key
+            bearerAuth:
+              type: http
+              scheme: bearer
+              bearerFormat: JWT
+            oauth:
+              type: oauth2
+              flows:
+                authorizationCode:
+                  authorizationUrl: https://example.com/auth
+                  tokenUrl: https://example.com/token
+                  scopes:
+                    read: Read
+                    write: Write
+        """
+
+    private func makeSecurityMetadataFixture(featureFlags: FeatureFlags = [.securityMetadata]) throws -> (
+        translator: TypesFileTranslator, operations: [OperationDescription], documentSecurity: [OpenAPI.SecurityRequirement]
+    ) {
+        let document = try YAMLDecoder().decode(OpenAPI.Document.self, from: Self.securityMetadataDocumentYAML)
+        let translator = TypesFileTranslator(
+            config: Config(mode: .types, access: .public, namingStrategy: .defensive, featureFlags: featureFlags),
+            diagnostics: XCTestDiagnosticCollector(test: self),
+            components: document.components
+        )
+        let operations = try OperationDescription.all(
+            from: document.paths,
+            in: document.components,
+            context: translator.context
+        )
+        return (translator, operations, document.security)
+    }
+
+    private func securityRequirementsDecl(forOperationID id: String) throws -> Declaration {
+        let (translator, operations, documentSecurity) = try makeSecurityMetadataFixture()
+        let operation = try XCTUnwrap(operations.first { $0.operationID == id })
+        return try translator.translateOperationSecurityRequirements(operation, documentSecurity: documentSecurity)
+    }
+
+    func testSecurityMetadata_inheritsDocumentLevel() throws {
+        try XCTAssertSwiftEquivalent(
+            securityRequirementsDecl(forOperationID: "inheritsDocSecurity"),
+            """
+            public static let securityRequirements: [OpenAPIRuntime.SecurityRequirement] = [
+                .init(schemes: [
+                    .init(
+                        name: "oauth",
+                        kind: .oauth2,
+                        scopes: [
+                            "read"
+                        ]
+                    )
+                ])
+            ]
+            """
+        )
+    }
+
+    func testSecurityMetadata_operationLevelAndOrGroups() throws {
+        try XCTAssertSwiftEquivalent(
+            securityRequirementsDecl(forOperationID: "overridesSecurity"),
+            """
+            public static let securityRequirements: [OpenAPIRuntime.SecurityRequirement] = [
+                .init(schemes: [
+                    .init(
+                        name: "apiKeyAuth",
+                        kind: .apiKey(
+                            name: "X-API-Key",
+                            location: .header
+                        ),
+                        scopes: []
+                    ),
+                    .init(
+                        name: "bearerAuth",
+                        kind: .http(
+                            scheme: "bearer",
+                            bearerFormat: "JWT"
+                        ),
+                        scopes: []
+                    )
+                ]),
+                .init(schemes: [
+                    .init(
+                        name: "oauth",
+                        kind: .oauth2,
+                        scopes: [
+                            "read",
+                            "write"
+                        ]
+                    )
+                ])
+            ]
+            """
+        )
+    }
+
+    func testSecurityMetadata_explicitlyPublic() throws {
+        try XCTAssertSwiftEquivalent(
+            securityRequirementsDecl(forOperationID: "explicitlyPublic"),
+            """
+            public static let securityRequirements: [OpenAPIRuntime.SecurityRequirement] = []
+            """
+        )
+    }
+
+    func testSecurityMetadata_operationSecurityNamespace() throws {
+        let (translator, operations, _) = try makeSecurityMetadataFixture()
+        try XCTAssertSwiftEquivalent(
+            translator.translateOperationSecurityNamespace(operations),
+            """
+            public enum OperationSecurity {
+                public static let requirementsByOperationID: [String: [OpenAPIRuntime.SecurityRequirement]] = Dictionary(uniqueKeysWithValues: [
+                    ("inheritsDocSecurity", Operations.inheritsDocSecurity.securityRequirements),
+                    ("overridesSecurity", Operations.overridesSecurity.securityRequirements),
+                    ("explicitlyPublic", Operations.explicitlyPublic.securityRequirements)
+                ])
+            }
+            """
+        )
+    }
+
+    func testSecurityMetadata_disabledByDefault() throws {
+        let (translator, operations, documentSecurity) = try makeSecurityMetadataFixture(featureFlags: [])
+        let renderer = TextBasedRenderer.default
+        renderer.renderCodeBlock(try translator.translateOperations(operations, documentSecurity: documentSecurity))
+        XCTAssertFalse(renderer.renderedContents().contains("securityRequirements"))
+    }
+
     func makeTypesTranslator(openAPIDocumentYAML: String) throws -> TypesFileTranslator {
         let document = try YAMLDecoder().decode(OpenAPI.Document.self, from: openAPIDocumentYAML)
         return TypesFileTranslator(


### PR DESCRIPTION
Implements **SOAR-0015** (proposal included in this PR) and addresses #37.

> **Depends on** apple/swift-openapi-runtime#203, which adds the `SecurityRequirement` value types this generated code references. That PR should land (and be tagged in a release) first.

### Motivation

The generator discards the OpenAPI `security` / `securitySchemes` sections entirely, so a `ClientMiddleware` — which only receives an `operationID` — cannot tell which operations require authentication, or which scheme. Adopters must either apply credentials unconditionally or hand-maintain a list that drifts from the document (#37, and the per-operation targeting gap in #551).

### Modifications

Adds a `securityMetadata` feature flag. When enabled, `TypesFileTranslator` emits, per operation, the security requirements it currently drops:

```swift
public enum Operations {
    public enum getGreeting {
        public static let id: String = "getGreeting"
        public static let securityRequirements: [OpenAPIRuntime.SecurityRequirement] = [
            .init(schemes: [.init(name: "OAuth2", kind: .oauth2, scopes: ["read"])])
        ]
    }
}
public enum OperationSecurity {
    public static let requirementsByOperationID: [String: [OpenAPIRuntime.SecurityRequirement]] = ...
}
```

Semantics mirror OpenAPI: outer array = OR of alternatives, each requirement's `schemes` = AND-group, `[]` = explicitly public; an operation without `security` inherits the document-level requirements. AND-groups are sorted by scheme name for deterministic output. Unsupported cases (`mutualTLS`, non-`bearer`/`basic` HTTP) raise a diagnostic. With the flag off, generated output is byte-identical.

Also includes the SOAR-0015 proposal, the `Proposals.md` entry, and the corresponding checkboxes in the supported-features article.

### Result

Adopters can enable `securityMetadata` and drive a conditional-authentication middleware from `OperationSecurity.requirementsByOperationID` — applying credentials only where required and failing fast when a required one is missing.

### Test Plan

Adds reference tests in `SnippetBasedReferenceTests` for inherited document-level security, operation-level AND/OR groups (apiKey + http-bearer + oauth2), explicit `security: []`, the `OperationSecurity` namespace, and that nothing is emitted when the flag is off. Full suite passes (330 tests). Also dogfooded end-to-end against a real 130-operation document, generating and compiling the metadata (114 authenticated / 16 public) into an app.

cc @czechboy0 @simonjbeaumont - flagging per the proposal process.