### PR TITLE
Support type: null in anyOf/oneOf/allOf as a nullability marker

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Extensions/OpenAPIKit.swift
+++ b/Sources/_OpenAPIGeneratorCore/Extensions/OpenAPIKit.swift
@@ -109,4 +109,10 @@ extension JSONSchema {
 
     /// Returns a human-readable description of the schema.
     var prettyDescription: String { value.prettyDescription }
+
+    /// A Boolean value indicating whether the schema is the `null` type.
+    var isNullType: Bool {
+        if case .null = value { return true }
+        return false
+    }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateAllAnyOneOf.swift
@@ -40,6 +40,8 @@ extension TypesFileTranslator {
     func translateAllOrAnyOf(typeName: TypeName, openAPIDescription: String?, type: AllOrAnyOf, schemas: [JSONSchema])
         throws -> Declaration
     {
+        // A `null` branch only marks the composition as nullable, it has no member.
+        let schemas = schemas.filter { !$0.isNullType }
         let properties: [(property: PropertyBlueprint, isKeyValuePair: Bool)] = try schemas.enumerated()
             .map { index, schema in
                 let key = "value\(index+1)"
@@ -129,6 +131,8 @@ extension TypesFileTranslator {
         discriminator: OpenAPI.Discriminator?,
         schemas: [JSONSchema]
     ) throws -> Declaration {
+        // A `null` branch only marks the oneOf as nullable, it has no case.
+        let schemas = schemas.filter { !$0.isNullType }
         let cases: [(String, [String]?, Bool, Comment?, TypeUsage, [Declaration])]
         if let discriminator {
             // > When using the discriminator, inline schemas will not be considered.

--- a/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateArray.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/CommonTranslations/translateArray.swift
@@ -58,7 +58,8 @@ extension TypesFileTranslator {
             .`typealias`(
                 accessModifier: config.access,
                 name: typeName.shortSwiftName,
-                existingType: .init(elementType.typeName.asUsage.asArray)
+                // Preserve the element's optionality, like builtin `[Element?]`.
+                existingType: .init(elementType.asArray)
             )
         )
         return inline + [arrayDecl]

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypeAssignment/isSchemaSupported.swift
@@ -157,12 +157,16 @@ extension FileTranslator {
             // an array is supported iff its element schema is supported
             return try isSchemaSupported(items, referenceStack: &referenceStack)
         case .all(of: let schemas, _):
+            // A `null` branch only marks the composition as nullable, ignore it here.
+            let schemas = schemas.filter { !$0.isNullType }
             guard !schemas.isEmpty else { return .unsupported(reason: .noSubschemas, schema: schema) }
             return try areSchemasSupported(schemas, referenceStack: &referenceStack)
         case .any(of: let schemas, _):
+            let schemas = schemas.filter { !$0.isNullType }
             guard !schemas.isEmpty else { return .unsupported(reason: .noSubschemas, schema: schema) }
             return try areSchemasSupported(schemas, referenceStack: &referenceStack)
         case .one(of: let schemas, let context):
+            let schemas = schemas.filter { !$0.isNullType }
             guard !schemas.isEmpty else { return .unsupported(reason: .noSubschemas, schema: schema) }
             guard context.discriminator != nil else {
                 return try areSchemasSupported(schemas, referenceStack: &referenceStack)

--- a/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/SnippetBasedReferenceTests.swift
@@ -1099,6 +1099,304 @@ final class SnippetBasedReferenceTests: XCTestCase {
         )
     }
 
+    func testComponentsSchemasOneOfWithNull_singleRef() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              B:
+                type: object
+                required: [c]
+                properties:
+                  c:
+                    type: string
+              A:
+                type: object
+                required: [b]
+                properties:
+                  b:
+                    oneOf:
+                      - $ref: '#/components/schemas/B'
+                      - type: 'null'
+            """,
+            """
+            public enum Schemas {
+                public struct B: Codable, Hashable, Sendable {
+                    public var c: Swift.String
+                    public init(c: Swift.String) {
+                        self.c = c
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case c
+                    }
+                }
+                public struct A: Codable, Hashable, Sendable {
+                    @frozen public enum bPayload: Codable, Hashable, Sendable {
+                        case B(Components.Schemas.B)
+                        public init(from decoder: any Swift.Decoder) throws {
+                            var errors: [any Swift.Error] = []
+                            do {
+                                self = .B(try .init(from: decoder))
+                                return
+                            } catch {
+                                errors.append(error)
+                            }
+                            throw Swift.DecodingError.failedToDecodeOneOfSchema(
+                                type: Self.self,
+                                codingPath: decoder.codingPath,
+                                errors: errors
+                            )
+                        }
+                        public func encode(to encoder: any Swift.Encoder) throws {
+                            switch self {
+                            case let .B(value):
+                                try value.encode(to: encoder)
+                            }
+                        }
+                    }
+                    public var b: Components.Schemas.A.bPayload?
+                    public init(b: Components.Schemas.A.bPayload? = nil) {
+                        self.b = b
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case b
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsSchemasOneOfWithNull_multiRef() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              B1:
+                type: object
+                required: [c]
+                properties:
+                  c:
+                    type: string
+              B2:
+                type: object
+                required: [d]
+                properties:
+                  d:
+                    type: string
+              A:
+                type: object
+                required: [b]
+                properties:
+                  b:
+                    oneOf:
+                      - $ref: '#/components/schemas/B1'
+                      - $ref: '#/components/schemas/B2'
+                      - type: 'null'
+            """,
+            """
+            public enum Schemas {
+                public struct B1: Codable, Hashable, Sendable {
+                    public var c: Swift.String
+                    public init(c: Swift.String) {
+                        self.c = c
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case c
+                    }
+                }
+                public struct B2: Codable, Hashable, Sendable {
+                    public var d: Swift.String
+                    public init(d: Swift.String) {
+                        self.d = d
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case d
+                    }
+                }
+                public struct A: Codable, Hashable, Sendable {
+                    @frozen public enum bPayload: Codable, Hashable, Sendable {
+                        case B1(Components.Schemas.B1)
+                        case B2(Components.Schemas.B2)
+                        public init(from decoder: any Swift.Decoder) throws {
+                            var errors: [any Swift.Error] = []
+                            do {
+                                self = .B1(try .init(from: decoder))
+                                return
+                            } catch {
+                                errors.append(error)
+                            }
+                            do {
+                                self = .B2(try .init(from: decoder))
+                                return
+                            } catch {
+                                errors.append(error)
+                            }
+                            throw Swift.DecodingError.failedToDecodeOneOfSchema(
+                                type: Self.self,
+                                codingPath: decoder.codingPath,
+                                errors: errors
+                            )
+                        }
+                        public func encode(to encoder: any Swift.Encoder) throws {
+                            switch self {
+                            case let .B1(value):
+                                try value.encode(to: encoder)
+                            case let .B2(value):
+                                try value.encode(to: encoder)
+                            }
+                        }
+                    }
+                    public var b: Components.Schemas.A.bPayload?
+                    public init(b: Components.Schemas.A.bPayload? = nil) {
+                        self.b = b
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case b
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsSchemasAnyOfWithNull_singleRef() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              B:
+                type: object
+                required: [c]
+                properties:
+                  c:
+                    type: string
+              A:
+                type: object
+                required: [b]
+                properties:
+                  b:
+                    anyOf:
+                      - $ref: '#/components/schemas/B'
+                      - type: 'null'
+            """,
+            """
+            public enum Schemas {
+                public struct B: Codable, Hashable, Sendable {
+                    public var c: Swift.String
+                    public init(c: Swift.String) {
+                        self.c = c
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case c
+                    }
+                }
+                public struct A: Codable, Hashable, Sendable {
+                    public struct bPayload: Codable, Hashable, Sendable {
+                        public var value1: Components.Schemas.B?
+                        public init(value1: Components.Schemas.B? = nil) {
+                            self.value1 = value1
+                        }
+                        public init(from decoder: any Swift.Decoder) throws {
+                            var errors: [any Swift.Error] = []
+                            do {
+                                self.value1 = try .init(from: decoder)
+                            } catch {
+                                errors.append(error)
+                            }
+                            try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                                [
+                                    self.value1
+                                ],
+                                type: Self.self,
+                                codingPath: decoder.codingPath,
+                                errors: errors
+                            )
+                        }
+                        public func encode(to encoder: any Swift.Encoder) throws {
+                            try self.value1?.encode(to: encoder)
+                        }
+                    }
+                    public var b: Components.Schemas.A.bPayload?
+                    public init(b: Components.Schemas.A.bPayload? = nil) {
+                        self.b = b
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case b
+                    }
+                }
+            }
+            """
+        )
+    }
+
+    func testComponentsSchemasArrayWithNullableOneOfItems() throws {
+        try self.assertSchemasTranslation(
+            """
+            schemas:
+              B:
+                type: object
+                required: [c]
+                properties:
+                  c:
+                    type: string
+              A:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      oneOf:
+                        - $ref: '#/components/schemas/B'
+                        - type: 'null'
+            """,
+            """
+            public enum Schemas {
+                public struct B: Codable, Hashable, Sendable {
+                    public var c: Swift.String
+                    public init(c: Swift.String) {
+                        self.c = c
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case c
+                    }
+                }
+                public struct A: Codable, Hashable, Sendable {
+                    @frozen public enum itemsPayloadPayload: Codable, Hashable, Sendable {
+                        case B(Components.Schemas.B)
+                        public init(from decoder: any Swift.Decoder) throws {
+                            var errors: [any Swift.Error] = []
+                            do {
+                                self = .B(try .init(from: decoder))
+                                return
+                            } catch {
+                                errors.append(error)
+                            }
+                            throw Swift.DecodingError.failedToDecodeOneOfSchema(
+                                type: Self.self,
+                                codingPath: decoder.codingPath,
+                                errors: errors
+                            )
+                        }
+                        public func encode(to encoder: any Swift.Encoder) throws {
+                            switch self {
+                            case let .B(value):
+                                try value.encode(to: encoder)
+                            }
+                        }
+                    }
+                    public typealias itemsPayload = [Components.Schemas.A.itemsPayloadPayload?]
+                    public var items: Components.Schemas.A.itemsPayload
+                    public init(items: Components.Schemas.A.itemsPayload) {
+                        self.items = items
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case items
+                    }
+                }
+            }
+            """
+        )
+    }
+
     func testComponentsSchemasOneOf_open_pattern() throws {
         try self.assertSchemasTranslation(
             """


### PR DESCRIPTION
### Motivation

In OpenAPI 3.1, a nullable value is commonly expressed by adding a `{ "type": "null" }` branch to an `anyOf`/`oneOf`/`allOf` (e.g. `anyOf: [$ref, {type: null}]`). Today the generator treats the `null` branch as an unsupported member, so the whole composition is skipped and emits `Schema "null" is not supported ... skipping`. This blocks common specs (FastAPI, Figma, and others) and is tracked in #906, #817, #419, #565, #513, #286.

OpenAPIKit already propagates the nullability onto the enclosing composition's core context when one of its subschemas is `null`, so the generator only needs to stop rejecting these schemas and skip the `null` member. This is the minimal, non-collapsing approach previously suggested by the maintainers, which keeps API evolution deterministic (adding a member expands the wrapper instead of changing its shape).

#### Prior maintainer guidance (the "filter" approach)

This PR intentionally implements the filtering approach that @czechboy0 described earlier, rather than the collapsing/optional-root approach of #557 and #558:

- #557 (comment): _"we should simply filter out null from anyOf/allOf schemas, as OpenAPIKit will already represent the nullability on the parent schema"_ — https://github.com/apple/swift-openapi-generator/pull/557#issuecomment-2034640640
- #558 (comment): _"does that mean we just need to filter out the null case in the generator and the rest should work?"_ — https://github.com/apple/swift-openapi-generator/pull/558#issuecomment-2034565928
- #558 (comment): _"would you be interested in opening a PR for the filtering of nulls ..."_ — https://github.com/apple/swift-openapi-generator/pull/558#issuecomment-2034659980

#### Minimal example that should be supported

```json
{
  "components": {
    "schemas": {
      "Child": { "type": "string" },
      "Parent": {
        "type": "object",
        "properties": {
          "child": {
            "anyOf": [
              { "$ref": "#/components/schemas/Child" },
              { "type": "null" }
            ]
          }
        }
      }
    }
  }
}
```

### Modifications

- Added `JSONSchema.isNullType` helper.
- `isSchemaSupported`: filter out the `null` branch of `allOf`/`anyOf`/`oneOf` before checking support, so the composition is generated instead of skipped.
- `translateAllAnyOneOf`: skip the `null` branch when generating members/cases (no member/case is emitted for it).
- `translateArray`: preserve the element's optionality (`[Element?]`), consistent with how builtin element types are already emitted, so arrays that mix values and `null` are supported.

### Result

- `anyOf`/`oneOf`/`allOf` containing a `type: null` branch are now generated as an optional wrapper (e.g. `var b: A.bPayload?`) instead of being skipped.
- The wrapper is not collapsed: `oneOf: [$ref, null]` yields a single-case optional enum, and adding a case simply expands it — API evolution stays deterministic.
- Arrays of nullable elements are emitted as `[Element?]`, preserving order while allowing `null` entries.
- Non-nullable compositions and arrays are unchanged.

### Test Plan

- Added snippet tests in `SnippetBasedReferenceTests` for `oneOf`/`anyOf` with `null` (single and multiple refs) and for an array with a nullable `oneOf` element.
- `swift test`: 329 tests, 0 failures.
- Validated end-to-end against a real-world spec: generation succeeds with no `Schema "null" is not supported` warnings, and nullable properties/array elements are emitted as optionals.
