### PR TITLE
Use newer swift-prometheus api in example

### DIFF
--- a/Examples/metrics-middleware-example/Package.swift
+++ b/Examples/metrics-middleware-example/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/swift-openapi-vapor", from: "1.0.0"),
         .package(url: "https://github.com/vapor/vapor", from: "4.89.0"),
         .package(url: "https://github.com/apple/swift-metrics", from: "2.4.1"),
-        .package(url: "https://github.com/swift-server/swift-prometheus", from: "2.0.0"),
+        .package(url: "https://github.com/swift-server/swift-prometheus", from: "2.2.0"),
     ],
     targets: [
         .target(

--- a/Examples/metrics-middleware-example/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
+++ b/Examples/metrics-middleware-example/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
@@ -33,9 +33,7 @@ struct Handler: APIProtocol {
         let app = try await Vapor.Application.make()
 
         app.get("metrics") { request in
-            var buffer: [UInt8] = []
-            buffer.reserveCapacity(1024)
-            registry.emit(into: &buffer)
+            let buffer = registry.emitToBuffer()
             return String(decoding: buffer, as: UTF8.self)
         }
 


### PR DESCRIPTION
### Modifications

Use the new API to emit the metrics into a re-used buffer

See https://swiftpackageindex.com/swift-server/swift-prometheus/2.2.0/documentation/prometheus/prometheuscollectorregistry/emittobuffer()

### Result

Using emitToBuffer() simplifies the code, and optimises it too, by auto-adjusting to the optimal size rather than hardcoding 1024

> Uses an internal buffer that auto-sizes on first call to find optimal initial capacity. The buffer may resize during the registry’s lifetime if output grows significantly. Subsequent calls reuse the established capacity, clearing content but preserving the initially allocated memory. Returns a copy.