### PR TITLE
SOAR-0015: Add namespace file splitting proposal

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/Proposals.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/Proposals.md
@@ -56,3 +56,4 @@ If you have any questions, tag [Honza Dvorsky](https://github.com/czechboy0) or 
 - <doc:SOAR-0012>
 - <doc:SOAR-0013>
 - <doc:SOAR-0014>
+- <doc:SOAR-0015>

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
@@ -110,14 +110,13 @@ Supporting build-tool plugin integration is outside this proposal. That follow-u
 
 ### API stability
 
-Existing users are unaffected unless they explicitly opt in:
+Existing users are unaffected unless they explicitly opt in. Without `output.types.fileSplitting`, types generation continues to produce the same single `Types.swift` output.
 
-- Existing configs continue to generate the same single `Types.swift` file by default.
-- Generated adopter-facing symbol names are not intended to change.
-- Runtime public API, runtime "Generated" SPI, transports, and middleware are not intended to change.
-- The new config file and CLI surface are generator API additions.
-- Programmatic generator callers now work with the generator pipeline's rendered output files.
-- Existing configured output file names continue to apply to the mode's primary output file.
+The main observable change for opted-in users is the generated output shape: a types generation run can produce multiple files instead of one. Direct CLI users and custom build integrations that enable this option need to write or compile every generated output file, not just the primary `Types.swift` file. Programmatic generator callers likewise need to handle the returned output-file collection.
+
+This does not intentionally change generated adopter-facing Swift symbols. The same generated declarations remain available to client and server code, but some declarations now live in `Types+Components.swift` and `Types+Operations.swift` instead of the primary file.
+
+Runtime public API, runtime "Generated" SPI, transports, and middleware are not intended to change. The new config file and CLI surface are generator API additions, and existing configured output file names continue to apply to the primary types output file.
 
 ### Future directions
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
@@ -1,0 +1,141 @@
+# SOAR-0015: Namespace-Based Types File Splitting
+
+Add opt-in namespace-based splitting for generated `Types.swift` output.
+
+## Overview
+
+- Proposal: SOAR-0015
+- Author(s): [Nick Candello](https://github.com/nac5504)
+- Status: **Awaiting Review**
+- Issue: [apple/swift-openapi-generator#929](https://github.com/apple/swift-openapi-generator/issues/929)
+- Implementation:
+    - [apple/swift-openapi-generator#925](https://github.com/apple/swift-openapi-generator/pull/925)
+- Affected components:
+    - generator
+- Related links:
+    - Prior discussion: [apple/swift-openapi-generator#866](https://github.com/apple/swift-openapi-generator/pull/866)
+
+### Introduction
+
+Introduces opt-in file splitting for generated `Types.swift` file. Generator stage now outputs 3 types files: root declarations remain in `Types.swift`, the generated `Components` namespace moves to `Types+Components.swift`, and the generated `Operations` namespace moves to `Types+Operations.swift`.
+
+### Motivation
+
+Large generated `Types.swift` files can dominate downstream Swift compilation time for sizeable OpenAPI specs. In [apple/swift-openapi-generator#866](https://github.com/apple/swift-openapi-generator/pull/866), various methods of splitting generated schema declarations were explored, and all of them demonstrated real compile-time improvements to differing degrees.
+
+The benchmark results from PR #925 show meaningful build-time wins across the board for API specs of varying sizes. In the post-generator Swift build measurements, Stripe's API improved from 4m49s to 2m13s, GitHub REST improved from 9m12s to 5m54s, and Jira improved from 59.5s to 37.7s. The benchmark suite also did not show a meaningful generator-time tradeoff.
+
+### Proposed solution
+
+Add a types output file-splitting configuration and support one strategy: `namespace`. This keeps the public option explicit while leaving the default output unchanged.
+
+Namespace-based splitting has a few useful properties:
+
+- Existing generation behavior remains unchanged unless users opt in.
+- The generated Swift symbol names remain the same; only the generated file layout changes.
+- The split follows namespaces that already exist in generated code, making the output predictable and easy to review.
+
+Users can enable the strategy in configuration:
+
+```yaml
+generate:
+  - types
+output:
+  types:
+    fileSplitting:
+      strategy: namespace
+```
+
+They can also enable the same strategy from the command line:
+
+```sh
+swift-openapi-generator generate openapi.yaml \
+  --mode types \
+  --types-file-splitting namespace
+```
+
+With this config enabled, the generator emits:
+
+- `Types.swift` for root declarations.
+- `Types+Components.swift` for the generated `Components` namespace.
+- `Types+Operations.swift` for the generated `Operations` namespace.
+
+#### Benchmark results
+
+The benchmark suite in PR #925 compares current single-file output against the new `namespace` splitting mode across representative OpenAPI specs. Each row uses five attempts with outliers excluded for VM compute inconsistencies; build and generator time charts use whiskers for +/- one standard deviation.
+
+The main benchmark result is that post-generator Swift build time improves for several large specs, while generator time remains close to the single-file baseline. The generator-stage breakdown suggests declaration routing is not a meaningful generator-time cost.
+
+![Post-generator Swift build times](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/e4580d68735097dec960548db3db3ca3da7ea833/cli-initiated-compile-build-times.svg)
+
+![Generator time](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/e40ef57a323e6e792b4964af647f3bfe63178e92/generator-time.svg)
+
+![Generator stage breakdown](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/c2da7a2272d8c71a1f8305da3c0dc940f474a7f6/generator-stage-breakdown.svg)
+
+If the proposal renderer does not embed external images, the benchmark chart sources are:
+
+- [Post-generator Swift build times](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/e4580d68735097dec960548db3db3ca3da7ea833/cli-initiated-compile-build-times.svg)
+- [Generator time](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/e40ef57a323e6e792b4964af647f3bfe63178e92/generator-time.svg)
+- [Generator stage breakdown](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/c2da7a2272d8c71a1f8305da3c0dc940f474a7f6/generator-stage-breakdown.svg)
+
+### Detailed design
+
+The implementation adds the configuration and pipeline plumbing needed for a single generator run to emit more than one Swift file. The default behavior remains unchanged: without an explicit types file-splitting configuration, types generation still emits one `Types.swift` file.
+
+The new configuration lives under generated output options:
+
+- `output.types.fileSplitting.strategy`, currently supporting `namespace`.
+
+The same model is used by YAML configuration, direct command-line invocation, and programmatic callers that construct `_OpenAPIGeneratorCore.Config` directly.
+
+At the pipeline boundary, `StructuredSwiftRepresentation` now contains an array of named structured Swift files. Rendering maps over that array, rendering each `NamedFileDescription` independently into an `InMemoryOutputFile`. The public `runGenerator` entry point returns all generated output files from the pipeline:
+
+```swift
+let files = try runGenerator(input: input, config: config, diagnostics: diagnostics)
+```
+
+For the `namespace` strategy, `TypesFileTranslator` routes declarations before rendering rather than parsing rendered Swift source after the fact:
+
+- `Types.swift` contains the root declarations, including `APIProtocol`, the API protocol extension, and server declarations.
+- `Types+Components.swift` contains the generated `Components` namespace.
+- `Types+Operations.swift` contains the generated `Operations` namespace.
+
+Output file names are planned from the splitting configuration using the configured primary types file name as the base. Existing configured output file names therefore continue to apply to the primary types output, while the two split files use the same `+Namespace` suffix convention.
+
+#### Build-tool plugin boundary
+
+SwiftPM and Xcode build-tool plugins must declare generated output files before invoking the generator executable. PR #925 therefore rejects build-tool plugin invocations when `output.types.fileSplitting` is configured.
+
+Supporting build-tool plugin integration is outside this proposal. That follow-up needs a design that lets the plugin determine declared output files without duplicating the generator's full YAML parsing behavior, especially because SwiftPM plugin targets cannot simply depend on the generator's YAML parsing library through the executable target.
+
+### API stability
+
+Existing users are unaffected unless they explicitly opt in:
+
+- Existing configs continue to generate the same single `Types.swift` file by default.
+- Generated adopter-facing symbol names are not intended to change.
+- Runtime public API, runtime "Generated" SPI, transports, and middleware are not intended to change.
+- The new config file and CLI surface are generator API additions.
+- Programmatic generator callers now work with the generator pipeline's rendered output files.
+- Existing configured output file names continue to apply to the mode's primary output file.
+
+### Future directions
+
+The following are intentionally outside the scope of this proposal:
+
+- SwiftPM and Xcode build-tool plugin support for split outputs.
+- More advanced sharding strategies, such as count-based slices or dependency-aware layering, if future benchmarks justify the added complexity.
+
+### Alternatives considered
+
+#### Land a broader generalized file-splitting strategy immediately
+
+This was rejected because PR #925 deliberately scopes the behavior to namespace-based splitting. Keeping the first proposal narrow makes the public API, generated output shape, and implementation easier to review.
+
+#### Parse rendered Swift source after generation
+
+This was rejected because translator-owned structured output can route declarations before rendering. That avoids parsing Swift source after generation and keeps the split tied to generator semantics rather than source text manipulation.
+
+#### Keep single-file-only generator APIs
+
+This was rejected because namespace splitting still needs the generator pipeline to represent and render multiple declared output files from a single generation run.

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
@@ -67,13 +67,6 @@ The generator's types-output path changes from producing one source file to prod
 
 Each generated file is a source-level fragment of the same generated API. Moving a declaration between these files does not rename it, change its access level, or introduce an additional Swift namespace.
 
-Types generation now produces a collection of output files. Programmatic callers of `runGenerator` must consume the full collection rather than assuming that types generation produces only one file:
-
-```swift
-// now returns an array of files
-let files = try runGenerator(input: input, config: config, diagnostics: diagnostics)
-```
-
 Contributors adding a new types-output entry point must preserve the complete collection rather than selecting only the primary file. Direct CLI generation writes all returned files to the output directory. SwiftPM and Xcode build-tool plugins declare the complete deterministic file set and compile it as generated source.
 
 #### Build-tool plugin support
@@ -86,7 +79,7 @@ This proposal does not change the runtime public API, runtime "Generated" SPI, o
 
 Existing and newly generated adopter code remains source compatible: symbol names, namespace nesting, and intended access are unchanged. Only the source-file layout changes, so integrations that assume a single `Types.swift` file must instead write, track, or compile the complete output set.
 
-The generator API does change: `runGenerator` returns `[InMemoryOutputFile]` instead of one `InMemoryOutputFile`, requiring programmatic callers to handle a collection. Existing configuration files and CLI arguments remain valid, but types generation now emits multiple files by default. The command and build-tool plugins automatically handle all generated files without additional configuration.
+Existing configuration files and CLI arguments remain valid, but types generation now emits multiple files by default. The command and build-tool plugins automatically handle all generated files without additional configuration.
 
 ### Future directions
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
@@ -23,9 +23,9 @@ This proposal splits generated `Types.swift` into multiple output files at the e
 
 Large generated `Types.swift` files can dominate downstream Swift compilation time for sizeable OpenAPI documents. Currently, adopters cannot ask the generator to produce smaller types files; working around the issue requires post-processing generated source, which is brittle and unsupported. In [apple/swift-openapi-generator#866](https://github.com/apple/swift-openapi-generator/pull/866), several ways of splitting generated declarations demonstrated compile-time improvements to differing degrees.
 
-The benchmark results from PR #925 show meaningful post-generator Swift build-time improvements for several large API documents. Stripe's API improved from 4m49s to 2m13s, GitHub REST improved from 9m12s to 5m54s, and Jira improved from 59.5s to 37.7s. The benchmark suite did not show a meaningful generator-time tradeoff.
+The benchmark results from [PR #925](https://github.com/apple/swift-openapi-generator/pull/925) show meaningful post-generator Swift build-time improvements for several large API documents. Stripe's API improved from 4m49s to 2m13s, GitHub REST improved from 9m12s to 5m54s, and Jira improved from 59.5s to 37.7s. The benchmark suite did not show a statistically significant generator-time slowdown.
 
-Generated namespaces provide stable, understandable splitting boundaries without introducing arbitrary declaration counts or dependency-grouping rules. Initially, this proposal introduced a more trivial verson of namespace splitting at the first namespace depth (i.e. `Types.swift`, `Types+Operations.swift`, `Types+Components.swift`), however enabling second-layer namespace splitting enables docs with heavy diversity within `Components` to see substantial benefits. Further proposals may split generated components even more in efforts to reduce default compile-time for package users.
+Generated namespaces provide stable, understandable splitting boundaries without introducing arbitrary declaration counts or dependency-grouping rules. Initially, this proposal introduced a more trivial version of namespace splitting at the first namespace depth (i.e. `Types.swift`, `Types+Operations.swift`, `Types+Components.swift`), however enabling second-layer namespace splitting enables docs with heavy diversity within `Components` to see substantial benefits.
 
 ### Proposed solution
 
@@ -48,8 +48,6 @@ Declarations are assigned to files according to the generated namespace that own
 - The `Components` namespace container is emitted in `Types+Components.swift`.
 - The `Operations` namespace is emitted in `Types+Operations.swift`.
 - The supported second-level `Components` namespaces are each emitted in their corresponding `Types+Components+<Namespace>.swift` file.
-
-All files are compiled into the same module, so adopters continue to use the same generated symbols and namespace hierarchy. Only the source-file layout changes. A configured primary types filename remains the base name for the output set, with namespace names appended using the `+Namespace` convention. For example, a primary filename of `GeneratedTypes.swift` produces `GeneratedTypes+Components.swift` and the corresponding namespace-derived files.
 
 #### Benchmark results
 
@@ -88,7 +86,7 @@ This proposal does not change the runtime public API, runtime "Generated" SPI, o
 
 Existing and newly generated adopter code remains source compatible: symbol names, namespace nesting, and intended access are unchanged. Only the source-file layout changes, so integrations that assume a single `Types.swift` file must instead write, track, or compile the complete output set.
 
-The generator API does change: `runGenerator` returns `[InMemoryOutputFile]` instead of one `InMemoryOutputFile`, requiring programmatic callers to handle a collection. Existing configuration files and CLI arguments remain valid, but types generation now emits multiple files by default. The command and build-tool plugins automatically handle all generated files without additional configuration. Custom names for Types.swift are also applied to the derived filenames.
+The generator API does change: `runGenerator` returns `[InMemoryOutputFile]` instead of one `InMemoryOutputFile`, requiring programmatic callers to handle a collection. Existing configuration files and CLI arguments remain valid, but types generation now emits multiple files by default. The command and build-tool plugins automatically handle all generated files without additional configuration.
 
 ### Future directions
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
@@ -6,7 +6,7 @@ Split generated types into deterministic, depth-two namespace files by default.
 
 - Proposal: SOAR-0015
 - Author(s): [Nick Candello](https://github.com/nac5504)
-- Status: **Awaiting Review**
+- Status: **In Review**
 - Issue: [apple/swift-openapi-generator#929](https://github.com/apple/swift-openapi-generator/issues/929)
 - Implementation:
     - [apple/swift-openapi-generator#925](https://github.com/apple/swift-openapi-generator/pull/925)
@@ -17,21 +17,21 @@ Split generated types into deterministic, depth-two namespace files by default.
 
 ### Introduction
 
-This proposal splits generated types into deterministic files at the existing generated namespace boundaries through depth two.
+This proposal splits generated `Types.swift` into multiple output files at the existing generated namespace boundaries to improve post-generator Swift build times.
 
 ### Motivation
 
 Large generated `Types.swift` files can dominate downstream Swift compilation time for sizeable OpenAPI documents. Currently, adopters cannot ask the generator to produce smaller types files; working around the issue requires post-processing generated source, which is brittle and unsupported. In [apple/swift-openapi-generator#866](https://github.com/apple/swift-openapi-generator/pull/866), several ways of splitting generated declarations demonstrated compile-time improvements to differing degrees.
 
-The benchmark results from PR #925 also show meaningful post-generator Swift build-time improvements for several large API documents. Stripe's API improved from 4m49s to 2m13s, GitHub REST improved from 9m12s to 5m54s, and Jira improved from 59.5s to 37.7s. The benchmark suite did not show a meaningful generator-time tradeoff.
+The benchmark results from PR #925 show meaningful post-generator Swift build-time improvements for several large API documents. Stripe's API improved from 4m49s to 2m13s, GitHub REST improved from 9m12s to 5m54s, and Jira improved from 59.5s to 37.7s. The benchmark suite did not show a meaningful generator-time tradeoff.
 
-Generated namespaces provide stable, understandable splitting boundaries without introducing arbitrary declaration counts or dependency-grouping rules. Splitting through depth two also gives component categories their own predictable files, including APIs whose generated parameters, responses, request bodies, or headers are substantial. Follow-up measurements did not show a consistent general performance improvement from depth two over depth one, so the depth-two choice is primarily about predictable organization and broader coverage rather than an additional performance claim.
+Generated namespaces provide stable, understandable splitting boundaries without introducing arbitrary declaration counts or dependency-grouping rules. Initially, this proposal introduced a more trivial verson of namespace splitting at the first namespace depth (i.e. `Types.swift`, `Types+Operations.swift`, `Types+Components.swift`), however enabling second-layer namespace splitting enables docs with heavy diversity within `Components` to see substantial benefits. Further proposals may split generated components even more in efforts to reduce default compile-time for package users.
 
 ### Proposed solution
 
-Namespace-based splitting becomes the standard types output shape. It requires no YAML configuration or command-line flag.
+Namespace-based splitting becomes the default types output shape. It requires no YAML configuration or command-line flag.
 
-A types generation run emits the following deterministic set of files:
+A types generation run emits the following set of files:
 
 - `Types.swift`
 - `Types+Components.swift`
@@ -51,13 +51,11 @@ Declarations are assigned to files according to the generated namespace that own
 
 All files are compiled into the same module, so adopters continue to use the same generated symbols and namespace hierarchy. Only the source-file layout changes. A configured primary types filename remains the base name for the output set, with namespace names appended using the `+Namespace` convention. For example, a primary filename of `GeneratedTypes.swift` produces `GeneratedTypes+Components.swift` and the corresponding namespace-derived files.
 
-The output set is unconditional and deterministic. This lets SwiftPM and Xcode build-tool plugins declare every generated file before invoking the generator, without parsing configuration to discover an optional output shape.
-
 #### Benchmark results
 
-The benchmark suite in PR #925 compares current single-file output against namespace splitting across representative OpenAPI documents. Each row uses five attempts with outliers excluded for VM compute inconsistencies; build and generator time charts use whiskers for +/- one standard deviation.
+The benchmark suite in PR #925 compares current single-file output against namespace splitting across representative OpenAPI documents. Each row uses five attempts with outliers excluded for VM compute inconsistencies; build and generator time charts use whiskers for +/- 1 standard deviation.
 
-The main benchmark result is that post-generator Swift build time improves for several large documents, while generator time remains close to the single-file baseline. The generator-stage breakdown suggests that assigning declarations to output files is not a meaningful generator-time cost.
+The main benchmark result is that post-generator Swift build time improves across the board for documents of varying sizes, while generator time remains close to the single-file baseline. The generator-stage breakdown suggests that assigning declarations to output files is not a meaningful generator-time cost.
 
 ![Post-generator Swift build times](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/e4580d68735097dec960548db3db3ca3da7ea833/cli-initiated-compile-build-times.svg)
 
@@ -65,21 +63,16 @@ The main benchmark result is that post-generator Swift build time improves for s
 
 ![Generator stage breakdown](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/c2da7a2272d8c71a1f8305da3c0dc940f474a7f6/generator-stage-breakdown.svg)
 
-If the proposal renderer does not embed external images, the benchmark chart sources are:
-
-- [Post-generator Swift build times](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/e4580d68735097dec960548db3db3ca3da7ea833/cli-initiated-compile-build-times.svg)
-- [Generator time](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/e40ef57a323e6e792b4964af647f3bfe63178e92/generator-time.svg)
-- [Generator stage breakdown](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/c2da7a2272d8c71a1f8305da3c0dc940f474a7f6/generator-stage-breakdown.svg)
-
 ### Detailed design
 
-The generator's types-output path changes from producing one source file to producing a named collection of source files. The file layout mirrors the generated Swift namespace hierarchy through depth two. A declaration belongs to the file for its nearest supported namespace boundary, while declarations outside those boundaries remain in the primary types file.
+The generator's types-output path changes from producing one source file to producing a named collection of source files. The file layout mirrors the generated Swift namespace hierarchy. A declaration belongs to the file for its nearest supported namespace boundary, while declarations outside those boundaries remain in the primary types file.
 
 Each generated file is a source-level fragment of the same generated API. Moving a declaration between these files does not rename it, change its access level, or introduce an additional Swift namespace.
 
 Types generation now produces a collection of output files. Programmatic callers of `runGenerator` must consume the full collection rather than assuming that types generation produces only one file:
 
 ```swift
+// now returns an array of files
 let files = try runGenerator(input: input, config: config, diagnostics: diagnostics)
 ```
 
@@ -89,23 +82,17 @@ Contributors adding a new types-output entry point must preserve the complete co
 
 SwiftPM and Xcode build-tool plugins must declare generated output files before invoking the generator executable. Because namespace splitting is unconditional and its depth-two file set is fixed, the plugins can declare those files without inspecting the generator configuration or using a prebuild command.
 
-This proposal does not switch the plugins to prebuild commands. A future strategy whose output filenames depend on document contents, such as count-based or dependency-based sharding, may require a prebuild command or another design for discovering outputs dynamically.
-
 ### API stability
 
-This proposal does not change the runtime public API, runtime "Generated" SPI, or the APIs implemented by transports and middleware. No generator change is required in response to a runtime API change.
+This proposal does not change the runtime public API, runtime "Generated" SPI, or the APIs implemented by transports and middleware.
 
-The generated adopter-facing Swift API remains source compatible: symbol names, namespace nesting, and intended access remain unchanged.
+Existing and newly generated adopter code remains source compatible: symbol names, namespace nesting, and intended access are unchanged. Only the source-file layout changes, so integrations that assume a single `Types.swift` file must instead write, track, or compile the complete output set.
 
-The generated source-file layout changes for all users of types generation. Integrations that assume generation produces only `Types.swift` must be updated to write, track, or compile the complete output collection. This includes programmatic `runGenerator` callers and workflows that check generated sources into source control.
-
-Existing generator configurations remain valid, and this proposal adds no configuration key or CLI option. The CLI and build-tool plugins produce more files, but require no new adopter input. Existing configured names for the primary types file continue to determine the base name used for the namespace-derived files.
+The generator API does change: `runGenerator` returns `[InMemoryOutputFile]` instead of one `InMemoryOutputFile`, requiring programmatic callers to handle a collection. Existing configuration files and CLI arguments remain valid, but types generation now emits multiple files by default. The command and build-tool plugins automatically handle all generated files without additional configuration. Custom names for Types.swift are also applied to the derived filenames.
 
 ### Future directions
 
 More advanced strategies could split especially large namespaces into count-based slices or dependency-aware layers if future benchmarks justify their additional complexity. Unlike the namespace layout in this proposal, those strategies may produce an output set that depends on the input document. Supporting them may therefore require SwiftPM and Xcode prebuild commands, or another mechanism for declaring dynamic outputs.
-
-Any such strategy should be evaluated separately, including its configuration surface, output stability, build-tool-plugin behavior, and measured performance benefit.
 
 ### Alternatives considered
 
@@ -115,12 +102,8 @@ An opt-in configuration was considered, but it would require build-tool plugins 
 
 #### Split only the top-level namespaces
 
-A depth-one split into `Types.swift`, `Types+Components.swift`, and `Types+Operations.swift` was considered and benchmarked. The depth-two layout was selected because it remains deterministic while giving each supported component category a predictable file and accommodating documents with substantial non-schema components. It does not add user-facing configuration.
+Initially, this proposal introduced a more trivial verson of namespace splitting at the first namespace depth (i.e. `Types.swift`, `Types+Operations.swift`, `Types+Components.swift`), however enabling second-layer namespace splitting enables docs with heavy diversity within `Components` to see substantial benefits.
 
 #### Add declaration-count or dependency-based sharding now
 
-These strategies could create more balanced files for unusually large namespaces, but their output sets depend on generated content and would add naming, configuration, stability, and build-tool-plugin questions. They remain possible follow-up work if benchmarks demonstrate sufficient benefit.
-
-#### Keep single-file-only generator APIs
-
-This was rejected because the generator and its callers need to represent, write, and compile the complete namespace-based output set from a single generation run.
+These strategies could create more parallelized compilation for very large namespaces, but their output sets depend on generated content and would add naming, configuration, stability, and build-tool-plugin questions. They remain possible follow-up work if benchmarks demonstrate sufficient benefit.

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
@@ -6,7 +6,7 @@ Split generated types into deterministic, depth-two namespace files by default.
 
 - Proposal: SOAR-0015
 - Author(s): [Nick Candello](https://github.com/nac5504)
-- Status: **In Review**
+- Status: **Ready for Implementation**
 - Issue: [apple/swift-openapi-generator#929](https://github.com/apple/swift-openapi-generator/issues/929)
 - Implementation:
     - [apple/swift-openapi-generator#925](https://github.com/apple/swift-openapi-generator/pull/925)

--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0015.md
@@ -1,6 +1,6 @@
 # SOAR-0015: Namespace-Based Types File Splitting
 
-Add opt-in namespace-based splitting for generated `Types.swift` output.
+Split generated types into deterministic, depth-two namespace files by default.
 
 ## Overview
 
@@ -17,54 +17,47 @@ Add opt-in namespace-based splitting for generated `Types.swift` output.
 
 ### Introduction
 
-Introduces opt-in file splitting for generated `Types.swift` file. Generator stage now outputs 3 types files: root declarations remain in `Types.swift`, the generated `Components` namespace moves to `Types+Components.swift`, and the generated `Operations` namespace moves to `Types+Operations.swift`.
+This proposal splits generated types into deterministic files at the existing generated namespace boundaries through depth two.
 
 ### Motivation
 
-Large generated `Types.swift` files can dominate downstream Swift compilation time for sizeable OpenAPI specs. In [apple/swift-openapi-generator#866](https://github.com/apple/swift-openapi-generator/pull/866), various methods of splitting generated schema declarations were explored, and all of them demonstrated real compile-time improvements to differing degrees.
+Large generated `Types.swift` files can dominate downstream Swift compilation time for sizeable OpenAPI documents. Currently, adopters cannot ask the generator to produce smaller types files; working around the issue requires post-processing generated source, which is brittle and unsupported. In [apple/swift-openapi-generator#866](https://github.com/apple/swift-openapi-generator/pull/866), several ways of splitting generated declarations demonstrated compile-time improvements to differing degrees.
 
-The benchmark results from PR #925 show meaningful build-time wins across the board for API specs of varying sizes. In the post-generator Swift build measurements, Stripe's API improved from 4m49s to 2m13s, GitHub REST improved from 9m12s to 5m54s, and Jira improved from 59.5s to 37.7s. The benchmark suite also did not show a meaningful generator-time tradeoff.
+The benchmark results from PR #925 also show meaningful post-generator Swift build-time improvements for several large API documents. Stripe's API improved from 4m49s to 2m13s, GitHub REST improved from 9m12s to 5m54s, and Jira improved from 59.5s to 37.7s. The benchmark suite did not show a meaningful generator-time tradeoff.
+
+Generated namespaces provide stable, understandable splitting boundaries without introducing arbitrary declaration counts or dependency-grouping rules. Splitting through depth two also gives component categories their own predictable files, including APIs whose generated parameters, responses, request bodies, or headers are substantial. Follow-up measurements did not show a consistent general performance improvement from depth two over depth one, so the depth-two choice is primarily about predictable organization and broader coverage rather than an additional performance claim.
 
 ### Proposed solution
 
-Add a types output file-splitting configuration and support one strategy: `namespace`. This keeps the public option explicit while leaving the default output unchanged.
+Namespace-based splitting becomes the standard types output shape. It requires no YAML configuration or command-line flag.
 
-Namespace-based splitting has a few useful properties:
+A types generation run emits the following deterministic set of files:
 
-- Existing generation behavior remains unchanged unless users opt in.
-- The generated Swift symbol names remain the same; only the generated file layout changes.
-- The split follows namespaces that already exist in generated code, making the output predictable and easy to review.
+- `Types.swift`
+- `Types+Components.swift`
+- `Types+Operations.swift`
+- `Types+Components+Schemas.swift`
+- `Types+Components+Parameters.swift`
+- `Types+Components+RequestBodies.swift`
+- `Types+Components+Responses.swift`
+- `Types+Components+Headers.swift`
 
-Users can enable the strategy in configuration:
+Declarations are assigned to files according to the generated namespace that owns them:
 
-```yaml
-generate:
-  - types
-output:
-  types:
-    fileSplitting:
-      strategy: namespace
-```
+- Root declarations remain in `Types.swift`.
+- The `Components` namespace container is emitted in `Types+Components.swift`.
+- The `Operations` namespace is emitted in `Types+Operations.swift`.
+- The supported second-level `Components` namespaces are each emitted in their corresponding `Types+Components+<Namespace>.swift` file.
 
-They can also enable the same strategy from the command line:
+All files are compiled into the same module, so adopters continue to use the same generated symbols and namespace hierarchy. Only the source-file layout changes. A configured primary types filename remains the base name for the output set, with namespace names appended using the `+Namespace` convention. For example, a primary filename of `GeneratedTypes.swift` produces `GeneratedTypes+Components.swift` and the corresponding namespace-derived files.
 
-```sh
-swift-openapi-generator generate openapi.yaml \
-  --mode types \
-  --types-file-splitting namespace
-```
-
-With this config enabled, the generator emits:
-
-- `Types.swift` for root declarations.
-- `Types+Components.swift` for the generated `Components` namespace.
-- `Types+Operations.swift` for the generated `Operations` namespace.
+The output set is unconditional and deterministic. This lets SwiftPM and Xcode build-tool plugins declare every generated file before invoking the generator, without parsing configuration to discover an optional output shape.
 
 #### Benchmark results
 
-The benchmark suite in PR #925 compares current single-file output against the new `namespace` splitting mode across representative OpenAPI specs. Each row uses five attempts with outliers excluded for VM compute inconsistencies; build and generator time charts use whiskers for +/- one standard deviation.
+The benchmark suite in PR #925 compares current single-file output against namespace splitting across representative OpenAPI documents. Each row uses five attempts with outliers excluded for VM compute inconsistencies; build and generator time charts use whiskers for +/- one standard deviation.
 
-The main benchmark result is that post-generator Swift build time improves for several large specs, while generator time remains close to the single-file baseline. The generator-stage breakdown suggests declaration routing is not a meaningful generator-time cost.
+The main benchmark result is that post-generator Swift build time improves for several large documents, while generator time remains close to the single-file baseline. The generator-stage breakdown suggests that assigning declarations to output files is not a meaningful generator-time cost.
 
 ![Post-generator Swift build times](https://gist.githubusercontent.com/nac5504/9452377b295faeca1d1198dd6d8ac07d/raw/e4580d68735097dec960548db3db3ca3da7ea833/cli-initiated-compile-build-times.svg)
 
@@ -80,61 +73,54 @@ If the proposal renderer does not embed external images, the benchmark chart sou
 
 ### Detailed design
 
-The implementation adds the configuration and pipeline plumbing needed for a single generator run to emit more than one Swift file. The default behavior remains unchanged: without an explicit types file-splitting configuration, types generation still emits one `Types.swift` file.
+The generator's types-output path changes from producing one source file to producing a named collection of source files. The file layout mirrors the generated Swift namespace hierarchy through depth two. A declaration belongs to the file for its nearest supported namespace boundary, while declarations outside those boundaries remain in the primary types file.
 
-The new configuration lives under generated output options:
+Each generated file is a source-level fragment of the same generated API. Moving a declaration between these files does not rename it, change its access level, or introduce an additional Swift namespace.
 
-- `output.types.fileSplitting.strategy`, currently supporting `namespace`.
-
-The same model is used by YAML configuration, direct command-line invocation, and programmatic callers that construct `_OpenAPIGeneratorCore.Config` directly.
-
-At the pipeline boundary, `StructuredSwiftRepresentation` now contains an array of named structured Swift files. Rendering maps over that array, rendering each `NamedFileDescription` independently into an `InMemoryOutputFile`. The public `runGenerator` entry point returns all generated output files from the pipeline:
+Types generation now produces a collection of output files. Programmatic callers of `runGenerator` must consume the full collection rather than assuming that types generation produces only one file:
 
 ```swift
 let files = try runGenerator(input: input, config: config, diagnostics: diagnostics)
 ```
 
-For the `namespace` strategy, `TypesFileTranslator` routes declarations before rendering rather than parsing rendered Swift source after the fact:
+Contributors adding a new types-output entry point must preserve the complete collection rather than selecting only the primary file. Direct CLI generation writes all returned files to the output directory. SwiftPM and Xcode build-tool plugins declare the complete deterministic file set and compile it as generated source.
 
-- `Types.swift` contains the root declarations, including `APIProtocol`, the API protocol extension, and server declarations.
-- `Types+Components.swift` contains the generated `Components` namespace.
-- `Types+Operations.swift` contains the generated `Operations` namespace.
+#### Build-tool plugin support
 
-Output file names are planned from the splitting configuration using the configured primary types file name as the base. Existing configured output file names therefore continue to apply to the primary types output, while the two split files use the same `+Namespace` suffix convention.
+SwiftPM and Xcode build-tool plugins must declare generated output files before invoking the generator executable. Because namespace splitting is unconditional and its depth-two file set is fixed, the plugins can declare those files without inspecting the generator configuration or using a prebuild command.
 
-#### Build-tool plugin boundary
-
-SwiftPM and Xcode build-tool plugins must declare generated output files before invoking the generator executable. PR #925 therefore rejects build-tool plugin invocations when `output.types.fileSplitting` is configured.
-
-Supporting build-tool plugin integration is outside this proposal. That follow-up needs a design that lets the plugin determine declared output files without duplicating the generator's full YAML parsing behavior, especially because SwiftPM plugin targets cannot simply depend on the generator's YAML parsing library through the executable target.
+This proposal does not switch the plugins to prebuild commands. A future strategy whose output filenames depend on document contents, such as count-based or dependency-based sharding, may require a prebuild command or another design for discovering outputs dynamically.
 
 ### API stability
 
-Existing users are unaffected unless they explicitly opt in. Without `output.types.fileSplitting`, types generation continues to produce the same single `Types.swift` output.
+This proposal does not change the runtime public API, runtime "Generated" SPI, or the APIs implemented by transports and middleware. No generator change is required in response to a runtime API change.
 
-The main observable change for opted-in users is the generated output shape: a types generation run can produce multiple files instead of one. Direct CLI users and custom build integrations that enable this option need to write or compile every generated output file, not just the primary `Types.swift` file. Programmatic generator callers likewise need to handle the returned output-file collection.
+The generated adopter-facing Swift API remains source compatible: symbol names, namespace nesting, and intended access remain unchanged.
 
-This does not intentionally change generated adopter-facing Swift symbols. The same generated declarations remain available to client and server code, but some declarations now live in `Types+Components.swift` and `Types+Operations.swift` instead of the primary file.
+The generated source-file layout changes for all users of types generation. Integrations that assume generation produces only `Types.swift` must be updated to write, track, or compile the complete output collection. This includes programmatic `runGenerator` callers and workflows that check generated sources into source control.
 
-Runtime public API, runtime "Generated" SPI, transports, and middleware are not intended to change. The new config file and CLI surface are generator API additions, and existing configured output file names continue to apply to the primary types output file.
+Existing generator configurations remain valid, and this proposal adds no configuration key or CLI option. The CLI and build-tool plugins produce more files, but require no new adopter input. Existing configured names for the primary types file continue to determine the base name used for the namespace-derived files.
 
 ### Future directions
 
-The following are intentionally outside the scope of this proposal:
+More advanced strategies could split especially large namespaces into count-based slices or dependency-aware layers if future benchmarks justify their additional complexity. Unlike the namespace layout in this proposal, those strategies may produce an output set that depends on the input document. Supporting them may therefore require SwiftPM and Xcode prebuild commands, or another mechanism for declaring dynamic outputs.
 
-- SwiftPM and Xcode build-tool plugin support for split outputs.
-- More advanced sharding strategies, such as count-based slices or dependency-aware layering, if future benchmarks justify the added complexity.
+Any such strategy should be evaluated separately, including its configuration surface, output stability, build-tool-plugin behavior, and measured performance benefit.
 
 ### Alternatives considered
 
-#### Land a broader generalized file-splitting strategy immediately
+#### Make namespace splitting opt-in
 
-This was rejected because PR #925 deliberately scopes the behavior to namespace-based splitting. Keeping the first proposal narrow makes the public API, generated output shape, and implementation easier to review.
+An opt-in configuration was considered, but it would require build-tool plugins to determine which output set to declare before generation and would leave most users on the slower single-file layout. A fixed default provides the benefit without adding a configuration knob.
 
-#### Parse rendered Swift source after generation
+#### Split only the top-level namespaces
 
-This was rejected because translator-owned structured output can route declarations before rendering. That avoids parsing Swift source after generation and keeps the split tied to generator semantics rather than source text manipulation.
+A depth-one split into `Types.swift`, `Types+Components.swift`, and `Types+Operations.swift` was considered and benchmarked. The depth-two layout was selected because it remains deterministic while giving each supported component category a predictable file and accommodating documents with substantial non-schema components. It does not add user-facing configuration.
+
+#### Add declaration-count or dependency-based sharding now
+
+These strategies could create more balanced files for unusually large namespaces, but their output sets depend on generated content and would add naming, configuration, stability, and build-tool-plugin questions. They remain possible follow-up work if benchmarks demonstrate sufficient benefit.
 
 #### Keep single-file-only generator APIs
 
-This was rejected because namespace splitting still needs the generator pipeline to represent and render multiple declared output files from a single generation run.
+This was rejected because the generator and its callers need to represent, write, and compile the complete namespace-based output set from a single generation run.


### PR DESCRIPTION
## Summary

- Adds SOAR-0015 for default namespace-based splitting of generated `Types.swift` output.
- Links the proposal to issue #929 and implementation PR #925.
- Adds SOAR-0015 to the proposals index.

## Notes

The proposal is scoped to the namespace split from PR #925: `Types.swift`, `Types+Components.swift`, and `Types+Operations.swift`, `Types+Components+Schemas.swift`, etc. More advanced sharding remains listed only as future direction.