### PR TITLE
Make nullable schemas referenced with $ref generate optional types

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
@@ -96,7 +96,9 @@ struct TypeAssigner {
             // it:
             let unboxedSchema = schema.flattenToJsonSchema()
             switch unboxedSchema.value {
-            case let .reference(reference, _): associatedType = try typeName(for: reference).asUsage
+            case let .reference(reference, _):
+                associatedType = try typeName(for: reference).asUsage
+                    .withOptional(try TypeMatcher(context: context).isOptional(unboxedSchema, components: components))
             default:
                 associatedType = try _typeUsage(
                     forPotentiallyInlinedValueNamed: hint,

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/TypeAssigner.swift
@@ -95,19 +95,13 @@ struct TypeAssigner {
             // JSONSchema.reference so we flatten the value before inspecting
             // it:
             let unboxedSchema = schema.flattenToJsonSchema()
-            switch unboxedSchema.value {
-            case let .reference(reference, _):
-                associatedType = try typeName(for: reference).asUsage
-                    .withOptional(try TypeMatcher(context: context).isOptional(unboxedSchema, components: components))
-            default:
-                associatedType = try _typeUsage(
-                    forPotentiallyInlinedValueNamed: hint,
-                    withSchema: unboxedSchema,
-                    components: components,
-                    inParent: parent,
-                    subtype: .appendScope
-                )
-            }
+            associatedType = try _typeUsage(
+                forPotentiallyInlinedValueNamed: hint,
+                withSchema: unboxedSchema,
+                components: components,
+                inParent: parent,
+                subtype: .appendScope
+            )
         } else {
             associatedType = nil
         }

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -2350,44 +2350,6 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
-    func testComponentsResponsesResponseWithNullableReferencedStringBody() throws {
-        try self.assertResponsesTranslation(
-            """
-            schemas:
-              MyNullableString:
-                type: [string, null]
-            responses:
-              MyResponse:
-                description: OK
-                content:
-                  application/json:
-                    schema:
-                      $ref: '#/components/schemas/MyNullableString'
-            """,
-            """
-            public enum Responses {
-                public struct MyResponse: Sendable, Hashable {
-                    @frozen public enum Body: Sendable, Hashable {
-                        case json(Components.Schemas.MyNullableString?)
-                        public var json: Components.Schemas.MyNullableString? {
-                            get throws {
-                                switch self {
-                                case let .json(body):
-                                    return body
-                                }
-                            }
-                        }
-                    }
-                    public var body: Components.Responses.MyResponse.Body
-                    public init(body: Components.Responses.MyResponse.Body) {
-                        self.body = body
-                    }
-                }
-            }
-            """
-        )
-    }
-
     func testComponentsResponsesResponseWithTransitivelyNullableReferencedBody() throws {
         try self.assertResponsesTranslation(
             """

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -2263,6 +2263,268 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testComponentsResponsesResponseWithNullableReferencedBody() throws {
+        try self.assertResponsesTranslation(
+            """
+            schemas:
+              MyNullableObject:
+                type: [object, null]
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+            responses:
+              MyResponse:
+                description: OK
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/MyNullableObject'
+            """,
+            """
+            public enum Responses {
+                public struct MyResponse: Sendable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
+                        case json(Components.Schemas.MyNullableObject?)
+                        public var json: Components.Schemas.MyNullableObject? {
+                            get throws {
+                                switch self {
+                                case let .json(body):
+                                    return body
+                                }
+                            }
+                        }
+                    }
+                    public var body: Components.Responses.MyResponse.Body
+                    public init(body: Components.Responses.MyResponse.Body) {
+                        self.body = body
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsResponsesResponseWithNullableKeywordReferencedBody() throws {
+        try self.assertResponsesTranslation(
+            """
+            schemas:
+              MyNullableObject:
+                type: object
+                nullable: true
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+            responses:
+              MyResponse:
+                description: OK
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/MyNullableObject'
+            """,
+            """
+            public enum Responses {
+                public struct MyResponse: Sendable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
+                        case json(Components.Schemas.MyNullableObject?)
+                        public var json: Components.Schemas.MyNullableObject? {
+                            get throws {
+                                switch self {
+                                case let .json(body):
+                                    return body
+                                }
+                            }
+                        }
+                    }
+                    public var body: Components.Responses.MyResponse.Body
+                    public init(body: Components.Responses.MyResponse.Body) {
+                        self.body = body
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsResponsesResponseWithNullableReferencedStringBody() throws {
+        try self.assertResponsesTranslation(
+            """
+            schemas:
+              MyNullableString:
+                type: [string, null]
+            responses:
+              MyResponse:
+                description: OK
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/MyNullableString'
+            """,
+            """
+            public enum Responses {
+                public struct MyResponse: Sendable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
+                        case json(Components.Schemas.MyNullableString?)
+                        public var json: Components.Schemas.MyNullableString? {
+                            get throws {
+                                switch self {
+                                case let .json(body):
+                                    return body
+                                }
+                            }
+                        }
+                    }
+                    public var body: Components.Responses.MyResponse.Body
+                    public init(body: Components.Responses.MyResponse.Body) {
+                        self.body = body
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsResponsesResponseWithTransitivelyNullableReferencedBody() throws {
+        try self.assertResponsesTranslation(
+            """
+            schemas:
+              MyNullableObject:
+                type: [object, null]
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+              MyNullableObjectAlias:
+                $ref: '#/components/schemas/MyNullableObject'
+            responses:
+              MyResponse:
+                description: OK
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/MyNullableObjectAlias'
+            """,
+            """
+            public enum Responses {
+                public struct MyResponse: Sendable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
+                        case json(Components.Schemas.MyNullableObjectAlias?)
+                        public var json: Components.Schemas.MyNullableObjectAlias? {
+                            get throws {
+                                switch self {
+                                case let .json(body):
+                                    return body
+                                }
+                            }
+                        }
+                    }
+                    public var body: Components.Responses.MyResponse.Body
+                    public init(body: Components.Responses.MyResponse.Body) {
+                        self.body = body
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsResponsesResponseWithNonNullableReferencedBody() throws {
+        try self.assertResponsesTranslation(
+            """
+            schemas:
+              MyObject:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+            responses:
+              MyResponse:
+                description: OK
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/MyObject'
+            """,
+            """
+            public enum Responses {
+                public struct MyResponse: Sendable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
+                        case json(Components.Schemas.MyObject)
+                        public var json: Components.Schemas.MyObject {
+                            get throws {
+                                switch self {
+                                case let .json(body):
+                                    return body
+                                }
+                            }
+                        }
+                    }
+                    public var body: Components.Responses.MyResponse.Body
+                    public init(body: Components.Responses.MyResponse.Body) {
+                        self.body = body
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsResponsesResponseWithNullableInlineBody() throws {
+        try self.assertResponsesTranslation(
+            """
+            responses:
+              MyResponse:
+                description: OK
+                content:
+                  application/json:
+                    schema:
+                      type: [object, null]
+                      properties:
+                        id:
+                          type: string
+                      required:
+                        - id
+            """,
+            """
+            public enum Responses {
+                public struct MyResponse: Sendable, Hashable {
+                    @frozen public enum Body: Sendable, Hashable {
+                        public struct jsonPayload: Codable, Hashable, Sendable {
+                            public var id: Swift.String
+                            public init(id: Swift.String) {
+                                self.id = id
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case id
+                            }
+                        }
+                        case json(Components.Responses.MyResponse.Body.jsonPayload?)
+                        public var json: Components.Responses.MyResponse.Body.jsonPayload? {
+                            get throws {
+                                switch self {
+                                case let .json(body):
+                                    return body
+                                }
+                            }
+                        }
+                    }
+                    public var body: Components.Responses.MyResponse.Body
+                    public init(body: Components.Responses.MyResponse.Body) {
+                        self.body = body
+                    }
+                }
+            }
+            """
+        )
+    }
+
     func testComponentsResponsesResponseWithHeader() throws {
         try self.assertResponsesTranslation(
             """
@@ -2382,6 +2644,9 @@ final class SnippetBasedReferenceTests: XCTestCase {
     func testComponentsRequestBodiesReference() throws {
         try self.assertRequestBodiesTranslation(
             """
+            schemas:
+              MyBody:
+                type: string
             requestBodies:
               MyResponseBody:
                 content:
@@ -2402,6 +2667,9 @@ final class SnippetBasedReferenceTests: XCTestCase {
     func testComponentsRequestBodiesMultipleContentTypes() throws {
         try self.assertRequestBodiesTranslation(
             """
+            schemas:
+              MyBody:
+                type: string
             requestBodies:
               MyResponseBody:
                 content:
@@ -3613,6 +3881,131 @@ final class SnippetBasedReferenceTests: XCTestCase {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return Operations.getFoo.Input(body: body)
+                }
+                """
+        )
+    }
+
+    func testResponseWithNullableReferencedBody() throws {
+        try self.assertResponseInTypesClientServerTranslation(
+            """
+            /foo:
+              get:
+                operationId: getFoo
+                responses:
+                  '200':
+                    description: OK
+                    content:
+                      application/json:
+                        schema:
+                          $ref: '#/components/schemas/MyNullableObject'
+            """,
+            """
+            schemas:
+              MyNullableObject:
+                type: [object, null]
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+            """,
+            output: """
+                @frozen public enum Output: Sendable, Hashable {
+                    public struct Ok: Sendable, Hashable {
+                        @frozen public enum Body: Sendable, Hashable {
+                            case json(Components.Schemas.MyNullableObject?)
+                            public var json: Components.Schemas.MyNullableObject? {
+                                get throws {
+                                    switch self {
+                                    case let .json(body):
+                                        return body
+                                    }
+                                }
+                            }
+                        }
+                        public var body: Operations.getFoo.Output.Ok.Body
+                        public init(body: Operations.getFoo.Output.Ok.Body) {
+                            self.body = body
+                        }
+                    }
+                    case ok(Operations.getFoo.Output.Ok)
+                    public var ok: Operations.getFoo.Output.Ok {
+                        get throws {
+                            switch self {
+                            case let .ok(response):
+                                return response
+                            default:
+                                try throwUnexpectedResponseStatus(
+                                    expectedStatus: "ok",
+                                    response: self
+                                )
+                            }
+                        }
+                    }
+                    case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+                }
+                """,
+            server: """
+                { output, request in
+                    switch output {
+                    case let .ok(value):
+                        suppressUnusedWarning(value)
+                        var response = HTTPTypes.HTTPResponse(soar_statusCode: 200)
+                        suppressMutabilityWarning(&response)
+                        let body: OpenAPIRuntime.HTTPBody
+                        switch value.body {
+                        case let .json(value):
+                            try converter.validateAcceptIfPresent(
+                                "application/json",
+                                in: request.headerFields
+                            )
+                            body = try converter.setResponseBodyAsJSON(
+                                value,
+                                headerFields: &response.headerFields,
+                                contentType: "application/json; charset=utf-8"
+                            )
+                        }
+                        return (response, body)
+                    case let .undocumented(statusCode, _):
+                        return (.init(soar_statusCode: statusCode), nil)
+                    }
+                }
+                """,
+            client: """
+                { response, responseBody in
+                    switch response.status.code {
+                    case 200:
+                        let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                        let body: Operations.getFoo.Output.Ok.Body
+                        let chosenContentType = try converter.bestContentType(
+                            received: contentType,
+                            options: [
+                                "application/json"
+                            ]
+                        )
+                        switch chosenContentType {
+                        case "application/json":
+                            body = try await converter.getResponseBodyAsJSON(
+                                Components.Schemas.MyNullableObject?.self,
+                                from: responseBody,
+                                transforming: { value in
+                                    .json(value)
+                                }
+                            )
+                        default:
+                            preconditionFailure("bestContentType chose an invalid content type.")
+                        }
+                        return .ok(.init(body: body))
+                    default:
+                        return .undocumented(
+                            statusCode: response.status.code,
+                            .init(
+                                headerFields: response.headerFields,
+                                body: responseBody
+                            )
+                        )
+                    }
                 }
                 """
         )


### PR DESCRIPTION
### Motivation

When a response body schema is referenced with `$ref`, the generated type is not optional even if the referenced schema is nullable.

```yaml
components:
  schemas:
    MyObject:
      type: [object, null]
      properties:
        id:
          type: string
      required:
        - id
  responses:
    MyResponse:
      description: OK
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/MyObject'
```

Current output:

```swift
@frozen public enum Body: Sendable, Hashable {
    case json(Components.Schemas.MyObject)
}
```

Expected output:

```swift
@frozen public enum Body: Sendable, Hashable {
    case json(Components.Schemas.MyObject?)
}
```

Writing the same schema inline already produces `...?`, so the behavior differs depending on whether `$ref` is used. This also contradicts the documented rule in `Handling-nullable-schemas.md`: "The nullability of a schema is propagated through references."

### Modifications

Removed the `.reference` branch in `TypeAssigner.typeUsage(usingNamingHint:withSchema:components:inParent:)`, which resolved the type name without applying nullability. Every schema now goes through `_typeUsage`, which already applies `withOptional(isOptional(...))` to references, so inline and referenced schemas share a single path.

Request bodies are unaffected, since `translateRequestBody` explicitly drops optionality with `withOptional(false)`.


### Result

Nullable schemas referenced with `$ref` are generated as optional types. This covers both `type: [object, null]` and `nullable: true`, as well as transitive references through another schema. The output for non-nullable references is unchanged.

### Test Plan

Added tests to `SnippetBasedReferenceTests`.