### PR TITLE
docs: fix typo lenght -> length

### DIFF
--- a/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0004.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0004.md
@@ -433,7 +433,7 @@ extension HTTPBody {
     /// Creates a new body with the provided async sequence.
     /// - Parameters:
     ///   - sequence: An async sequence that provides the byte chunks.
-    ///   - length: The total lenght of the body.
+    ///   - length: The total length of the body.
     ///   - iterationBehavior: The iteration behavior of the sequence, which
     ///     indicates whether it can be iterated multiple times.
     @inlinable public convenience init<Bytes>(_ sequence: Bytes, length: HTTPBody.Length, iterationBehavior: IterationBehavior) where Bytes : Sendable, Bytes : AsyncSequence, Bytes.Element == ArraySlice<UInt8>
@@ -441,7 +441,7 @@ extension HTTPBody {
     /// Creates a new body with the provided async sequence of byte sequences.
     /// - Parameters:
     ///   - sequence: An async sequence that provides the byte chunks.
-    ///   - length: The total lenght of the body.
+    ///   - length: The total length of the body.
     ///   - iterationBehavior: The iteration behavior of the sequence, which
     ///     indicates whether it can be iterated multiple times.
     @inlinable public convenience init<Bytes>(_ sequence: Bytes, length: HTTPBody.Length, iterationBehavior: IterationBehavior) where Bytes : Sendable, Bytes : AsyncSequence, Bytes.Element : Sequence, Bytes.Element.Element == UInt8
@@ -519,7 +519,7 @@ extension HTTPBody {
     /// Creates a new body with the provided async sequence of string chunks.
     /// - Parameters:
     ///   - sequence: An async sequence that provides the string chunks.
-    ///   - length: The total lenght of the body.
+    ///   - length: The total length of the body.
     ///   - iterationBehavior: The iteration behavior of the sequence, which
     ///     indicates whether it can be iterated multiple times.
     @inlinable public convenience init<Strings>(_ sequence: Strings, length: HTTPBody.Length, iterationBehavior: IterationBehavior) where Strings : Sendable, Strings : AsyncSequence, Strings.Element : Sendable, Strings.Element : StringProtocol


### PR DESCRIPTION
One-word typo fix in `Sources/swift-openapi-generator/Documentation.docc/Proposals/SOAR-0004.md:436`: the doc-comment sample reads "- length: The total lenght of the body." → `length`.

The parameter name itself is already correct; only its description is misspelled.
