### PR TITLE
Emit a clear error instead of crashing on duplicate generated schema names

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
@@ -25,7 +25,9 @@ extension TypesFileTranslator {
     func boxRecursiveTypes(_ decls: [Declaration]) throws -> [Declaration] {
 
         let nodes = decls.compactMap(DeclarationRecursionDetector.Node.init)
-        let nodeLookup = Dictionary(uniqueKeysWithValues: nodes.map { ($0.name, $0) })
+        let nodeLookup = nodes.reduce(into: [String: DeclarationRecursionDetector.Node]()) { lookup, node in
+            if lookup[node.name] == nil { lookup[node.name] = node }
+        }
         let container = DeclarationRecursionDetector.Container(lookupMap: nodeLookup)
 
         let boxedNames = try RecursionDetector.computeBoxedTypes(rootNodes: nodes, container: container)

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateBoxedTypes.swift
@@ -25,9 +25,7 @@ extension TypesFileTranslator {
     func boxRecursiveTypes(_ decls: [Declaration]) throws -> [Declaration] {
 
         let nodes = decls.compactMap(DeclarationRecursionDetector.Node.init)
-        let nodeLookup = nodes.reduce(into: [String: DeclarationRecursionDetector.Node]()) { lookup, node in
-            if lookup[node.name] == nil { lookup[node.name] = node }
-        }
+        let nodeLookup = Dictionary(nodes.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
         let container = DeclarationRecursionDetector.Container(lookupMap: nodeLookup)
 
         let boxedNames = try RecursionDetector.computeBoxedTypes(rootNodes: nodes, container: container)

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateSchemas.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateSchemas.swift
@@ -64,6 +64,7 @@ extension TypesFileTranslator {
                 isMultipartContent: multipartSchemaNames.contains(key)
             )
         }
+        try emitDuplicateTypeNameDiagnostic(in: decls)
         let declsWithBoxingApplied = try boxRecursiveTypes(decls)
         let componentsSchemasEnum = Declaration.commentable(
             JSONSchema.sectionComment(),
@@ -74,5 +75,27 @@ extension TypesFileTranslator {
             )
         )
         return componentsSchemasEnum
+    }
+
+    /// Emits an error when multiple top-level schema declarations have the same generated Swift type name.
+    /// - Parameter declarations: The declarations generated in the `Components.Schemas` namespace.
+    /// - Throws: An error if the diagnostic collector throws while receiving the collision diagnostic.
+    private func emitDuplicateTypeNameDiagnostic(in declarations: [Declaration]) throws {
+        var observedNames: Set<String> = []
+        var duplicateNames: Set<String> = []
+        for name in declarations.compactMap(\.name) where !observedNames.insert(name).inserted {
+            duplicateNames.insert(name)
+        }
+        guard !duplicateNames.isEmpty else { return }
+
+        let nameList = duplicateNames.sorted().map { "'\($0)'" }.joined(separator: ", ")
+        try diagnostics.emit(
+            .error(
+                message: "Multiple schemas in '#/components/schemas' map to the same generated Swift type names "
+                    + "\(nameList), which is not supported. Use the 'defensive' naming strategy or add "
+                    + "'nameOverrides' entries so every schema generates a unique name.",
+                context: ["names": nameList]
+            )
+        )
     }
 }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_translateSchemas.swift
@@ -47,4 +47,88 @@ class Test_translateSchemas: Test_Core {
             XCTAssertEqual(collector.diagnostics.map(\.description), diagnosticDescriptions)
         }
     }
+
+    func testDuplicateGeneratedSchemaNamesThrowErrorDiagnostic() throws {
+        let schemas: OpenAPI.ComponentDictionary<JSONSchema> = ["NullTime": .string, "nullTime": .string]
+        let diagnostics = ErrorThrowingDiagnosticCollector(upstream: StdErrPrintingDiagnosticCollector())
+        let translator = makeTranslator(
+            components: .init(schemas: schemas),
+            diagnostics: diagnostics,
+            namingStrategy: .idiomatic
+        )
+
+        XCTAssertThrowsError(try translator.translateSchemas(schemas, multipartSchemaNames: [])) { error in
+            guard let diagnostic = error as? Diagnostic else { return XCTFail("Expected a Diagnostic, got \(error)") }
+            XCTAssertEqual(diagnostic.severity, .error)
+            XCTAssertEqual(diagnostic.context, ["names": "'NullTime'"])
+        }
+    }
+
+    func testDuplicateGeneratedSchemaNamesDoNotTrapWithNonThrowingCollector() throws {
+        let schemas: OpenAPI.ComponentDictionary<JSONSchema> = ["NullTime": .string, "nullTime": .string]
+        let collector = AccumulatingDiagnosticCollector()
+        let translator = makeTranslator(
+            components: .init(schemas: schemas),
+            diagnostics: collector,
+            namingStrategy: .idiomatic
+        )
+
+        _ = try translator.translateSchemas(schemas, multipartSchemaNames: [])
+
+        XCTAssertEqual(
+            collector.diagnostics.map(\.description),
+            [
+                "error: Multiple schemas in '#/components/schemas' map to the same generated Swift type names "
+                    + "'NullTime', which is not supported. Use the 'defensive' naming strategy or add "
+                    + "'nameOverrides' entries so every schema generates a unique name. [context: names='NullTime']"
+            ]
+        )
+    }
+
+    func testMultipleDuplicateGeneratedSchemaNamesAreReportedDeterministically() throws {
+        let schemas: OpenAPI.ComponentDictionary<JSONSchema> = [
+            "Zulu": .string, "zulu": .string, "Alpha": .string, "alpha": .string,
+        ]
+        let collector = AccumulatingDiagnosticCollector()
+        let translator = makeTranslator(
+            components: .init(schemas: schemas),
+            diagnostics: collector,
+            namingStrategy: .idiomatic
+        )
+
+        _ = try translator.translateSchemas(schemas, multipartSchemaNames: [])
+
+        XCTAssertEqual(collector.diagnostics.count, 1)
+        XCTAssertEqual(collector.diagnostics.first?.context, ["names": "'Alpha', 'Zulu'"])
+    }
+
+    func testDuplicateNestedBasenamesInDifferentNamespacesAreValid() throws {
+        let schemas: OpenAPI.ComponentDictionary<JSONSchema> = [
+            "A": .object(properties: ["t": .object(properties: ["value": .string])]),
+            "B": .object(properties: ["t": .object(properties: ["value": .string])]),
+        ]
+        let collector = AccumulatingDiagnosticCollector()
+        let translator = makeTranslator(
+            components: .init(schemas: schemas),
+            diagnostics: collector,
+            namingStrategy: .idiomatic
+        )
+
+        let declaration = try translator.translateSchemas(schemas, multipartSchemaNames: [])
+
+        guard case .enum(let schemasNamespace) = declaration.strippingTopComment else {
+            return XCTFail("Expected the Components.Schemas namespace")
+        }
+        let topLevelNames = schemasNamespace.members.compactMap(\.name).sorted()
+        let nestedNames = schemasNamespace.members
+            .flatMap { declaration -> [String] in
+                guard case .struct(let description) = declaration.strippingTopComment else { return [] }
+                return description.members.compactMap(\.name).map { "\(description.name).\($0)" }
+            }
+            .filter { $0.hasSuffix(".TPayload") }.sorted()
+
+        XCTAssertEqual(topLevelNames, ["A", "B"])
+        XCTAssertEqual(nestedNames, ["A.TPayload", "B.TPayload"])
+        XCTAssertTrue(collector.diagnostics.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

When the idiomatic naming strategy maps distinct OpenAPI component keys to the same generated Swift type name, schema translation currently reaches `Dictionary(uniqueKeysWithValues:)` in recursive-type boxing and traps. This change detects duplicate generated top-level schema names before boxing and emits a deterministic error diagnostic with the documented `defensive` naming and `nameOverrides` resolution paths.

The defensive lookup in `translateBoxedTypes` keeps execution from reaching the duplicate-key dictionary initializer when a non-throwing diagnostic collector continues after the error. Duplicate basenames in different namespaces remain valid.

Fixes #854.

## Prior work and attribution

This continues the work from #907/#914 by Aditya Singh and incorporates the review feedback left there.

The original issue and reproduction were reported by @marknefedov in #854. Aditya Singh (`@adityasingh2400`) implemented the substantial prior repair in #907 and #914. The placement in `translateSchemas`, keeping `translateBoxedTypes` focused on boxing, the single plural diagnostic path, and the `A.T` / `B.T` namespace countercase follow review direction from @simonjbeaumont on #914.

The bug report and repair lineage are not original to this patch; this submission does not claim discovery or sole authorship.

## Verification

- Apple Swift 6.3.2 / macOS SDK 26.5 build 25F70: frozen baseline collision probe RED with exit 133 and `Fatal error: Duplicate values for key: 'NullTime'`.
- The identical collision probe after applying this exact patch completes with one error diagnostic and exit 0.
- `A.T` / `B.T` repository-native generated identities `A.TPayload` / `B.TPayload`: exit 0, no diagnostic.
- `Test_translateSchemas`: throwing collector, non-throwing collector, deterministic multiple collisions, and namespace countercase coverage.
- Previously verified affected offline surface: 312 tests, 1 expected pre-existing skip, 0 failures.
- Strict `swift-format lint` and `git diff --check`: exit 0.

## Scope

Exactly three files change: two `_OpenAPIGeneratorCore` implementation files and one focused test file. No public API or new architecture is introduced.
