### PR TITLE
Add dependency-aware types file splitting

### DIFF
--- a/Sources/_OpenAPIGeneratorCore/Config.swift
+++ b/Sources/_OpenAPIGeneratorCore/Config.swift
@@ -70,6 +70,9 @@ public struct Config: Sendable {
     /// The maximum number of declarations emitted in each split namespace file.
     public var maxDeclarationsPerFile: Int?
 
+    /// The maximum number of dependency-ordered layers emitted for generated types.
+    public var dependencyLayerCount: Int?
+
     /// Creates a configuration with the specified generator mode and imports.
     /// - Parameters:
     ///   - mode: The mode to use for generation.
@@ -84,6 +87,7 @@ public struct Config: Sendable {
     ///   - typeOverrides: A map of OpenAPI schema names to desired custom type names.
     ///   - featureFlags: Additional pre-release features to enable.
     ///   - maxDeclarationsPerFile: The maximum number of declarations emitted in each split namespace file.
+    ///   - dependencyLayerCount: The maximum number of dependency-ordered layers emitted for generated types.
     public init(
         mode: GeneratorMode,
         access: AccessModifier,
@@ -94,7 +98,8 @@ public struct Config: Sendable {
         nameOverrides: [String: String] = [:],
         typeOverrides: TypeOverrides = .init(),
         featureFlags: FeatureFlags = [],
-        maxDeclarationsPerFile: Int? = nil
+        maxDeclarationsPerFile: Int? = nil,
+        dependencyLayerCount: Int? = nil
     ) {
         self.mode = mode
         self.access = access
@@ -106,5 +111,6 @@ public struct Config: Sendable {
         self.typeOverrides = typeOverrides
         self.featureFlags = featureFlags
         self.maxDeclarationsPerFile = maxDeclarationsPerFile
+        self.dependencyLayerCount = dependencyLayerCount
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Config.swift
+++ b/Sources/_OpenAPIGeneratorCore/Config.swift
@@ -67,6 +67,9 @@ public struct Config: Sendable {
     /// Additional pre-release features to enable.
     public var featureFlags: FeatureFlags
 
+    /// The maximum number of declarations emitted in each split namespace file.
+    public var maxDeclarationsPerFile: Int?
+
     /// Creates a configuration with the specified generator mode and imports.
     /// - Parameters:
     ///   - mode: The mode to use for generation.
@@ -80,6 +83,7 @@ public struct Config: Sendable {
     ///     of the naming strategy.
     ///   - typeOverrides: A map of OpenAPI schema names to desired custom type names.
     ///   - featureFlags: Additional pre-release features to enable.
+    ///   - maxDeclarationsPerFile: The maximum number of declarations emitted in each split namespace file.
     public init(
         mode: GeneratorMode,
         access: AccessModifier,
@@ -89,7 +93,8 @@ public struct Config: Sendable {
         namingStrategy: NamingStrategy,
         nameOverrides: [String: String] = [:],
         typeOverrides: TypeOverrides = .init(),
-        featureFlags: FeatureFlags = []
+        featureFlags: FeatureFlags = [],
+        maxDeclarationsPerFile: Int? = nil
     ) {
         self.mode = mode
         self.access = access
@@ -100,5 +105,6 @@ public struct Config: Sendable {
         self.nameOverrides = nameOverrides
         self.typeOverrides = typeOverrides
         self.featureFlags = featureFlags
+        self.maxDeclarationsPerFile = maxDeclarationsPerFile
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
+++ b/Sources/_OpenAPIGeneratorCore/Layers/StructuredSwiftRepresentation.swift
@@ -1082,6 +1082,22 @@ struct NamedFileDescription: Equatable, Codable {
 
     /// The contents of the file.
     var contents: FileDescription
+
+    /// Internal information describing a dynamically generated file's role.
+    var metadata: GeneratedFileMetadata? = nil
+}
+
+/// Internal machine-readable information about a dynamically generated file.
+struct GeneratedFileMetadata: Equatable, Codable {
+
+    /// The generated namespace or root represented by the file.
+    var role: String
+
+    /// The zero-based dependency layer, when the file is dependency layered.
+    var dependencyLayer: Int?
+
+    /// The zero-based declaration chunk within the role and dependency layer.
+    var declarationChunk: Int?
 }
 
 /// A file with contents made up of structured Swift code.

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/SchemaDependencyGraph.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/SchemaDependencyGraph.swift
@@ -1,0 +1,276 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIKit
+
+/// A deterministic dependency graph of reusable schemas.
+struct SchemaDependencyGraph {
+
+    /// Schema-to-schema edges, where each value is a dependency of the key.
+    var edges: [String: Set<String>]
+
+    /// Strongly connected schema groups in deterministic discovery order.
+    var stronglyConnectedComponents: [[String]]
+
+    /// The natural dependency layer of each schema.
+    var naturalLayerBySchema: [String: Int]
+
+    /// The number of natural dependency layers.
+    var naturalLayerCount: Int { (naturalLayerBySchema.values.max() ?? -1) + 1 }
+
+    /// Builds the dependency graph from the schemas in the parsed and filtered document.
+    static func build(from schemas: OpenAPI.ComponentDictionary<JSONSchema>) -> Self {
+        let schemaNames = Set(schemas.map(\.key.rawValue))
+        var edges: [String: Set<String>] = [:]
+        for (key, schema) in schemas {
+            var references = schemaReferences(in: schema)
+            references.formIntersection(schemaNames)
+            edges[key.rawValue] = references
+        }
+
+        let scc = stronglyConnectedComponents(in: edges)
+        let componentBySchema = Dictionary(
+            uniqueKeysWithValues: scc.enumerated().flatMap { component, schemas in schemas.map { ($0, component) } }
+        )
+        var componentDependencies = Array(repeating: Set<Int>(), count: scc.count)
+        for (schema, references) in edges {
+            guard let component = componentBySchema[schema] else { continue }
+            for reference in references {
+                guard let dependency = componentBySchema[reference], dependency != component else { continue }
+                componentDependencies[component].insert(dependency)
+            }
+        }
+
+        let componentLayers = dependencyLayers(for: componentDependencies)
+        let naturalLayerBySchema = Dictionary(
+            uniqueKeysWithValues: componentBySchema.map { schema, component in (schema, componentLayers[component]) }
+        )
+        return .init(edges: edges, stronglyConnectedComponents: scc, naturalLayerBySchema: naturalLayerBySchema)
+    }
+
+    /// Maps natural graph depth into at most the requested number of contiguous layers.
+    func mappedLayers(requestedLayerCount: Int) -> [String: Int] {
+        guard naturalLayerCount > requestedLayerCount else { return naturalLayerBySchema }
+        return naturalLayerBySchema.mapValues { naturalLayer in naturalLayer * requestedLayerCount / naturalLayerCount }
+    }
+
+    /// Returns all schema references contained anywhere in a schema.
+    static func schemaReferences(in schema: JSONSchema) -> Set<String> {
+        var references: Set<String> = []
+        collectSchemaReferences(in: schema, into: &references)
+        return references
+    }
+
+    /// Returns all schema references used by a reusable parameter.
+    static func schemaReferences(in parameter: OpenAPI.Parameter, components: OpenAPI.Components) -> Set<String> {
+        var references: Set<String> = []
+        collectSchemaOrContentReferences(parameter.schemaOrContent, components: components, into: &references)
+        return references
+    }
+
+    /// Returns all schema references used by a reusable header.
+    static func schemaReferences(in header: OpenAPI.Header, components: OpenAPI.Components) -> Set<String> {
+        var references: Set<String> = []
+        collectSchemaOrContentReferences(header.schemaOrContent, components: components, into: &references)
+        return references
+    }
+
+    /// Returns all schema references used by a reusable request body.
+    static func schemaReferences(in request: OpenAPI.Request, components: OpenAPI.Components) -> Set<String> {
+        var references: Set<String> = []
+        collectContentReferences(in: request.content, components: components, into: &references)
+        return references
+    }
+
+    /// Returns all schema references used by a reusable response, including referenced headers.
+    static func schemaReferences(in response: OpenAPI.Response, components: OpenAPI.Components) -> Set<String> {
+        var references: Set<String> = []
+        collectContentReferences(in: response.content, components: components, into: &references)
+        for (_, unresolvedHeader) in response.headers ?? [:] {
+            guard let header = resolve(unresolvedHeader, in: components) else { continue }
+            collectSchemaOrContentReferences(header.schemaOrContent, components: components, into: &references)
+        }
+        return references
+    }
+
+    /// Returns all schema references used by an operation and its path-level parameters.
+    static func schemaReferences(in description: OperationDescription) -> Set<String> {
+        var references: Set<String> = []
+        let components = description.components
+        for unresolvedParameter in description.pathParameters + description.operation.parameters {
+            guard let parameter = resolve(unresolvedParameter, in: components) else { continue }
+            collectSchemaOrContentReferences(parameter.schemaOrContent, components: components, into: &references)
+        }
+        if let unresolvedRequest = description.operation.requestBody,
+            let request = resolve(unresolvedRequest, in: components)
+        {
+            collectContentReferences(in: request.content, components: components, into: &references)
+        }
+        for (_, unresolvedResponse) in description.operation.responses {
+            guard let response = resolve(unresolvedResponse, in: components) else { continue }
+            references.formUnion(schemaReferences(in: response, components: components))
+        }
+        return references
+    }
+
+    private static func resolve<Component: ComponentDictionaryLocatable>(
+        _ unresolved: Either<OpenAPI.Reference<Component>, Component>,
+        in components: OpenAPI.Components
+    ) -> Component? {
+        switch unresolved {
+        case .a(let reference): return try? components.lookup(reference)
+        case .b(let component): return component
+        }
+    }
+
+    private static func collectSchemaOrContentReferences(
+        _ schemaOrContent: Either<OpenAPI.Parameter.SchemaContext, OpenAPI.Content.Map>,
+        components: OpenAPI.Components,
+        into references: inout Set<String>
+    ) {
+        switch schemaOrContent {
+        case .a(let context): collectSchemaOrReference(context.schema, into: &references)
+        case .b(let content): collectContentReferences(in: content, components: components, into: &references)
+        }
+    }
+
+    private static func collectContentReferences(
+        in content: OpenAPI.Content.Map,
+        components: OpenAPI.Components,
+        into references: inout Set<String>
+    ) {
+        for (_, unresolvedValue) in content {
+            guard let value = resolve(unresolvedValue, in: components) else { continue }
+            if let schema = value.schema { collectSchemaReferences(in: schema, into: &references) }
+            if let itemSchema = value.itemSchema { collectSchemaReferences(in: itemSchema, into: &references) }
+        }
+    }
+
+    private static func collectSchemaOrReference(
+        _ schema: Either<OpenAPI.Reference<JSONSchema>, JSONSchema>,
+        into references: inout Set<String>
+    ) {
+        switch schema {
+        case .a(let reference): collectReference(reference.jsonReference, into: &references)
+        case .b(let schema): collectSchemaReferences(in: schema, into: &references)
+        }
+    }
+
+    private static func collectSchemaReferences(in schema: JSONSchema, into references: inout Set<String>) {
+        if let discriminator = schema.discriminator {
+            let mappedReferences =
+                (discriminator.mapping?.values.map { $0 } ?? []) + (discriminator.defaultMapping.map { [$0] } ?? [])
+            for rawReference in mappedReferences {
+                guard let reference = JSONReference<JSONSchema>.InternalReference(rawValue: rawReference) else {
+                    continue
+                }
+                collectReference(.internal(reference), into: &references)
+            }
+        }
+
+        switch schema.value {
+        case .reference(let reference, _): collectReference(reference, into: &references)
+        case .object(_, let context):
+            for (_, property) in context.properties { collectSchemaReferences(in: property, into: &references) }
+            if case .b(let schema)? = context.additionalProperties {
+                collectSchemaReferences(in: schema, into: &references)
+            }
+        case .array(_, let context):
+            if let items = context.items { collectSchemaReferences(in: items, into: &references) }
+        case .all(of: let schemas, _), .any(of: let schemas, _), .one(of: let schemas, _):
+            for schema in schemas { collectSchemaReferences(in: schema, into: &references) }
+        case .not(let schema, _): collectSchemaReferences(in: schema, into: &references)
+        default: break
+        }
+    }
+
+    private static func collectReference(_ reference: JSONReference<JSONSchema>, into references: inout Set<String>) {
+        guard case .internal(let internalReference) = reference, case .component(name: let name) = internalReference
+        else { return }
+        references.insert(name)
+    }
+
+    /// Iterative Tarjan SCC to avoid recursion depth limits on large specifications.
+    private static func stronglyConnectedComponents(in graph: [String: Set<String>]) -> [[String]] {
+        let sortedGraph = graph.mapValues { $0.sorted() }
+        var nextIndex = 0
+        var nodeStack: [String] = []
+        var indices: [String: Int] = [:]
+        var lowLinks: [String: Int] = [:]
+        var nodesOnStack: Set<String> = []
+        var components: [[String]] = []
+
+        struct Frame {
+            var node: String
+            var neighbors: [String]
+            var nextNeighbor: Int
+        }
+
+        for start in graph.keys.sorted() where indices[start] == nil {
+            indices[start] = nextIndex
+            lowLinks[start] = nextIndex
+            nextIndex += 1
+            nodeStack.append(start)
+            nodesOnStack.insert(start)
+            var frames = [Frame(node: start, neighbors: sortedGraph[start] ?? [], nextNeighbor: 0)]
+
+            while !frames.isEmpty {
+                let frameIndex = frames.count - 1
+                let node = frames[frameIndex].node
+                if frames[frameIndex].nextNeighbor < frames[frameIndex].neighbors.count {
+                    let neighbor = frames[frameIndex].neighbors[frames[frameIndex].nextNeighbor]
+                    frames[frameIndex].nextNeighbor += 1
+                    if indices[neighbor] == nil {
+                        indices[neighbor] = nextIndex
+                        lowLinks[neighbor] = nextIndex
+                        nextIndex += 1
+                        nodeStack.append(neighbor)
+                        nodesOnStack.insert(neighbor)
+                        frames.append(Frame(node: neighbor, neighbors: sortedGraph[neighbor] ?? [], nextNeighbor: 0))
+                    } else if nodesOnStack.contains(neighbor) {
+                        lowLinks[node] = min(lowLinks[node]!, indices[neighbor]!)
+                    }
+                } else {
+                    frames.removeLast()
+                    if let parent = frames.last?.node { lowLinks[parent] = min(lowLinks[parent]!, lowLinks[node]!) }
+                    if lowLinks[node] == indices[node] {
+                        var component: [String] = []
+                        while let member = nodeStack.popLast() {
+                            nodesOnStack.remove(member)
+                            component.append(member)
+                            if member == node { break }
+                        }
+                        components.append(component.sorted())
+                    }
+                }
+            }
+        }
+        return components
+    }
+
+    private static func dependencyLayers(for dependencies: [Set<Int>]) -> [Int] {
+        var layers = Array(repeating: 0, count: dependencies.count)
+        var unresolved = Set(dependencies.indices)
+        while !unresolved.isEmpty {
+            let ready =
+                unresolved.filter { component in dependencies[component].allSatisfy { !unresolved.contains($0) } }
+                .sorted()
+            precondition(!ready.isEmpty, "The SCC condensation graph must be acyclic.")
+            for component in ready {
+                layers[component] = (dependencies[component].map { layers[$0] }.max() ?? -1) + 1
+                unresolved.remove(component)
+            }
+        }
+        return layers
+    }
+}

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
@@ -11,7 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import Algorithms
 import OpenAPIKit
 
 /// A translator for the generated common types.
@@ -37,6 +36,10 @@ struct TypesFileTranslator: FileTranslator {
         if let maxDeclarationsPerFile, maxDeclarationsPerFile <= 0 {
             throw GenericError(message: "Expected output.maxDeclarationsPerFile to be greater than zero.")
         }
+        let dependencyLayerCount = config.dependencyLayerCount
+        if let dependencyLayerCount, dependencyLayerCount <= 0 {
+            throw GenericError(message: "Expected output.dependencyLayerCount to be greater than zero.")
+        }
 
         let topComment = self.topComment
 
@@ -49,12 +52,25 @@ struct TypesFileTranslator: FileTranslator {
         let serversDecl = translateServers(doc.servers)
 
         let multipartSchemaNames = try parseSchemaNamesUsedInMultipart(paths: doc.paths, components: doc.components)
+        let operationDescriptions = try OperationDescription.all(from: doc.paths, in: doc.components, context: context)
+        if let dependencyLayerCount {
+            return try translateDependencyLayeredFile(
+                doc: doc,
+                topComment: topComment,
+                imports: imports,
+                apiProtocol: apiProtocol,
+                apiProtocolExtension: apiProtocolExtension,
+                serversDecl: serversDecl,
+                multipartSchemaNames: multipartSchemaNames,
+                operationDescriptions: operationDescriptions,
+                requestedLayerCount: dependencyLayerCount
+            )
+        }
+
         let componentNamespaces = try translateComponentNamespaceDescriptions(
             doc.components,
             multipartSchemaNames: multipartSchemaNames
         )
-
-        let operationDescriptions = try OperationDescription.all(from: doc.paths, in: doc.components, context: context)
         let operations = try translateOperations(operationDescriptions)
 
         let componentsRoot = CodeBlock.declaration(
@@ -142,34 +158,17 @@ struct TypesFileTranslator: FileTranslator {
             )
         )
         let namespaceFiles = namespaces.flatMap { namespace in
-            splitFiles(
-                for: namespace.declarations,
+            makeSplitFiles(
+                for: namespace.declarations.map { [$0] },
                 extending: namespace.path.joined(separator: "."),
-                baseFileName: namespace.baseFileName
+                baseFileName: namespace.baseFileName,
+                role: namespace.path.joined(separator: "."),
+                dependencyLayer: nil,
+                preserveEmptyFile: true,
+                topComment: topComment,
+                imports: imports,
+                maxDeclarationsPerFile: maxDeclarationsPerFile
             )
-        }
-
-        func splitFiles(for declarations: [Declaration], extending namespace: String, baseFileName: String)
-            -> [NamedFileDescription]
-        {
-            let declarationChunks =
-                maxDeclarationsPerFile.map { declarations.chunks(ofCount: $0).map(Array.init) } ?? [declarations]
-            // Preserve the unsuffixed namespace file even when there are no declarations.
-            return (declarationChunks.isEmpty ? [declarations] : declarationChunks).enumerated()
-                .map { splitIndex, declarations in
-                    NamedFileDescription(
-                        name: splitIndex == 0 ? baseFileName : baseFileName.appendingFileNameSuffix(String(splitIndex)),
-                        contents: .init(
-                            topComment: topComment,
-                            imports: imports,
-                            codeBlocks: [
-                                .declaration(
-                                    .extension(accessModifier: nil, onType: namespace, declarations: declarations)
-                                )
-                            ]
-                        )
-                    )
-                }
         }
 
         return StructuredSwiftRepresentation(
@@ -185,11 +184,239 @@ struct TypesFileTranslator: FileTranslator {
             ] + namespaceFiles
         )
     }
+
+    private func translateDependencyLayeredFile(
+        doc: ParsedOpenAPIRepresentation,
+        topComment: Comment,
+        imports: [ImportDescription],
+        apiProtocol: Declaration,
+        apiProtocolExtension: Declaration,
+        serversDecl: Declaration,
+        multipartSchemaNames: Set<OpenAPI.ComponentKey>,
+        operationDescriptions: [OperationDescription],
+        requestedLayerCount: Int
+    ) throws -> StructuredSwiftRepresentation {
+        let graph = SchemaDependencyGraph.build(from: doc.components.schemas)
+        let layerBySchema = graph.mappedLayers(requestedLayerCount: requestedLayerCount)
+
+        let schemaGroups = try translateSchemaDeclarationGroups(
+            doc.components.schemas,
+            multipartSchemaNames: multipartSchemaNames
+        )
+        let schemaGroupsByOwner = Dictionary(uniqueKeysWithValues: schemaGroups.map { ($0.owner, $0.declarations) })
+        let schemaLayerGroups: [Int: [[Declaration]]] = Dictionary(grouping: graph.stronglyConnectedComponents) {
+            component in component.compactMap { layerBySchema[$0] }.max() ?? 0
+        }
+        .mapValues { components in
+            components.map { component in component.sorted().flatMap { schemaGroupsByOwner[$0] ?? [] } }
+        }
+
+        let resolvedParameters = try doc.components.parameters.mapValues { try doc.components.assumeLookupOnce($0) }
+        let resolvedRequestBodies = try doc.components.requestBodies.mapValues {
+            try doc.components.assumeLookupOnce($0)
+        }
+        let resolvedResponses = try doc.components.responses.mapValues { try doc.components.assumeLookupOnce($0) }
+        let resolvedHeaders = try doc.components.headers.mapValues {
+            (header: Either<OpenAPI.Reference<OpenAPI.Header>, OpenAPI.Header>) in
+            try doc.components.assumeLookupOnce(header)
+        }
+
+        func highestLayer(for references: Set<String>) -> Int { references.compactMap { layerBySchema[$0] }.max() ?? 0 }
+
+        func groupsByLayer<Component>(
+            _ groups: [OwnedDeclarations],
+            components: OpenAPI.ComponentDictionary<Component>,
+            references: (Component) -> Set<String>
+        ) -> [Int: [[Declaration]]] {
+            var result: [Int: [[Declaration]]] = [:]
+            for group in groups {
+                guard let key = OpenAPI.ComponentKey(rawValue: group.owner), let component = components[key] else {
+                    continue
+                }
+                result[highestLayer(for: references(component)), default: []].append(group.declarations)
+            }
+            return result
+        }
+
+        let parameterGroups = try translateComponentParameterDeclarationGroups(resolvedParameters)
+        let requestBodyGroups = try translateComponentRequestBodyDeclarationGroups(resolvedRequestBodies)
+        let responseGroups = try translateComponentResponseDeclarationGroups(resolvedResponses)
+        let headerGroups = try translateComponentHeaderDeclarationGroups(resolvedHeaders)
+
+        var operationGroupsByLayer: [Int: [[Declaration]]] = [:]
+        for description in operationDescriptions {
+            let layer = highestLayer(for: SchemaDependencyGraph.schemaReferences(in: description))
+            operationGroupsByLayer[layer, default: []].append([try translateOperation(description)])
+        }
+
+        let componentsRoot = CodeBlock.declaration(
+            .commentable(
+                .doc("Types generated from the components section of the OpenAPI document."),
+                .enum(.init(accessModifier: config.access, name: Constants.Components.namespace, members: []))
+            )
+        )
+        let namespaces: [(name: String, comment: Comment?)] = [
+            (Constants.Components.Schemas.namespace, JSONSchema.sectionComment()),
+            (Constants.Components.Parameters.namespace, OpenAPI.Parameter.sectionComment()),
+            (Constants.Components.RequestBodies.namespace, OpenAPI.Request.sectionComment()),
+            (Constants.Components.Responses.namespace, OpenAPI.Response.sectionComment()),
+            (Constants.Components.Headers.namespace, OpenAPI.Header.sectionComment()),
+        ]
+        let componentNamespacesRoot = CodeBlock.declaration(
+            .extension(
+                accessModifier: nil,
+                onType: Constants.Components.namespace,
+                declarations: namespaces.map { namespace in
+                    .commentable(
+                        namespace.comment,
+                        .enum(.init(accessModifier: config.access, name: namespace.name, members: []))
+                    )
+                }
+            )
+        )
+        let operationsRoot = CodeBlock.declaration(
+            .commentable(
+                .operationsNamespace(),
+                .enum(.init(accessModifier: config.access, name: Constants.Operations.namespace, members: []))
+            )
+        )
+
+        var files: [NamedFileDescription] = [
+            .init(
+                name: OutputFileName.types.rawValue,
+                contents: .init(
+                    topComment: topComment,
+                    imports: imports,
+                    codeBlocks: [
+                        .declaration(apiProtocol), .declaration(apiProtocolExtension), .declaration(serversDecl),
+                        componentsRoot, operationsRoot,
+                    ]
+                ),
+                metadata: .init(role: "typesRoot", dependencyLayer: nil, declarationChunk: nil)
+            ),
+            .init(
+                name: OutputFileName.typesComponents.rawValue,
+                contents: .init(topComment: topComment, imports: imports, codeBlocks: [componentNamespacesRoot]),
+                metadata: .init(role: "componentsRoot", dependencyLayer: nil, declarationChunk: nil)
+            ),
+        ]
+
+        func appendLayerFiles(
+            groupsByLayer: [Int: [[Declaration]]],
+            namespace: String,
+            baseFileName: String,
+            role: String
+        ) {
+            for layer in groupsByLayer.keys.sorted() where !(groupsByLayer[layer] ?? []).flatMap({ $0 }).isEmpty {
+                files += makeSplitFiles(
+                    for: groupsByLayer[layer] ?? [],
+                    extending: namespace,
+                    baseFileName: baseFileName.appendingFileNameSuffix("Layer\(layer)"),
+                    role: role,
+                    dependencyLayer: layer,
+                    preserveEmptyFile: false,
+                    topComment: topComment,
+                    imports: imports,
+                    maxDeclarationsPerFile: config.maxDeclarationsPerFile
+                )
+            }
+        }
+
+        appendLayerFiles(
+            groupsByLayer: schemaLayerGroups,
+            namespace: "Components.Schemas",
+            baseFileName: OutputFileName.typesComponentsSchemas.rawValue,
+            role: "components.schemas"
+        )
+        appendLayerFiles(
+            groupsByLayer: groupsByLayer(parameterGroups, components: resolvedParameters) {
+                SchemaDependencyGraph.schemaReferences(in: $0, components: doc.components)
+            },
+            namespace: "Components.Parameters",
+            baseFileName: OutputFileName.typesComponentsParameters.rawValue,
+            role: "components.parameters"
+        )
+        appendLayerFiles(
+            groupsByLayer: groupsByLayer(requestBodyGroups, components: resolvedRequestBodies) {
+                SchemaDependencyGraph.schemaReferences(in: $0, components: doc.components)
+            },
+            namespace: "Components.RequestBodies",
+            baseFileName: OutputFileName.typesComponentsRequestBodies.rawValue,
+            role: "components.requestBodies"
+        )
+        appendLayerFiles(
+            groupsByLayer: groupsByLayer(responseGroups, components: resolvedResponses) {
+                SchemaDependencyGraph.schemaReferences(in: $0, components: doc.components)
+            },
+            namespace: "Components.Responses",
+            baseFileName: OutputFileName.typesComponentsResponses.rawValue,
+            role: "components.responses"
+        )
+        appendLayerFiles(
+            groupsByLayer: groupsByLayer(headerGroups, components: resolvedHeaders) {
+                SchemaDependencyGraph.schemaReferences(in: $0, components: doc.components)
+            },
+            namespace: "Components.Headers",
+            baseFileName: OutputFileName.typesComponentsHeaders.rawValue,
+            role: "components.headers"
+        )
+        appendLayerFiles(
+            groupsByLayer: operationGroupsByLayer,
+            namespace: Constants.Operations.namespace,
+            baseFileName: OutputFileName.typesOperations.rawValue,
+            role: "operations"
+        )
+        return .init(files: files)
+    }
+
+    private func makeSplitFiles(
+        for declarationGroups: [[Declaration]],
+        extending namespace: String,
+        baseFileName: String,
+        role: String,
+        dependencyLayer: Int?,
+        preserveEmptyFile: Bool,
+        topComment: Comment,
+        imports: [ImportDescription],
+        maxDeclarationsPerFile: Int?
+    ) -> [NamedFileDescription] {
+        let declarationChunks: [[Declaration]]
+        if let maxDeclarationsPerFile {
+            var chunks: [[Declaration]] = []
+            for group in declarationGroups {
+                if let last = chunks.indices.last, !chunks[last].isEmpty,
+                    chunks[last].count + group.count <= maxDeclarationsPerFile
+                {
+                    chunks[last].append(contentsOf: group)
+                } else {
+                    chunks.append(group)
+                }
+            }
+            declarationChunks = chunks
+        } else {
+            declarationChunks = declarationGroups.isEmpty ? [] : [declarationGroups.flatMap { $0 }]
+        }
+        let chunks = declarationChunks.isEmpty && preserveEmptyFile ? [[]] : declarationChunks
+        return chunks.enumerated()
+            .map { splitIndex, declarations in
+                NamedFileDescription(
+                    name: splitIndex == 0 ? baseFileName : baseFileName.appendingFileNameSuffix(String(splitIndex)),
+                    contents: .init(
+                        topComment: topComment,
+                        imports: imports,
+                        codeBlocks: [
+                            .declaration(.extension(accessModifier: nil, onType: namespace, declarations: declarations))
+                        ]
+                    ),
+                    metadata: .init(role: role, dependencyLayer: dependencyLayer, declarationChunk: splitIndex)
+                )
+            }
+    }
 }
 
 extension String {
     /// Returns a Swift file name with the provided suffix appended before the extension.
-    fileprivate func appendingFileNameSuffix(_ suffix: String) -> String {
+    func appendingFileNameSuffix(_ suffix: String) -> String {
         hasSuffix(".swift") ? "\(dropLast(".swift".count))+\(suffix).swift" : "\(self)+\(suffix).swift"
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/TypesFileTranslator.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import Algorithms
 import OpenAPIKit
 
 /// A translator for the generated common types.
@@ -32,6 +33,11 @@ struct TypesFileTranslator: FileTranslator {
 
         let doc = parsedOpenAPI
 
+        let maxDeclarationsPerFile = config.maxDeclarationsPerFile
+        if let maxDeclarationsPerFile, maxDeclarationsPerFile <= 0 {
+            throw GenericError(message: "Expected output.maxDeclarationsPerFile to be greater than zero.")
+        }
+
         let topComment = self.topComment
 
         let imports = importDescriptions(adding: Constants.File.imports)
@@ -51,9 +57,6 @@ struct TypesFileTranslator: FileTranslator {
         let operationDescriptions = try OperationDescription.all(from: doc.paths, in: doc.components, context: context)
         let operations = try translateOperations(operationDescriptions)
 
-        let rootCodeBlocks: [CodeBlock] = [
-            .declaration(apiProtocol), .declaration(apiProtocolExtension), .declaration(serversDecl),
-        ]
         let componentsRoot = CodeBlock.declaration(
             .commentable(
                 .doc(
@@ -64,39 +67,149 @@ struct TypesFileTranslator: FileTranslator {
                 .enum(.init(accessModifier: config.access, name: Constants.Components.namespace, members: []))
             )
         )
-        let componentNamespaceFiles: [NamedFileDescription] = componentNamespaces.map { namespace in
-            .init(
-                name: namespace.outputFile.rawValue,
-                contents: .init(
-                    topComment: topComment,
-                    imports: imports,
-                    codeBlocks: [
-                        .declaration(
-                            .extension(
-                                accessModifier: nil,
-                                onType: Constants.Components.namespace,
-                                declarations: [namespace.declaration]
+        if maxDeclarationsPerFile == nil {
+            let rootCodeBlocks: [CodeBlock] = [
+                .declaration(apiProtocol), .declaration(apiProtocolExtension), .declaration(serversDecl),
+            ]
+            let componentNamespaceFiles: [NamedFileDescription] = componentNamespaces.map { namespace in
+                .init(
+                    name: namespace.outputFile.rawValue,
+                    contents: .init(
+                        topComment: topComment,
+                        imports: imports,
+                        codeBlocks: [
+                            .declaration(
+                                .extension(
+                                    accessModifier: nil,
+                                    onType: Constants.Components.namespace,
+                                    declarations: [namespace.declaration]
+                                )
                             )
-                        )
-                    ]
+                        ]
+                    )
                 )
+            }
+            return StructuredSwiftRepresentation(
+                files: [
+                    .init(
+                        name: OutputFileName.types.rawValue,
+                        contents: .init(topComment: topComment, imports: imports, codeBlocks: rootCodeBlocks)
+                    ),
+                    .init(
+                        name: OutputFileName.typesComponents.rawValue,
+                        contents: .init(topComment: topComment, imports: imports, codeBlocks: [componentsRoot])
+                    ),
+                    .init(
+                        name: OutputFileName.typesOperations.rawValue,
+                        contents: .init(topComment: topComment, imports: imports, codeBlocks: [operations])
+                    ),
+                ] + componentNamespaceFiles
             )
         }
+
+        typealias Namespace = (path: [String], baseFileName: String, comment: Comment?, declarations: [Declaration])
+        let namespaces: [Namespace] =
+            [
+                (
+                    path: [Constants.Operations.namespace], baseFileName: OutputFileName.typesOperations.rawValue,
+                    comment: operations.comment, declarations: operations.namespaceDeclarations
+                )
+            ]
+            + componentNamespaces.map { namespace in
+                let contents = namespace.declaration.namespaceContents
+                return (
+                    path: [Constants.Components.namespace, contents.name], baseFileName: namespace.outputFile.rawValue,
+                    comment: contents.comment, declarations: contents.declarations
+                )
+            }
+
+        func namespaceRoot(for namespace: Namespace) -> Declaration {
+            (.commentable(
+                namespace.comment,
+                .enum(.init(accessModifier: config.access, name: namespace.path.last!, members: []))
+            ))
+        }
+
+        let typesRoot: [CodeBlock] =
+            [.declaration(apiProtocol), .declaration(apiProtocolExtension), .declaration(serversDecl), componentsRoot]
+            + namespaces.filter { $0.path.count == 1 }.map { .declaration(namespaceRoot(for: $0)) }
+        let componentNamespacesRoot = CodeBlock.declaration(
+            .extension(
+                accessModifier: nil,
+                onType: Constants.Components.namespace,
+                declarations: namespaces.filter { $0.path.dropLast() == [Constants.Components.namespace] }
+                    .map(namespaceRoot)
+            )
+        )
+        let namespaceFiles = namespaces.flatMap { namespace in
+            splitFiles(
+                for: namespace.declarations,
+                extending: namespace.path.joined(separator: "."),
+                baseFileName: namespace.baseFileName
+            )
+        }
+
+        func splitFiles(for declarations: [Declaration], extending namespace: String, baseFileName: String)
+            -> [NamedFileDescription]
+        {
+            let declarationChunks =
+                maxDeclarationsPerFile.map { declarations.chunks(ofCount: $0).map(Array.init) } ?? [declarations]
+            // Preserve the unsuffixed namespace file even when there are no declarations.
+            return (declarationChunks.isEmpty ? [declarations] : declarationChunks).enumerated()
+                .map { splitIndex, declarations in
+                    NamedFileDescription(
+                        name: splitIndex == 0 ? baseFileName : baseFileName.appendingFileNameSuffix(String(splitIndex)),
+                        contents: .init(
+                            topComment: topComment,
+                            imports: imports,
+                            codeBlocks: [
+                                .declaration(
+                                    .extension(accessModifier: nil, onType: namespace, declarations: declarations)
+                                )
+                            ]
+                        )
+                    )
+                }
+        }
+
         return StructuredSwiftRepresentation(
             files: [
                 .init(
                     name: OutputFileName.types.rawValue,
-                    contents: .init(topComment: topComment, imports: imports, codeBlocks: rootCodeBlocks)
+                    contents: .init(topComment: topComment, imports: imports, codeBlocks: typesRoot)
                 ),
                 .init(
                     name: OutputFileName.typesComponents.rawValue,
-                    contents: .init(topComment: topComment, imports: imports, codeBlocks: [componentsRoot])
+                    contents: .init(topComment: topComment, imports: imports, codeBlocks: [componentNamespacesRoot])
                 ),
-                .init(
-                    name: OutputFileName.typesOperations.rawValue,
-                    contents: .init(topComment: topComment, imports: imports, codeBlocks: [operations])
-                ),
-            ] + componentNamespaceFiles
+            ] + namespaceFiles
         )
+    }
+}
+
+extension String {
+    /// Returns a Swift file name with the provided suffix appended before the extension.
+    fileprivate func appendingFileNameSuffix(_ suffix: String) -> String {
+        hasSuffix(".swift") ? "\(dropLast(".swift".count))+\(suffix).swift" : "\(self)+\(suffix).swift"
+    }
+}
+
+extension Declaration {
+    /// Returns a component namespace's comment and the declarations to emit in extension files.
+    fileprivate var namespaceContents: (name: String, comment: Comment?, declarations: [Declaration]) {
+        guard case .commentable(let comment, .enum(let description)) = self else {
+            preconditionFailure("Expected a commented enum namespace declaration.")
+        }
+        return (description.name, comment, description.members)
+    }
+}
+
+extension CodeBlock {
+    /// Returns the operation declarations to emit in extension files.
+    fileprivate var namespaceDeclarations: [Declaration] {
+        guard case .declaration(.enum(let description)) = item else {
+            preconditionFailure("Expected an enum namespace declaration code block.")
+        }
+        return description.members
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentHeaders.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentHeaders.swift
@@ -22,6 +22,18 @@ extension TypesFileTranslator {
     /// - Throws: An error if there's an issue during translation or header processing.
     func translateComponentHeaders(_ headers: OpenAPI.ComponentDictionary<OpenAPI.Header>) throws -> Declaration {
 
+        let decls = try translateComponentHeaderDeclarationGroups(headers).flatMap(\.declarations)
+
+        let componentsParametersEnum = Declaration.commentable(
+            OpenAPI.Header.sectionComment(),
+            .enum(accessModifier: config.access, name: Constants.Components.Headers.namespace, members: decls)
+        )
+        return componentsParametersEnum
+    }
+
+    func translateComponentHeaderDeclarationGroups(_ headers: OpenAPI.ComponentDictionary<OpenAPI.Header>) throws
+        -> [OwnedDeclarations]
+    {
         let typedHeaders: [(OpenAPI.ComponentKey, TypedResponseHeader)] = try headers.compactMap { key, header in
             let parent = typeAssigner.typeName(for: key, of: OpenAPI.Header.self)
             guard let value = try typedResponseHeader(from: .b(header), named: key.rawValue, inParent: parent) else {
@@ -29,14 +41,11 @@ extension TypesFileTranslator {
             }
             return (key, value)
         }
-        let decls: [Declaration] = try typedHeaders.flatMap { key, value in
-            try translateResponseHeaderInTypes(componentKey: key, header: value)
+        return try typedHeaders.map { key, value in
+            OwnedDeclarations(
+                owner: key.rawValue,
+                declarations: try translateResponseHeaderInTypes(componentKey: key, header: value)
+            )
         }
-
-        let componentsParametersEnum = Declaration.commentable(
-            OpenAPI.Header.sectionComment(),
-            .enum(accessModifier: config.access, name: Constants.Components.Headers.namespace, members: decls)
-        )
-        return componentsParametersEnum
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentParameters.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentParameters.swift
@@ -24,19 +24,28 @@ extension TypesFileTranslator {
         -> Declaration
     {
 
-        let typedParameters: [(OpenAPI.ComponentKey, TypedParameter)] = try parameters.compactMap { key, parameter in
-            let parent = typeAssigner.typeName(for: key, of: OpenAPI.Parameter.self)
-            guard let value = try parseAsTypedParameter(from: .b(parameter), inParent: parent) else { return nil }
-            return (key, value)
-        }
-        let decls: [Declaration] = try typedParameters.flatMap { key, value in
-            try translateParameterInTypes(componentKey: key, parameter: value)
-        }
+        let decls = try translateComponentParameterDeclarationGroups(parameters).flatMap(\.declarations)
 
         let componentsParametersEnum = Declaration.commentable(
             OpenAPI.Parameter.sectionComment(),
             .enum(accessModifier: config.access, name: Constants.Components.Parameters.namespace, members: decls)
         )
         return componentsParametersEnum
+    }
+
+    func translateComponentParameterDeclarationGroups(_ parameters: OpenAPI.ComponentDictionary<OpenAPI.Parameter>)
+        throws -> [OwnedDeclarations]
+    {
+        let typedParameters: [(OpenAPI.ComponentKey, TypedParameter)] = try parameters.compactMap { key, parameter in
+            let parent = typeAssigner.typeName(for: key, of: OpenAPI.Parameter.self)
+            guard let value = try parseAsTypedParameter(from: .b(parameter), inParent: parent) else { return nil }
+            return (key, value)
+        }
+        return try typedParameters.map { key, value in
+            OwnedDeclarations(
+                owner: key.rawValue,
+                declarations: try translateParameterInTypes(componentKey: key, parameter: value)
+            )
+        }
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentRequestBodies.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentRequestBodies.swift
@@ -21,16 +21,24 @@ extension TypesFileTranslator {
     /// - Returns: An enum declaration representing the requestBodies namespace.
     /// - Throws: An error if there's an issue during translation or request body processing.
     func translateComponentRequestBodies(_ items: OpenAPI.ComponentDictionary<OpenAPI.Request>) throws -> Declaration {
-        let typedItems: [TypedRequestBody] = try items.compactMap { key, item in
-            let typeName = typeAssigner.typeName(for: key, of: OpenAPI.Request.self)
-            return try typedRequestBody(typeName: typeName, from: .b(item))
-        }
-        let decls: [Declaration] = try typedItems.map { value in try translateRequestBodyInTypes(requestBody: value) }
+        let decls = try translateComponentRequestBodyDeclarationGroups(items).flatMap(\.declarations)
 
         let componentsEnum = Declaration.commentable(
             OpenAPI.Request.sectionComment(),
             .enum(accessModifier: config.access, name: Constants.Components.RequestBodies.namespace, members: decls)
         )
         return componentsEnum
+    }
+
+    func translateComponentRequestBodyDeclarationGroups(_ items: OpenAPI.ComponentDictionary<OpenAPI.Request>) throws
+        -> [OwnedDeclarations]
+    {
+        let typedItems: [(OpenAPI.ComponentKey, TypedRequestBody)] = try items.compactMap { key, item in
+            let typeName = typeAssigner.typeName(for: key, of: OpenAPI.Request.self)
+            return try typedRequestBody(typeName: typeName, from: .b(item)).map { (key, $0) }
+        }
+        return try typedItems.map { key, value in
+            OwnedDeclarations(owner: key.rawValue, declarations: [try translateRequestBodyInTypes(requestBody: value)])
+        }
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentResponses.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateComponentResponses.swift
@@ -22,19 +22,28 @@ extension TypesFileTranslator {
     /// - Throws: An error if there's an issue during translation or request body processing
     func translateComponentResponses(_ responses: OpenAPI.ComponentDictionary<OpenAPI.Response>) throws -> Declaration {
 
-        let typedResponses: [TypedResponse] = responses.map { key, response in
-            let typeName = typeAssigner.typeName(for: key, of: OpenAPI.Response.self)
-            let value = TypedResponse(response: response, typeUsage: typeName.asUsage, isInlined: false)
-            return value
-        }
-        let decls: [Declaration] = try typedResponses.map { value in
-            try translateResponseInTypes(typeName: value.typeUsage.typeName, response: value)
-        }
+        let decls = try translateComponentResponseDeclarationGroups(responses).flatMap(\.declarations)
 
         let componentsResponsesEnum = Declaration.commentable(
             OpenAPI.Response.sectionComment(),
             .enum(accessModifier: config.access, name: Constants.Components.Responses.namespace, members: decls)
         )
         return componentsResponsesEnum
+    }
+
+    func translateComponentResponseDeclarationGroups(_ responses: OpenAPI.ComponentDictionary<OpenAPI.Response>) throws
+        -> [OwnedDeclarations]
+    {
+        let typedResponses: [(OpenAPI.ComponentKey, TypedResponse)] = responses.map { key, response in
+            let typeName = typeAssigner.typeName(for: key, of: OpenAPI.Response.self)
+            let value = TypedResponse(response: response, typeUsage: typeName.asUsage, isInlined: false)
+            return (key, value)
+        }
+        return try typedResponses.map { key, value in
+            OwnedDeclarations(
+                owner: key.rawValue,
+                declarations: [try translateResponseInTypes(typeName: value.typeUsage.typeName, response: value)]
+            )
+        }
     }
 }

--- a/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateSchemas.swift
+++ b/Sources/_OpenAPIGeneratorCore/Translator/TypesTranslator/translateSchemas.swift
@@ -15,6 +15,12 @@ import OpenAPIKit
 
 extension TypesFileTranslator {
 
+    /// A translated declaration group that must remain with its owning OpenAPI component.
+    struct OwnedDeclarations {
+        var owner: String
+        var declarations: [Declaration]
+    }
+
     /// Returns a list of declarations for the provided schema, defined in the
     /// OpenAPI document under the specified component key.
     ///
@@ -57,15 +63,11 @@ extension TypesFileTranslator {
         _ schemas: OpenAPI.ComponentDictionary<JSONSchema>,
         multipartSchemaNames: Set<OpenAPI.ComponentKey>
     ) throws -> Declaration {
-        let decls: [Declaration] = try schemas.flatMap { key, value in
-            try translateSchema(
-                componentKey: key,
-                schema: value,
-                isMultipartContent: multipartSchemaNames.contains(key)
-            )
-        }
-        try emitDuplicateTypeNameDiagnostic(in: decls)
-        let declsWithBoxingApplied = try boxRecursiveTypes(decls)
+        let declsWithBoxingApplied = try translateSchemaDeclarationGroups(
+            schemas,
+            multipartSchemaNames: multipartSchemaNames
+        )
+        .flatMap(\.declarations)
         let componentsSchemasEnum = Declaration.commentable(
             JSONSchema.sectionComment(),
             .enum(
@@ -75,6 +77,39 @@ extension TypesFileTranslator {
             )
         )
         return componentsSchemasEnum
+    }
+
+    /// Translates schemas while preserving which declarations belong to each schema.
+    func translateSchemaDeclarationGroups(
+        _ schemas: OpenAPI.ComponentDictionary<JSONSchema>,
+        multipartSchemaNames: Set<OpenAPI.ComponentKey>
+    ) throws -> [OwnedDeclarations] {
+        let groups = try schemas.map { key, value in
+            OwnedDeclarations(
+                owner: key.rawValue,
+                declarations: try translateSchema(
+                    componentKey: key,
+                    schema: value,
+                    isMultipartContent: multipartSchemaNames.contains(key)
+                )
+            )
+        }
+        let declarations = groups.flatMap(\.declarations)
+        try emitDuplicateTypeNameDiagnostic(in: declarations)
+        let boxedDeclarations = try boxRecursiveTypes(declarations)
+        precondition(
+            boxedDeclarations.count == declarations.count,
+            "Recursive boxing must preserve the number and ownership of top-level declarations."
+        )
+
+        var nextDeclaration = 0
+        return groups.map { group in
+            defer { nextDeclaration += group.declarations.count }
+            return OwnedDeclarations(
+                owner: group.owner,
+                declarations: Array(boxedDeclarations[nextDeclaration..<(nextDeclaration + group.declarations.count)])
+            )
+        }
     }
 
     /// Emits an error when multiple top-level schema declarations have the same generated Swift type name.

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -48,6 +48,8 @@ The configuration file has the following keys:
 - `typeOverrides` (optional): Allows replacing a generated type with a custom type.
     - `schemas` (optional): a string to string dictionary. The key is the name of the schema, the last component of `#/components/schemas/Foo` (here, `Foo`). The value is the custom type name, such as `CustomFoo`. Check out details in [SOAR-0014](https://swiftpackageindex.com/apple/swift-openapi-generator/documentation/swift-openapi-generator/soar-0014).
 - `featureFlags` (optional): array of strings. Each string must be a valid feature flag to enable. For a list of currently supported feature flags, check out [FeatureFlags.swift](https://github.com/apple/swift-openapi-generator/blob/main/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift).
+- `output` (optional): Controls the generated source-file layout.
+    - `maxDeclarationsPerFile` (optional): A positive integer that limits the number of declarations in each split types namespace file.
 
 ### Example config files
 
@@ -122,6 +124,33 @@ Types generation emits a fixed set of files organized by generated namespace:
 - `Types+Components+Headers.swift`
 
 > Important: The number and names of generated files are _not_ considered to be stable, and can change at any time. For details, check out <doc:API-stability-of-the-generator>.
+
+Each parent file owns its child namespace declarations, and the corresponding `+Namespace` files extend those
+namespaces with generated declarations.
+
+The file layout does not change generated Swift symbol names. For example, schema types remain nested under
+`Components.Schemas`. When invoking the generator directly or checking generated sources into a repository, retain all
+of the emitted files.
+
+The command-line tool and command plugin can further split the declaration-bearing namespace files by setting a
+maximum number of declarations per file:
+
+```yaml
+generate:
+  - types
+output:
+  maxDeclarationsPerFile: 100
+```
+
+For example, a `Schemas` namespace with 250 declarations keeps its first 100 declarations in
+`Types+Components+Schemas.swift`, then places the remaining declarations in two extension files:
+
+- `Types+Components+Schemas+1.swift`
+- `Types+Components+Schemas+2.swift`
+
+The build-tool plugin does not support `maxDeclarationsPerFile` because the number of generated files depends on the
+input document, while build commands must declare their outputs before running the generator. Supporting this option
+there requires migrating the plugin to a prebuild command.
 
 ### Document filtering
 

--- a/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
+++ b/Sources/swift-openapi-generator/Documentation.docc/Articles/Configuring-the-generator.md
@@ -50,6 +50,7 @@ The configuration file has the following keys:
 - `featureFlags` (optional): array of strings. Each string must be a valid feature flag to enable. For a list of currently supported feature flags, check out [FeatureFlags.swift](https://github.com/apple/swift-openapi-generator/blob/main/Sources/_OpenAPIGeneratorCore/FeatureFlags.swift).
 - `output` (optional): Controls the generated source-file layout.
     - `maxDeclarationsPerFile` (optional): A positive integer that limits the number of declarations in each split types namespace file.
+    - `dependencyLayerCount` (optional): A positive integer that limits the number of dependency-ordered layers in the generated types files.
 
 ### Example config files
 
@@ -148,9 +149,35 @@ For example, a `Schemas` namespace with 250 declarations keeps its first 100 dec
 - `Types+Components+Schemas+1.swift`
 - `Types+Components+Schemas+2.swift`
 
-The build-tool plugin does not support `maxDeclarationsPerFile` because the number of generated files depends on the
-input document, while build commands must declare their outputs before running the generator. Supporting this option
-there requires migrating the plugin to a prebuild command.
+The command-line tool and command plugin can also group generated types into dependency-ordered layers:
+
+```yaml
+generate:
+  - types
+output:
+  dependencyLayerCount: 4
+  maxDeclarationsPerFile: 100
+```
+
+Schemas that mutually reference each other remain in one strongly connected group. The generator puts schemas with
+no dependencies in layer 0, then puts dependents in later layers so a generated declaration only references schemas
+in its own or an earlier layer. Reusable parameters, headers, request bodies, and responses retain their existing
+`Components` namespace and are assigned to the highest schema layer they reference. Operations are assigned using the
+same rule.
+
+The configured value is a maximum. If the schema graph is shallower, the generator does not emit empty layers. If the
+graph is deeper, contiguous natural graph depths are folded proportionally into the requested count without changing
+dependency order. Layered files use names such as `Types+Components+Schemas+Layer0.swift` and
+`Types+Operations+Layer2.swift`.
+
+When both output options are present, dependency grouping happens first and `maxDeclarationsPerFile` is applied to
+each namespace layer independently. Schema-owned declaration groups and mutually recursive groups are not split, so
+a single indivisible group can exceed the configured declaration maximum. Additional chunks append the existing
+numeric suffix, for example `Types+Components+Schemas+Layer2+1.swift`.
+
+The build-tool plugin does not support either dynamic output option because the number of generated files depends on
+the input document, while build commands must declare their outputs before running the generator. Supporting these
+options there requires migrating the plugin to a prebuild command.
 
 ### Document filtering
 

--- a/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
@@ -29,6 +29,9 @@ extension _GenerateOptions {
     /// resolving options, generating code, and handling diagnostics.
     func runGenerator(outputDirectory: URL, pluginSource: PluginSource?, isDryRun: Bool) async throws {
         let config = try loadedConfig()
+        if let maxDeclarationsPerFile = config?.output?.maxDeclarationsPerFile, maxDeclarationsPerFile <= 0 {
+            throw ValidationError("Expected output.maxDeclarationsPerFile to be greater than zero.")
+        }
         let sortedModes = try resolvedModes(config)
         let resolvedAccessModifier = resolvedAccessModifier(config)
         let resolvedAdditionalImports = resolvedAdditionalImports(config)
@@ -47,7 +50,8 @@ extension _GenerateOptions {
                 namingStrategy: resolvedNamingStragy,
                 nameOverrides: resolvedNameOverrides,
                 typeOverrides: resolvedTypeOverrides,
-                featureFlags: resolvedFeatureFlags
+                featureFlags: resolvedFeatureFlags,
+                maxDeclarationsPerFile: $0 == .types ? config?.output?.maxDeclarationsPerFile : nil
             )
         }
         let (diagnostics, finalizeDiagnostics) = preparedDiagnosticsCollector(outputPath: diagnosticsOutputPath)
@@ -67,6 +71,7 @@ extension _GenerateOptions {
                 .sorted(by: { $0.key < $1.key })
                 .map { "\"\($0.key)\"->\"\($0.value)\"" }.joined(separator: ", "))
             - Feature flags: \(resolvedFeatureFlags.isEmpty ? "<none>" : resolvedFeatureFlags.map(\.rawValue).joined(separator: ", "))
+            - Maximum declarations per split types file: \(config?.output?.maxDeclarationsPerFile.map(String.init) ?? "<none>")
             - Output file names: \(sortedModes.flatMap { mode in OutputFileName.allCases.filter { mode.outputFileNames.contains($0) } }.map(\.rawValue).joined(separator: ", "))
             - Output directory: \(outputDirectory.path)
             - Diagnostics output path: \(diagnosticsOutputPath?.path ?? "<none - logs to stderr>")

--- a/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
+++ b/Sources/swift-openapi-generator/GenerateOptions+runGenerator.swift
@@ -32,6 +32,9 @@ extension _GenerateOptions {
         if let maxDeclarationsPerFile = config?.output?.maxDeclarationsPerFile, maxDeclarationsPerFile <= 0 {
             throw ValidationError("Expected output.maxDeclarationsPerFile to be greater than zero.")
         }
+        if let dependencyLayerCount = config?.output?.dependencyLayerCount, dependencyLayerCount <= 0 {
+            throw ValidationError("Expected output.dependencyLayerCount to be greater than zero.")
+        }
         let sortedModes = try resolvedModes(config)
         let resolvedAccessModifier = resolvedAccessModifier(config)
         let resolvedAdditionalImports = resolvedAdditionalImports(config)
@@ -51,7 +54,8 @@ extension _GenerateOptions {
                 nameOverrides: resolvedNameOverrides,
                 typeOverrides: resolvedTypeOverrides,
                 featureFlags: resolvedFeatureFlags,
-                maxDeclarationsPerFile: $0 == .types ? config?.output?.maxDeclarationsPerFile : nil
+                maxDeclarationsPerFile: $0 == .types ? config?.output?.maxDeclarationsPerFile : nil,
+                dependencyLayerCount: $0 == .types ? config?.output?.dependencyLayerCount : nil
             )
         }
         let (diagnostics, finalizeDiagnostics) = preparedDiagnosticsCollector(outputPath: diagnosticsOutputPath)
@@ -72,6 +76,7 @@ extension _GenerateOptions {
                 .map { "\"\($0.key)\"->\"\($0.value)\"" }.joined(separator: ", "))
             - Feature flags: \(resolvedFeatureFlags.isEmpty ? "<none>" : resolvedFeatureFlags.map(\.rawValue).joined(separator: ", "))
             - Maximum declarations per split types file: \(config?.output?.maxDeclarationsPerFile.map(String.init) ?? "<none>")
+            - Maximum dependency layers: \(config?.output?.dependencyLayerCount.map(String.init) ?? "<none>")
             - Output file names: \(sortedModes.flatMap { mode in OutputFileName.allCases.filter { mode.outputFileNames.contains($0) } }.map(\.rawValue).joined(separator: ", "))
             - Output directory: \(outputDirectory.path)
             - Diagnostics output path: \(diagnosticsOutputPath?.path ?? "<none - logs to stderr>")

--- a/Sources/swift-openapi-generator/UserConfig.swift
+++ b/Sources/swift-openapi-generator/UserConfig.swift
@@ -80,5 +80,8 @@ struct _UserConfig: Codable {
     struct Output: Codable {
         /// The maximum number of declarations emitted in each split types namespace file.
         var maxDeclarationsPerFile: Int?
+
+        /// The maximum number of dependency-ordered layers emitted for generated types.
+        var dependencyLayerCount: Int?
     }
 }

--- a/Sources/swift-openapi-generator/UserConfig.swift
+++ b/Sources/swift-openapi-generator/UserConfig.swift
@@ -51,6 +51,9 @@ struct _UserConfig: Codable {
     /// A set of features to explicitly enable.
     var featureFlags: FeatureFlags?
 
+    /// Options controlling generated output files.
+    var output: Output?
+
     /// A set of raw values corresponding to the coding keys of this struct.
     static let codingKeysRawValues = Set(CodingKeys.allCases.map({ $0.rawValue }))
 
@@ -64,11 +67,18 @@ struct _UserConfig: Codable {
         case nameOverrides
         case typeOverrides
         case featureFlags
+        case output
     }
 
     /// A container of type overrides.
     struct TypeOverrides: Codable {
         /// A dictionary of overrides for replacing the types generated from schemas with manually provided types.
         var schemas: [String: String]?
+    }
+
+    /// Options controlling generated output files.
+    struct Output: Codable {
+        /// The maximum number of declarations emitted in each split types namespace file.
+        var maxDeclarationsPerFile: Int?
     }
 }

--- a/Sources/swift-openapi-generator/runGenerator.swift
+++ b/Sources/swift-openapi-generator/runGenerator.swift
@@ -43,6 +43,12 @@ extension _Tool {
         isDryRun: Bool,
         diagnostics: any DiagnosticCollector & Sendable
     ) async throws {
+        if pluginSource == .build, configs.contains(where: { $0.mode == .types && $0.maxDeclarationsPerFile != nil }) {
+            throw ValidationError(
+                "output.maxDeclarationsPerFile is not supported by the build-tool plugin because its generated output files must be declared before generation."
+            )
+        }
+
         let docData: Data
         do { docData = try Data(contentsOf: doc) } catch {
             throw ValidationError("Failed to load the OpenAPI document at path \(doc.path), error: \(error)")

--- a/Sources/swift-openapi-generator/runGenerator.swift
+++ b/Sources/swift-openapi-generator/runGenerator.swift
@@ -43,9 +43,13 @@ extension _Tool {
         isDryRun: Bool,
         diagnostics: any DiagnosticCollector & Sendable
     ) async throws {
-        if pluginSource == .build, configs.contains(where: { $0.mode == .types && $0.maxDeclarationsPerFile != nil }) {
+        if pluginSource == .build,
+            configs.contains(where: {
+                $0.mode == .types && ($0.maxDeclarationsPerFile != nil || $0.dependencyLayerCount != nil)
+            })
+        {
             throw ValidationError(
-                "output.maxDeclarationsPerFile is not supported by the build-tool plugin because its generated output files must be declared before generation."
+                "Dynamic output splitting is not supported by the build-tool plugin because its generated output files must be declared before generation."
             )
         }
 

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_TypesFileTranslatorFileSplitting.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_TypesFileTranslatorFileSplitting.swift
@@ -170,6 +170,162 @@ final class Test_TypesFileTranslatorFileSplitting: Test_Core {
         }
     }
 
+    func testDependencyLayersMustBePositive() throws {
+        let input = InMemoryInputFile(absolutePath: URL(string: "openapi.yaml")!, contents: Data(Self.source.utf8))
+
+        for invalidCount in [0, -1] {
+            XCTAssertThrowsError(
+                try runGenerator(
+                    input: input,
+                    config: Config(
+                        mode: .types,
+                        access: .public,
+                        namingStrategy: .defensive,
+                        dependencyLayerCount: invalidCount
+                    ),
+                    diagnostics: AccumulatingDiagnosticCollector()
+                )
+            ) { error in
+                XCTAssertTrue(String(describing: error).contains("dependencyLayerCount to be greater than zero"))
+            }
+        }
+    }
+
+    func testShallowDependencyGraphDoesNotProduceEmptyLayerFiles() throws {
+        let input = InMemoryInputFile(absolutePath: URL(string: "openapi.yaml")!, contents: Data(Self.source.utf8))
+        let outputs = try runGenerator(
+            input: input,
+            config: Config(mode: .types, access: .public, namingStrategy: .defensive, dependencyLayerCount: 4),
+            diagnostics: AccumulatingDiagnosticCollector()
+        )
+
+        XCTAssertEqual(
+            outputs.map(\.baseName),
+            [
+                "Types.swift", "Types+Components.swift", "Types+Components+Schemas+Layer0.swift",
+                "Types+Operations+Layer0.swift",
+            ]
+        )
+        XCTAssertFalse(outputs.map(\.baseName).contains { $0.contains("Layer1") })
+    }
+
+    func testEmptySchemaGraphPlacesUnreferencedOperationsInLayerZero() throws {
+        let source = """
+            openapi: "3.1.0"
+            info:
+              title: NoSchemas
+              version: "1.0.0"
+            paths:
+              /health:
+                get:
+                  operationId: getHealth
+                  responses:
+                    "204":
+                      description: Healthy.
+            """
+        let input = InMemoryInputFile(absolutePath: URL(string: "openapi.yaml")!, contents: Data(source.utf8))
+        let outputs = try runGenerator(
+            input: input,
+            config: Config(mode: .types, access: .public, namingStrategy: .defensive, dependencyLayerCount: 3),
+            diagnostics: AccumulatingDiagnosticCollector()
+        )
+        let outputByName = Self.outputByName(outputs)
+
+        XCTAssertNil(outputByName["Types+Components+Schemas+Layer0.swift"])
+        XCTAssertTrue(try XCTUnwrap(outputByName["Types+Operations+Layer0.swift"]).contains("getHealth"))
+        XCTAssertFalse(outputs.map(\.baseName).contains { $0.contains("Layer1") })
+    }
+
+    func testDependencyLayersPlaceComponentsAndOperationsAtHighestReferencedLayer() throws {
+        let input = InMemoryInputFile(
+            absolutePath: URL(string: "openapi.yaml")!,
+            contents: Data(Self.dependencyLayerSource.utf8)
+        )
+        let diagnostics = AccumulatingDiagnosticCollector()
+        let outputs = try runGenerator(
+            input: input,
+            config: Config(mode: .types, access: .public, namingStrategy: .defensive, dependencyLayerCount: 4),
+            diagnostics: diagnostics
+        )
+        XCTAssertEqual(diagnostics.diagnostics.filter { $0.severity == .error }.count, 0)
+        let outputByName = Self.outputByName(outputs)
+
+        let lowestSchemas = try XCTUnwrap(outputByName["Types+Components+Schemas+Layer0.swift"])
+        XCTAssertTrue(lowestSchemas.contains("struct A"))
+        XCTAssertTrue(lowestSchemas.contains("struct B"))
+        XCTAssertTrue(try XCTUnwrap(outputByName["Types+Components+Schemas+Layer1.swift"]).contains("struct C"))
+        XCTAssertTrue(try XCTUnwrap(outputByName["Types+Components+Schemas+Layer2.swift"]).contains("struct D"))
+        let highestSchemas = try XCTUnwrap(outputByName["Types+Components+Schemas+Layer3.swift"])
+        XCTAssertTrue(highestSchemas.contains("struct HelperOwner"))
+
+        XCTAssertTrue(try XCTUnwrap(outputByName["Types+Components+Parameters+Layer2.swift"]).contains("HighParameter"))
+        XCTAssertTrue(
+            try XCTUnwrap(outputByName["Types+Components+RequestBodies+Layer2.swift"]).contains("HighRequest")
+        )
+        XCTAssertTrue(try XCTUnwrap(outputByName["Types+Components+Responses+Layer2.swift"]).contains("HighResponse"))
+        XCTAssertTrue(try XCTUnwrap(outputByName["Types+Components+Headers+Layer1.swift"]).contains("HighHeader"))
+        XCTAssertTrue(try XCTUnwrap(outputByName["Types+Operations+Layer0.swift"]).contains("getLow"))
+        XCTAssertTrue(try XCTUnwrap(outputByName["Types+Operations+Layer2.swift"]).contains("getHigh"))
+    }
+
+    func testDependencyLayersComposeWithDeclarationSplittingAndKeepSCCsTogether() throws {
+        let input = InMemoryInputFile(
+            absolutePath: URL(string: "openapi.yaml")!,
+            contents: Data(Self.dependencyLayerSource.utf8)
+        )
+        let config = Config(
+            mode: .types,
+            access: .public,
+            namingStrategy: .defensive,
+            maxDeclarationsPerFile: 1,
+            dependencyLayerCount: 2
+        )
+        let first = try runGenerator(input: input, config: config, diagnostics: AccumulatingDiagnosticCollector())
+        let second = try runGenerator(input: input, config: config, diagnostics: AccumulatingDiagnosticCollector())
+
+        XCTAssertEqual(first.map(\.baseName), second.map(\.baseName))
+        XCTAssertEqual(first.map(\.contents), second.map(\.contents))
+        XCTAssertTrue(first.map(\.baseName).contains("Types+Components+Schemas+Layer0+1.swift"))
+        XCTAssertTrue(first.map(\.baseName).contains("Types+Components+Schemas+Layer1+1.swift"))
+
+        let sources = first.map { String(decoding: $0.contents, as: UTF8.self) }
+        let mutualSource = try XCTUnwrap(sources.first { $0.contains("struct MutualOne") })
+        XCTAssertTrue(mutualSource.contains("struct MutualTwo"))
+        XCTAssertTrue(mutualSource.contains("Storage"), "Expected recursive boxing to remain applied within the SCC.")
+        XCTAssertFalse(sources.filter { $0.contains("struct MutualOne") || $0.contains("struct MutualTwo") }.count > 1)
+
+        let helperSource = try XCTUnwrap(sources.first { $0.contains("struct HelperOwner") })
+        XCTAssertTrue(helperSource.contains("struct detailPayload"))
+    }
+
+    func testDependencyLayersPreserveDuplicateGeneratedNameDiagnostic() throws {
+        let source = """
+            openapi: "3.1.0"
+            info:
+              title: DuplicateNames
+              version: "1.0.0"
+            paths: {}
+            components:
+              schemas:
+                NullTime:
+                  type: string
+                nullTime:
+                  type: string
+            """
+        let input = InMemoryInputFile(absolutePath: URL(string: "openapi.yaml")!, contents: Data(source.utf8))
+        let diagnostics = AccumulatingDiagnosticCollector()
+
+        _ = try runGenerator(
+            input: input,
+            config: Config(mode: .types, access: .public, namingStrategy: .idiomatic, dependencyLayerCount: 2),
+            diagnostics: diagnostics
+        )
+
+        XCTAssertEqual(diagnostics.diagnostics.count, 1)
+        XCTAssertTrue(diagnostics.diagnostics[0].description.contains("Multiple schemas"))
+        XCTAssertEqual(diagnostics.diagnostics[0].context, ["names": "'NullTime'"])
+    }
+
     private static func outputByName(_ outputs: [InMemoryOutputFile]) -> [String: String] {
         Dictionary(
             uniqueKeysWithValues: outputs.map { output in
@@ -241,5 +397,101 @@ final class Test_TypesFileTranslatorFileSplitting: Test_Core {
                 - id
             Role:
               type: string
+        """
+
+    private static let dependencyLayerSource = """
+        openapi: "3.1.0"
+        info:
+          title: DependencyLayers
+          version: "1.0.0"
+        paths:
+          /low:
+            get:
+              operationId: getLow
+              responses:
+                "200":
+                  description: Low.
+                  content:
+                    application/json:
+                      schema:
+                        $ref: "#/components/schemas/A"
+          /high:
+            get:
+              operationId: getHigh
+              parameters:
+                - $ref: "#/components/parameters/HighParameter"
+              requestBody:
+                $ref: "#/components/requestBodies/HighRequest"
+              responses:
+                "200":
+                  $ref: "#/components/responses/HighResponse"
+        components:
+          schemas:
+            A:
+              type: object
+              properties:
+                value:
+                  type: string
+            B:
+              type: object
+              properties:
+                a:
+                  $ref: "#/components/schemas/A"
+            C:
+              type: object
+              properties:
+                b:
+                  $ref: "#/components/schemas/B"
+            D:
+              type: object
+              properties:
+                c:
+                  $ref: "#/components/schemas/C"
+            HelperOwner:
+              type: object
+              properties:
+                d:
+                  $ref: "#/components/schemas/D"
+                detail:
+                  type: object
+                  properties:
+                    value:
+                      type: string
+            MutualOne:
+              type: object
+              properties:
+                other:
+                  $ref: "#/components/schemas/MutualTwo"
+            MutualTwo:
+              type: object
+              properties:
+                other:
+                  $ref: "#/components/schemas/MutualOne"
+          parameters:
+            HighParameter:
+              name: high
+              in: query
+              schema:
+                $ref: "#/components/schemas/D"
+          headers:
+            HighHeader:
+              schema:
+                $ref: "#/components/schemas/C"
+          requestBodies:
+            HighRequest:
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/D"
+          responses:
+            HighResponse:
+              description: High.
+              headers:
+                X-High:
+                  $ref: "#/components/headers/HighHeader"
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/D"
         """
 }

--- a/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_TypesFileTranslatorFileSplitting.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Hooks/Test_TypesFileTranslatorFileSplitting.swift
@@ -103,6 +103,71 @@ final class Test_TypesFileTranslatorFileSplitting: Test_Core {
         XCTAssertTrue(operationsSource.contains("enum Operations"))
         XCTAssertFalse(operationsSource.contains("enum Components"))
         XCTAssertFalse(operationsSource.contains("protocol APIProtocol"))
+        XCTAssertTrue(operationsSource.contains("getUser"))
+    }
+
+    func testConfiguredMaximumSplitsDeclarationsAcrossExtensionFiles() throws {
+        let input = InMemoryInputFile(absolutePath: URL(string: "openapi.yaml")!, contents: Data(Self.source.utf8))
+        let diagnostics = AccumulatingDiagnosticCollector()
+        let outputs = try runGenerator(
+            input: input,
+            config: Config(mode: .types, access: .public, namingStrategy: .defensive, maxDeclarationsPerFile: 1),
+            diagnostics: diagnostics
+        )
+
+        XCTAssertEqual(diagnostics.diagnostics.count, 0)
+        XCTAssertEqual(
+            outputs.map(\.baseName),
+            [
+                "Types.swift", "Types+Components.swift", "Types+Operations.swift", "Types+Operations+1.swift",
+                "Types+Components+Schemas.swift", "Types+Components+Schemas+1.swift",
+                "Types+Components+Parameters.swift", "Types+Components+RequestBodies.swift",
+                "Types+Components+Responses.swift", "Types+Components+Headers.swift",
+            ]
+        )
+
+        let outputByName = Self.outputByName(outputs)
+        for outputSource in outputByName.values { XCTAssertTrue(outputSource.contains("public import")) }
+        let operationsContainer = try XCTUnwrap(outputByName["Types+Operations.swift"])
+        let operationsSplitFile = try XCTUnwrap(outputByName["Types+Operations+1.swift"])
+        let schemasContainer = try XCTUnwrap(outputByName["Types+Components+Schemas.swift"])
+        let schemasSplitFile = try XCTUnwrap(outputByName["Types+Components+Schemas+1.swift"])
+
+        XCTAssertTrue(operationsContainer.contains("extension Operations"))
+        XCTAssertFalse(operationsContainer.contains("enum Operations"))
+        XCTAssertTrue(operationsContainer.contains("getUser"))
+        XCTAssertFalse(operationsContainer.contains("listUsers"))
+        XCTAssertTrue(operationsSplitFile.contains("extension Operations"))
+        XCTAssertFalse(operationsSplitFile.contains("getUser"))
+        XCTAssertTrue(operationsSplitFile.contains("listUsers"))
+        XCTAssertTrue(schemasContainer.contains("extension Components.Schemas"))
+        XCTAssertFalse(schemasContainer.contains("enum Schemas"))
+        XCTAssertTrue(schemasContainer.contains("struct User"))
+        XCTAssertFalse(schemasContainer.contains("Role"))
+        XCTAssertTrue(schemasSplitFile.contains("extension Components.Schemas"))
+        XCTAssertFalse(schemasSplitFile.contains("struct User"))
+        XCTAssertTrue(schemasSplitFile.contains("Role"))
+    }
+
+    func testConfiguredMaximumMustBePositive() throws {
+        let input = InMemoryInputFile(absolutePath: URL(string: "openapi.yaml")!, contents: Data(Self.source.utf8))
+
+        for invalidLimit in [0, -1] {
+            XCTAssertThrowsError(
+                try runGenerator(
+                    input: input,
+                    config: Config(
+                        mode: .types,
+                        access: .public,
+                        namingStrategy: .defensive,
+                        maxDeclarationsPerFile: invalidLimit
+                    ),
+                    diagnostics: AccumulatingDiagnosticCollector()
+                )
+            ) { error in
+                XCTAssertTrue(String(describing: error).contains("maxDeclarationsPerFile to be greater than zero"))
+            }
+        }
     }
 
     private static func outputByName(_ outputs: [InMemoryOutputFile]) -> [String: String] {
@@ -156,6 +221,12 @@ final class Test_TypesFileTranslatorFileSplitting: Test_Core {
                     application/json:
                       schema:
                         $ref: "#/components/schemas/User"
+          /users:
+            get:
+              operationId: listUsers
+              responses:
+                "200":
+                  description: A list of users.
         components:
           schemas:
             User:
@@ -168,5 +239,7 @@ final class Test_TypesFileTranslatorFileSplitting: Test_Core {
                   format: date-time
               required:
                 - id
+            Role:
+              type: string
         """
 }

--- a/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_SchemaDependencyGraph.swift
+++ b/Tests/OpenAPIGeneratorCoreTests/Translator/TypesTranslator/Test_SchemaDependencyGraph.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftOpenAPIGenerator open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftOpenAPIGenerator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftOpenAPIGenerator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import OpenAPIKit
+import XCTest
+@testable import _OpenAPIGeneratorCore
+
+final class Test_SchemaDependencyGraph: XCTestCase {
+
+    func testDependenciesAndStronglyConnectedComponentsProduceNaturalLayers() {
+        let schemas: OpenAPI.ComponentDictionary<JSONSchema> = [
+            "A": .string, "B": .object(properties: ["a": .reference(.component(named: "A"))]),
+            "C": .object(properties: ["b": .reference(.component(named: "B")), "d": .reference(.component(named: "D"))]
+            ), "D": .object(properties: ["c": .reference(.component(named: "C"))]),
+        ]
+
+        let graph = SchemaDependencyGraph.build(from: schemas)
+
+        XCTAssertEqual(graph.edges["B"], ["A"])
+        XCTAssertEqual(graph.edges["C"], ["B", "D"])
+        XCTAssertTrue(graph.stronglyConnectedComponents.contains(["C", "D"]))
+        XCTAssertEqual(graph.naturalLayerBySchema, ["A": 0, "B": 1, "C": 2, "D": 2])
+        for (schema, dependencies) in graph.edges {
+            for dependency in dependencies {
+                XCTAssertLessThanOrEqual(graph.naturalLayerBySchema[dependency]!, graph.naturalLayerBySchema[schema]!)
+            }
+        }
+    }
+
+    func testDeepGraphFoldsProportionallyWithoutForwardDependencies() {
+        let graph = SchemaDependencyGraph.build(from: Self.chain(length: 5))
+        let mapped = graph.mappedLayers(requestedLayerCount: 3)
+
+        XCTAssertEqual(mapped, ["S0": 0, "S1": 0, "S2": 1, "S3": 1, "S4": 2])
+        for (schema, dependencies) in graph.edges {
+            for dependency in dependencies { XCTAssertLessThanOrEqual(mapped[dependency]!, mapped[schema]!) }
+        }
+    }
+
+    func testShallowGraphDoesNotPadEmptyLayers() {
+        let graph = SchemaDependencyGraph.build(from: Self.chain(length: 2))
+        XCTAssertEqual(graph.mappedLayers(requestedLayerCount: 5), ["S0": 0, "S1": 1])
+        XCTAssertEqual(Set(graph.mappedLayers(requestedLayerCount: 5).values), [0, 1])
+    }
+
+    func testGraphConstructionIsDeterministic() {
+        let schemas = Self.chain(length: 20)
+        let first = SchemaDependencyGraph.build(from: schemas)
+        let second = SchemaDependencyGraph.build(from: schemas)
+
+        XCTAssertEqual(first.edges, second.edges)
+        XCTAssertEqual(first.stronglyConnectedComponents, second.stronglyConnectedComponents)
+        XCTAssertEqual(first.naturalLayerBySchema, second.naturalLayerBySchema)
+    }
+
+    private static func chain(length: Int) -> OpenAPI.ComponentDictionary<JSONSchema> {
+        var schemas: OpenAPI.ComponentDictionary<JSONSchema> = [:]
+        for index in 0..<length {
+            schemas[OpenAPI.ComponentKey(rawValue: "S\(index)")!] =
+                index == 0 ? .string : .object(properties: ["previous": .reference(.component(named: "S\(index - 1)"))])
+        }
+        return schemas
+    }
+}

--- a/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/FileBasedReferenceTests.swift
@@ -21,6 +21,7 @@ struct TestConfig: Encodable {
     var mode: GeneratorMode
     var additionalImports: [String]?
     var featureFlags: FeatureFlags?
+    var maxDeclarationsPerFile: Int?
     var namingStrategy: NamingStrategy
     var nameOverrides: [String: String]
     var referenceOutputDirectory: String
@@ -34,7 +35,8 @@ extension TestConfig {
             additionalImports: additionalImports ?? [],
             namingStrategy: namingStrategy,
             nameOverrides: nameOverrides,
-            featureFlags: featureFlags ?? []
+            featureFlags: featureFlags ?? [],
+            maxDeclarationsPerFile: maxDeclarationsPerFile
         )
     }
 }
@@ -145,6 +147,7 @@ final class FileBasedReferenceTests: XCTestCase {
                     mode: mode,
                     additionalImports: [],
                     featureFlags: featureFlags,
+                    maxDeclarationsPerFile: mode == .types ? 10_000 : nil,
                     namingStrategy: .idiomatic,
                     nameOverrides: [:],
                     referenceOutputDirectory: "ReferenceSources/\(project.fixtureCodeDirectoryName)"

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+Headers.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+Headers.swift
@@ -9,12 +9,9 @@ public import struct Foundation.URL
 public import struct Foundation.Data
 public import struct Foundation.Date
 #endif
-extension Components {
-    /// Types generated from the `#/components/headers` section of the OpenAPI document.
-    public enum Headers {
-        /// A description here.
-        ///
-        /// - Remark: Generated from `#/components/headers/TracingHeader`.
-        public typealias TracingHeader = Swift.String
-    }
+extension Components.Headers {
+    /// A description here.
+    ///
+    /// - Remark: Generated from `#/components/headers/TracingHeader`.
+    public typealias TracingHeader = Swift.String
 }

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+Parameters.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+Parameters.swift
@@ -9,16 +9,13 @@ public import struct Foundation.URL
 public import struct Foundation.Data
 public import struct Foundation.Date
 #endif
-extension Components {
-    /// Types generated from the `#/components/parameters` section of the OpenAPI document.
-    public enum Parameters {
-        /// Supply this parameter to filter pets born since the provided date.
-        ///
-        /// - Remark: Generated from `#/components/parameters/query.born-since`.
-        public typealias Query_bornSince = Components.Schemas.Dob
-        /// The id of the pet to retrieve
-        ///
-        /// - Remark: Generated from `#/components/parameters/path.petId`.
-        public typealias Path_petId = Swift.Int64
-    }
+extension Components.Parameters {
+    /// Supply this parameter to filter pets born since the provided date.
+    ///
+    /// - Remark: Generated from `#/components/parameters/query.born-since`.
+    public typealias Query_bornSince = Components.Schemas.Dob
+    /// The id of the pet to retrieve
+    ///
+    /// - Remark: Generated from `#/components/parameters/path.petId`.
+    public typealias Path_petId = Swift.Int64
 }

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+RequestBodies.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+RequestBodies.swift
@@ -9,130 +9,127 @@ public import struct Foundation.URL
 public import struct Foundation.Data
 public import struct Foundation.Date
 #endif
-extension Components {
-    /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
-    public enum RequestBodies {
-        /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest`.
-        @frozen public enum UpdatePetRequest: Sendable, Hashable {
-            /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json`.
-            public struct JsonPayload: Codable, Hashable, Sendable {
-                /// Pet name
-                ///
-                /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json/name`.
-                public var name: Swift.String?
-                /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json/kind`.
-                public var kind: Components.Schemas.PetKind?
-                /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json/tag`.
-                public var tag: Swift.String?
-                /// Creates a new `JsonPayload`.
+extension Components.RequestBodies {
+    /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest`.
+    @frozen public enum UpdatePetRequest: Sendable, Hashable {
+        /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json`.
+        public struct JsonPayload: Codable, Hashable, Sendable {
+            /// Pet name
+            ///
+            /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json/name`.
+            public var name: Swift.String?
+            /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json/kind`.
+            public var kind: Components.Schemas.PetKind?
+            /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/json/tag`.
+            public var tag: Swift.String?
+            /// Creates a new `JsonPayload`.
+            ///
+            /// - Parameters:
+            ///   - name: Pet name
+            ///   - kind:
+            ///   - tag:
+            public init(
+                name: Swift.String? = nil,
+                kind: Components.Schemas.PetKind? = nil,
+                tag: Swift.String? = nil
+            ) {
+                self.name = name
+                self.kind = kind
+                self.tag = tag
+            }
+            public enum CodingKeys: String, CodingKey {
+                case name
+                case kind
+                case tag
+            }
+        }
+        /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/content/application\/json`.
+        case json(Components.RequestBodies.UpdatePetRequest.JsonPayload)
+    }
+    /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest`.
+    @frozen public enum MultipartUploadTypedRequest: Sendable, Hashable {
+        /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm`.
+        @frozen public enum MultipartFormPayload: Sendable, Hashable {
+            /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log`.
+            public struct LogPayload: Sendable, Hashable {
+                /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log/headers`.
+                public struct Headers: Sendable, Hashable {
+                    /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log/headers/x-log-type`.
+                    @frozen public enum XLogTypePayload: String, Codable, Hashable, Sendable, CaseIterable {
+                        case structured = "structured"
+                        case unstructured = "unstructured"
+                    }
+                    /// The type of the log.
+                    ///
+                    /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log/headers/x-log-type`.
+                    public var xLogType: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload.Headers.XLogTypePayload?
+                    /// Creates a new `Headers`.
+                    ///
+                    /// - Parameters:
+                    ///   - xLogType: The type of the log.
+                    public init(xLogType: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload.Headers.XLogTypePayload? = nil) {
+                        self.xLogType = xLogType
+                    }
+                }
+                /// Received HTTP response headers
+                public var headers: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload.Headers
+                public var body: OpenAPIRuntime.HTTPBody
+                /// Creates a new `LogPayload`.
                 ///
                 /// - Parameters:
-                ///   - name: Pet name
-                ///   - kind:
-                ///   - tag:
+                ///   - headers: Received HTTP response headers
+                ///   - body:
                 public init(
-                    name: Swift.String? = nil,
-                    kind: Components.Schemas.PetKind? = nil,
-                    tag: Swift.String? = nil
+                    headers: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload.Headers = .init(),
+                    body: OpenAPIRuntime.HTTPBody
                 ) {
-                    self.name = name
-                    self.kind = kind
-                    self.tag = tag
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case name
-                    case kind
-                    case tag
+                    self.headers = headers
+                    self.body = body
                 }
             }
-            /// - Remark: Generated from `#/components/requestBodies/UpdatePetRequest/content/application\/json`.
-            case json(Components.RequestBodies.UpdatePetRequest.JsonPayload)
-        }
-        /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest`.
-        @frozen public enum MultipartUploadTypedRequest: Sendable, Hashable {
-            /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm`.
-            @frozen public enum MultipartFormPayload: Sendable, Hashable {
-                /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log`.
-                public struct LogPayload: Sendable, Hashable {
-                    /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log/headers`.
-                    public struct Headers: Sendable, Hashable {
-                        /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log/headers/x-log-type`.
-                        @frozen public enum XLogTypePayload: String, Codable, Hashable, Sendable, CaseIterable {
-                            case structured = "structured"
-                            case unstructured = "unstructured"
-                        }
-                        /// The type of the log.
-                        ///
-                        /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/log/headers/x-log-type`.
-                        public var xLogType: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload.Headers.XLogTypePayload?
-                        /// Creates a new `Headers`.
-                        ///
-                        /// - Parameters:
-                        ///   - xLogType: The type of the log.
-                        public init(xLogType: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload.Headers.XLogTypePayload? = nil) {
-                            self.xLogType = xLogType
-                        }
-                    }
-                    /// Received HTTP response headers
-                    public var headers: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload.Headers
-                    public var body: OpenAPIRuntime.HTTPBody
-                    /// Creates a new `LogPayload`.
+            case log(OpenAPIRuntime.MultipartPart<Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload>)
+            /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/metadata`.
+            public struct MetadataPayload: Sendable, Hashable {
+                /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/metadata/content/body`.
+                public struct BodyPayload: Codable, Hashable, Sendable {
+                    /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/metadata/content/body/createdAt`.
+                    public var createdAt: Foundation.Date
+                    /// Creates a new `BodyPayload`.
                     ///
                     /// - Parameters:
-                    ///   - headers: Received HTTP response headers
-                    ///   - body:
-                    public init(
-                        headers: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload.Headers = .init(),
-                        body: OpenAPIRuntime.HTTPBody
-                    ) {
-                        self.headers = headers
-                        self.body = body
+                    ///   - createdAt:
+                    public init(createdAt: Foundation.Date) {
+                        self.createdAt = createdAt
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case createdAt
                     }
                 }
-                case log(OpenAPIRuntime.MultipartPart<Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.LogPayload>)
-                /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/metadata`.
-                public struct MetadataPayload: Sendable, Hashable {
-                    /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/metadata/content/body`.
-                    public struct BodyPayload: Codable, Hashable, Sendable {
-                        /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/metadata/content/body/createdAt`.
-                        public var createdAt: Foundation.Date
-                        /// Creates a new `BodyPayload`.
-                        ///
-                        /// - Parameters:
-                        ///   - createdAt:
-                        public init(createdAt: Foundation.Date) {
-                            self.createdAt = createdAt
-                        }
-                        public enum CodingKeys: String, CodingKey {
-                            case createdAt
-                        }
-                    }
-                    public var body: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.MetadataPayload.BodyPayload
-                    /// Creates a new `MetadataPayload`.
-                    ///
-                    /// - Parameters:
-                    ///   - body:
-                    public init(body: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.MetadataPayload.BodyPayload) {
-                        self.body = body
-                    }
+                public var body: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.MetadataPayload.BodyPayload
+                /// Creates a new `MetadataPayload`.
+                ///
+                /// - Parameters:
+                ///   - body:
+                public init(body: Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.MetadataPayload.BodyPayload) {
+                    self.body = body
                 }
-                case metadata(OpenAPIRuntime.MultipartPart<Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.MetadataPayload>)
-                /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/keyword`.
-                public struct KeywordPayload: Sendable, Hashable {
-                    public var body: OpenAPIRuntime.HTTPBody
-                    /// Creates a new `KeywordPayload`.
-                    ///
-                    /// - Parameters:
-                    ///   - body:
-                    public init(body: OpenAPIRuntime.HTTPBody) {
-                        self.body = body
-                    }
-                }
-                case keyword(OpenAPIRuntime.MultipartPart<Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.KeywordPayload>)
-                case undocumented(OpenAPIRuntime.MultipartRawPart)
             }
-            /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/content/multipart\/form-data`.
-            case multipartForm(OpenAPIRuntime.MultipartBody<Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload>)
+            case metadata(OpenAPIRuntime.MultipartPart<Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.MetadataPayload>)
+            /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/multipartForm/keyword`.
+            public struct KeywordPayload: Sendable, Hashable {
+                public var body: OpenAPIRuntime.HTTPBody
+                /// Creates a new `KeywordPayload`.
+                ///
+                /// - Parameters:
+                ///   - body:
+                public init(body: OpenAPIRuntime.HTTPBody) {
+                    self.body = body
+                }
+            }
+            case keyword(OpenAPIRuntime.MultipartPart<Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload.KeywordPayload>)
+            case undocumented(OpenAPIRuntime.MultipartRawPart)
         }
+        /// - Remark: Generated from `#/components/requestBodies/MultipartUploadTypedRequest/content/multipart\/form-data`.
+        case multipartForm(OpenAPIRuntime.MultipartBody<Components.RequestBodies.MultipartUploadTypedRequest.MultipartFormPayload>)
     }
 }

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+Responses.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+Responses.swift
@@ -9,181 +9,178 @@ public import struct Foundation.URL
 public import struct Foundation.Data
 public import struct Foundation.Date
 #endif
-extension Components {
-    /// Types generated from the `#/components/responses` section of the OpenAPI document.
-    public enum Responses {
-        public struct ErrorBadRequest: Sendable, Hashable {
-            /// - Remark: Generated from `#/components/responses/ErrorBadRequest/headers`.
-            public struct Headers: Sendable, Hashable {
-                /// A description here.
-                ///
-                /// - Remark: Generated from `#/components/responses/ErrorBadRequest/headers/X-Reason`.
-                public var xReason: Swift.String?
-                /// Creates a new `Headers`.
-                ///
-                /// - Parameters:
-                ///   - xReason: A description here.
-                public init(xReason: Swift.String? = nil) {
-                    self.xReason = xReason
-                }
-            }
-            /// Received HTTP response headers
-            public var headers: Components.Responses.ErrorBadRequest.Headers
-            /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content`.
-            @frozen public enum Body: Sendable, Hashable {
-                /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/json`.
-                public struct JsonPayload: Codable, Hashable, Sendable {
-                    /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/json/code`.
-                    public var code: Swift.Int
-                    /// Creates a new `JsonPayload`.
-                    ///
-                    /// - Parameters:
-                    ///   - code:
-                    public init(code: Swift.Int) {
-                        self.code = code
-                    }
-                    public enum CodingKeys: String, CodingKey {
-                        case code
-                    }
-                }
-                /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/application\/json`.
-                case json(Components.Responses.ErrorBadRequest.Body.JsonPayload)
-                /// The associated value of the enum case if `self` is `.json`.
-                ///
-                /// - Throws: An error if `self` is not `.json`.
-                /// - SeeAlso: `.json`.
-                public var json: Components.Responses.ErrorBadRequest.Body.JsonPayload {
-                    get throws {
-                        switch self {
-                        case let .json(body):
-                            return body
-                        }
-                    }
-                }
-            }
-            /// Received HTTP response body
-            public var body: Components.Responses.ErrorBadRequest.Body
-            /// Creates a new `ErrorBadRequest`.
+extension Components.Responses {
+    public struct ErrorBadRequest: Sendable, Hashable {
+        /// - Remark: Generated from `#/components/responses/ErrorBadRequest/headers`.
+        public struct Headers: Sendable, Hashable {
+            /// A description here.
+            ///
+            /// - Remark: Generated from `#/components/responses/ErrorBadRequest/headers/X-Reason`.
+            public var xReason: Swift.String?
+            /// Creates a new `Headers`.
             ///
             /// - Parameters:
-            ///   - headers: Received HTTP response headers
-            ///   - body: Received HTTP response body
-            public init(
-                headers: Components.Responses.ErrorBadRequest.Headers = .init(),
-                body: Components.Responses.ErrorBadRequest.Body
-            ) {
-                self.headers = headers
-                self.body = body
+            ///   - xReason: A description here.
+            public init(xReason: Swift.String? = nil) {
+                self.xReason = xReason
             }
         }
-        public struct MultipartDownloadTypedResponse: Sendable, Hashable {
-            /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content`.
-            @frozen public enum Body: Sendable, Hashable {
-                /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm`.
-                @frozen public enum MultipartFormPayload: Sendable, Hashable {
-                    /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log`.
-                    public struct LogPayload: Sendable, Hashable {
-                        /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log/headers`.
-                        public struct Headers: Sendable, Hashable {
-                            /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log/headers/x-log-type`.
-                            @frozen public enum XLogTypePayload: String, Codable, Hashable, Sendable, CaseIterable {
-                                case structured = "structured"
-                                case unstructured = "unstructured"
-                            }
-                            /// The type of the log.
-                            ///
-                            /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log/headers/x-log-type`.
-                            public var xLogType: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload.Headers.XLogTypePayload?
-                            /// Creates a new `Headers`.
-                            ///
-                            /// - Parameters:
-                            ///   - xLogType: The type of the log.
-                            public init(xLogType: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload.Headers.XLogTypePayload? = nil) {
-                                self.xLogType = xLogType
-                            }
-                        }
-                        /// Received HTTP response headers
-                        public var headers: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload.Headers
-                        public var body: OpenAPIRuntime.HTTPBody
-                        /// Creates a new `LogPayload`.
-                        ///
-                        /// - Parameters:
-                        ///   - headers: Received HTTP response headers
-                        ///   - body:
-                        public init(
-                            headers: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload.Headers = .init(),
-                            body: OpenAPIRuntime.HTTPBody
-                        ) {
-                            self.headers = headers
-                            self.body = body
-                        }
-                    }
-                    case log(OpenAPIRuntime.MultipartPart<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload>)
-                    /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/metadata`.
-                    public struct MetadataPayload: Sendable, Hashable {
-                        /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/metadata/content/body`.
-                        public struct BodyPayload: Codable, Hashable, Sendable {
-                            /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/metadata/content/body/createdAt`.
-                            public var createdAt: Foundation.Date
-                            /// Creates a new `BodyPayload`.
-                            ///
-                            /// - Parameters:
-                            ///   - createdAt:
-                            public init(createdAt: Foundation.Date) {
-                                self.createdAt = createdAt
-                            }
-                            public enum CodingKeys: String, CodingKey {
-                                case createdAt
-                            }
-                        }
-                        public var body: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.MetadataPayload.BodyPayload
-                        /// Creates a new `MetadataPayload`.
-                        ///
-                        /// - Parameters:
-                        ///   - body:
-                        public init(body: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.MetadataPayload.BodyPayload) {
-                            self.body = body
-                        }
-                    }
-                    case metadata(OpenAPIRuntime.MultipartPart<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.MetadataPayload>)
-                    /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/keyword`.
-                    public struct KeywordPayload: Sendable, Hashable {
-                        public var body: OpenAPIRuntime.HTTPBody
-                        /// Creates a new `KeywordPayload`.
-                        ///
-                        /// - Parameters:
-                        ///   - body:
-                        public init(body: OpenAPIRuntime.HTTPBody) {
-                            self.body = body
-                        }
-                    }
-                    case keyword(OpenAPIRuntime.MultipartPart<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.KeywordPayload>)
-                    case undocumented(OpenAPIRuntime.MultipartRawPart)
-                }
-                /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipart\/form-data`.
-                case multipartForm(OpenAPIRuntime.MultipartBody<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload>)
-                /// The associated value of the enum case if `self` is `.multipartForm`.
+        /// Received HTTP response headers
+        public var headers: Components.Responses.ErrorBadRequest.Headers
+        /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content`.
+        @frozen public enum Body: Sendable, Hashable {
+            /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/json`.
+            public struct JsonPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/json/code`.
+                public var code: Swift.Int
+                /// Creates a new `JsonPayload`.
                 ///
-                /// - Throws: An error if `self` is not `.multipartForm`.
-                /// - SeeAlso: `.multipartForm`.
-                public var multipartForm: OpenAPIRuntime.MultipartBody<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload> {
-                    get throws {
-                        switch self {
-                        case let .multipartForm(body):
-                            return body
-                        }
+                /// - Parameters:
+                ///   - code:
+                public init(code: Swift.Int) {
+                    self.code = code
+                }
+                public enum CodingKeys: String, CodingKey {
+                    case code
+                }
+            }
+            /// - Remark: Generated from `#/components/responses/ErrorBadRequest/content/application\/json`.
+            case json(Components.Responses.ErrorBadRequest.Body.JsonPayload)
+            /// The associated value of the enum case if `self` is `.json`.
+            ///
+            /// - Throws: An error if `self` is not `.json`.
+            /// - SeeAlso: `.json`.
+            public var json: Components.Responses.ErrorBadRequest.Body.JsonPayload {
+                get throws {
+                    switch self {
+                    case let .json(body):
+                        return body
                     }
                 }
             }
-            /// Received HTTP response body
-            public var body: Components.Responses.MultipartDownloadTypedResponse.Body
-            /// Creates a new `MultipartDownloadTypedResponse`.
-            ///
-            /// - Parameters:
-            ///   - body: Received HTTP response body
-            public init(body: Components.Responses.MultipartDownloadTypedResponse.Body) {
-                self.body = body
+        }
+        /// Received HTTP response body
+        public var body: Components.Responses.ErrorBadRequest.Body
+        /// Creates a new `ErrorBadRequest`.
+        ///
+        /// - Parameters:
+        ///   - headers: Received HTTP response headers
+        ///   - body: Received HTTP response body
+        public init(
+            headers: Components.Responses.ErrorBadRequest.Headers = .init(),
+            body: Components.Responses.ErrorBadRequest.Body
+        ) {
+            self.headers = headers
+            self.body = body
+        }
+    }
+    public struct MultipartDownloadTypedResponse: Sendable, Hashable {
+        /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content`.
+        @frozen public enum Body: Sendable, Hashable {
+            /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm`.
+            @frozen public enum MultipartFormPayload: Sendable, Hashable {
+                /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log`.
+                public struct LogPayload: Sendable, Hashable {
+                    /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log/headers`.
+                    public struct Headers: Sendable, Hashable {
+                        /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log/headers/x-log-type`.
+                        @frozen public enum XLogTypePayload: String, Codable, Hashable, Sendable, CaseIterable {
+                            case structured = "structured"
+                            case unstructured = "unstructured"
+                        }
+                        /// The type of the log.
+                        ///
+                        /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/log/headers/x-log-type`.
+                        public var xLogType: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload.Headers.XLogTypePayload?
+                        /// Creates a new `Headers`.
+                        ///
+                        /// - Parameters:
+                        ///   - xLogType: The type of the log.
+                        public init(xLogType: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload.Headers.XLogTypePayload? = nil) {
+                            self.xLogType = xLogType
+                        }
+                    }
+                    /// Received HTTP response headers
+                    public var headers: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload.Headers
+                    public var body: OpenAPIRuntime.HTTPBody
+                    /// Creates a new `LogPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - headers: Received HTTP response headers
+                    ///   - body:
+                    public init(
+                        headers: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload.Headers = .init(),
+                        body: OpenAPIRuntime.HTTPBody
+                    ) {
+                        self.headers = headers
+                        self.body = body
+                    }
+                }
+                case log(OpenAPIRuntime.MultipartPart<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.LogPayload>)
+                /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/metadata`.
+                public struct MetadataPayload: Sendable, Hashable {
+                    /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/metadata/content/body`.
+                    public struct BodyPayload: Codable, Hashable, Sendable {
+                        /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/metadata/content/body/createdAt`.
+                        public var createdAt: Foundation.Date
+                        /// Creates a new `BodyPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - createdAt:
+                        public init(createdAt: Foundation.Date) {
+                            self.createdAt = createdAt
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case createdAt
+                        }
+                    }
+                    public var body: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.MetadataPayload.BodyPayload
+                    /// Creates a new `MetadataPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - body:
+                    public init(body: Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.MetadataPayload.BodyPayload) {
+                        self.body = body
+                    }
+                }
+                case metadata(OpenAPIRuntime.MultipartPart<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.MetadataPayload>)
+                /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipartForm/keyword`.
+                public struct KeywordPayload: Sendable, Hashable {
+                    public var body: OpenAPIRuntime.HTTPBody
+                    /// Creates a new `KeywordPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - body:
+                    public init(body: OpenAPIRuntime.HTTPBody) {
+                        self.body = body
+                    }
+                }
+                case keyword(OpenAPIRuntime.MultipartPart<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload.KeywordPayload>)
+                case undocumented(OpenAPIRuntime.MultipartRawPart)
             }
+            /// - Remark: Generated from `#/components/responses/MultipartDownloadTypedResponse/content/multipart\/form-data`.
+            case multipartForm(OpenAPIRuntime.MultipartBody<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload>)
+            /// The associated value of the enum case if `self` is `.multipartForm`.
+            ///
+            /// - Throws: An error if `self` is not `.multipartForm`.
+            /// - SeeAlso: `.multipartForm`.
+            public var multipartForm: OpenAPIRuntime.MultipartBody<Components.Responses.MultipartDownloadTypedResponse.Body.MultipartFormPayload> {
+                get throws {
+                    switch self {
+                    case let .multipartForm(body):
+                        return body
+                    }
+                }
+            }
+        }
+        /// Received HTTP response body
+        public var body: Components.Responses.MultipartDownloadTypedResponse.Body
+        /// Creates a new `MultipartDownloadTypedResponse`.
+        ///
+        /// - Parameters:
+        ///   - body: Received HTTP response body
+        public init(body: Components.Responses.MultipartDownloadTypedResponse.Body) {
+            self.body = body
         }
     }
 }

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+Schemas.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components+Schemas.swift
@@ -9,865 +9,916 @@ public import struct Foundation.URL
 public import struct Foundation.Data
 public import struct Foundation.Date
 #endif
-extension Components {
-    /// Types generated from the `#/components/schemas` section of the OpenAPI document.
-    public enum Schemas {
-        /// Pet metadata
+extension Components.Schemas {
+    /// Pet metadata
+    ///
+    /// - Remark: Generated from `#/components/schemas/Pet`.
+    public struct Pet: Codable, Hashable, Sendable {
+        /// Pet id
         ///
-        /// - Remark: Generated from `#/components/schemas/Pet`.
-        public struct Pet: Codable, Hashable, Sendable {
-            /// Pet id
-            ///
-            /// - Remark: Generated from `#/components/schemas/Pet/id`.
-            public var id: Swift.Int64
-            /// Pet name
-            ///
-            /// - Remark: Generated from `#/components/schemas/Pet/name`.
-            public var name: Swift.String
-            /// - Remark: Generated from `#/components/schemas/Pet/tag`.
-            public var tag: Swift.String?
-            /// Pet genome (base64-encoded)
-            ///
-            /// - Remark: Generated from `#/components/schemas/Pet/genome`.
-            public var genome: OpenAPIRuntime.Base64EncodedData?
-            /// - Remark: Generated from `#/components/schemas/Pet/kind`.
-            public var kind: Components.Schemas.PetKind?
-            /// Creates a new `Pet`.
-            ///
-            /// - Parameters:
-            ///   - id: Pet id
-            ///   - name: Pet name
-            ///   - tag:
-            ///   - genome: Pet genome (base64-encoded)
-            ///   - kind:
-            public init(
-                id: Swift.Int64,
-                name: Swift.String,
-                tag: Swift.String? = nil,
-                genome: OpenAPIRuntime.Base64EncodedData? = nil,
-                kind: Components.Schemas.PetKind? = nil
-            ) {
-                self.id = id
-                self.name = name
-                self.tag = tag
-                self.genome = genome
-                self.kind = kind
-            }
-            public enum CodingKeys: String, CodingKey {
-                case id
-                case name
-                case tag
-                case genome
-                case kind
-            }
+        /// - Remark: Generated from `#/components/schemas/Pet/id`.
+        public var id: Swift.Int64
+        /// Pet name
+        ///
+        /// - Remark: Generated from `#/components/schemas/Pet/name`.
+        public var name: Swift.String
+        /// - Remark: Generated from `#/components/schemas/Pet/tag`.
+        public var tag: Swift.String?
+        /// Pet genome (base64-encoded)
+        ///
+        /// - Remark: Generated from `#/components/schemas/Pet/genome`.
+        public var genome: OpenAPIRuntime.Base64EncodedData?
+        /// - Remark: Generated from `#/components/schemas/Pet/kind`.
+        public var kind: Components.Schemas.PetKind?
+        /// Creates a new `Pet`.
+        ///
+        /// - Parameters:
+        ///   - id: Pet id
+        ///   - name: Pet name
+        ///   - tag:
+        ///   - genome: Pet genome (base64-encoded)
+        ///   - kind:
+        public init(
+            id: Swift.Int64,
+            name: Swift.String,
+            tag: Swift.String? = nil,
+            genome: OpenAPIRuntime.Base64EncodedData? = nil,
+            kind: Components.Schemas.PetKind? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.tag = tag
+            self.genome = genome
+            self.kind = kind
         }
-        /// - Remark: Generated from `#/components/schemas/MixedAnyOf`.
-        public struct MixedAnyOf: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value1`.
-            public var value1: Foundation.Date?
-            /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value2`.
-            public var value2: Components.Schemas.PetKind?
-            /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value3`.
-            public var value3: Components.Schemas.Pet?
-            /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value4`.
-            public var value4: Swift.String?
-            /// Creates a new `MixedAnyOf`.
-            ///
-            /// - Parameters:
-            ///   - value1:
-            ///   - value2:
-            ///   - value3:
-            ///   - value4:
-            public init(
-                value1: Foundation.Date? = nil,
-                value2: Components.Schemas.PetKind? = nil,
-                value3: Components.Schemas.Pet? = nil,
-                value4: Swift.String? = nil
-            ) {
-                self.value1 = value1
-                self.value2 = value2
-                self.value3 = value3
-                self.value4 = value4
+        public enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case tag
+            case genome
+            case kind
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/MixedAnyOf`.
+    public struct MixedAnyOf: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value1`.
+        public var value1: Foundation.Date?
+        /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value2`.
+        public var value2: Components.Schemas.PetKind?
+        /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value3`.
+        public var value3: Components.Schemas.Pet?
+        /// - Remark: Generated from `#/components/schemas/MixedAnyOf/value4`.
+        public var value4: Swift.String?
+        /// Creates a new `MixedAnyOf`.
+        ///
+        /// - Parameters:
+        ///   - value1:
+        ///   - value2:
+        ///   - value3:
+        ///   - value4:
+        public init(
+            value1: Foundation.Date? = nil,
+            value2: Components.Schemas.PetKind? = nil,
+            value3: Components.Schemas.Pet? = nil,
+            value4: Swift.String? = nil
+        ) {
+            self.value1 = value1
+            self.value2 = value2
+            self.value3 = value3
+            self.value4 = value4
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            var errors: [any Swift.Error] = []
+            do {
+                self.value1 = try decoder.decodeFromSingleValueContainer()
+            } catch {
+                errors.append(error)
             }
-            public init(from decoder: any Swift.Decoder) throws {
-                var errors: [any Swift.Error] = []
-                do {
-                    self.value1 = try decoder.decodeFromSingleValueContainer()
-                } catch {
-                    errors.append(error)
-                }
-                do {
-                    self.value2 = try decoder.decodeFromSingleValueContainer()
-                } catch {
-                    errors.append(error)
-                }
-                do {
-                    self.value3 = try .init(from: decoder)
-                } catch {
-                    errors.append(error)
-                }
-                do {
-                    self.value4 = try decoder.decodeFromSingleValueContainer()
-                } catch {
-                    errors.append(error)
-                }
-                try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
-                    [
-                        self.value1,
-                        self.value2,
-                        self.value3,
-                        self.value4
-                    ],
-                    type: Self.self,
-                    codingPath: decoder.codingPath,
-                    errors: errors
-                )
+            do {
+                self.value2 = try decoder.decodeFromSingleValueContainer()
+            } catch {
+                errors.append(error)
             }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try encoder.encodeFirstNonNilValueToSingleValueContainer([
+            do {
+                self.value3 = try .init(from: decoder)
+            } catch {
+                errors.append(error)
+            }
+            do {
+                self.value4 = try decoder.decodeFromSingleValueContainer()
+            } catch {
+                errors.append(error)
+            }
+            try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                [
                     self.value1,
                     self.value2,
+                    self.value3,
                     self.value4
-                ])
-                try self.value3?.encode(to: encoder)
+                ],
+                type: Self.self,
+                codingPath: decoder.codingPath,
+                errors: errors
+            )
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try encoder.encodeFirstNonNilValueToSingleValueContainer([
+                self.value1,
+                self.value2,
+                self.value4
+            ])
+            try self.value3?.encode(to: encoder)
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/MixedOneOf`.
+    @frozen public enum MixedOneOf: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/MixedOneOf/case1`.
+        case case1(Foundation.Date)
+        /// - Remark: Generated from `#/components/schemas/MixedOneOf/case2`.
+        case PetKind(Components.Schemas.PetKind)
+        /// - Remark: Generated from `#/components/schemas/MixedOneOf/case3`.
+        case Pet(Components.Schemas.Pet)
+        public init(from decoder: any Swift.Decoder) throws {
+            var errors: [any Swift.Error] = []
+            do {
+                self = .case1(try decoder.decodeFromSingleValueContainer())
+                return
+            } catch {
+                errors.append(error)
+            }
+            do {
+                self = .PetKind(try decoder.decodeFromSingleValueContainer())
+                return
+            } catch {
+                errors.append(error)
+            }
+            do {
+                self = .Pet(try .init(from: decoder))
+                return
+            } catch {
+                errors.append(error)
+            }
+            throw Swift.DecodingError.failedToDecodeOneOfSchema(
+                type: Self.self,
+                codingPath: decoder.codingPath,
+                errors: errors
+            )
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            switch self {
+            case let .case1(value):
+                try encoder.encodeToSingleValueContainer(value)
+            case let .PetKind(value):
+                try encoder.encodeToSingleValueContainer(value)
+            case let .Pet(value):
+                try value.encode(to: encoder)
             }
         }
-        /// - Remark: Generated from `#/components/schemas/MixedOneOf`.
-        @frozen public enum MixedOneOf: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/MixedOneOf/case1`.
-            case case1(Foundation.Date)
-            /// - Remark: Generated from `#/components/schemas/MixedOneOf/case2`.
-            case PetKind(Components.Schemas.PetKind)
-            /// - Remark: Generated from `#/components/schemas/MixedOneOf/case3`.
-            case Pet(Components.Schemas.Pet)
-            public init(from decoder: any Swift.Decoder) throws {
-                var errors: [any Swift.Error] = []
-                do {
-                    self = .case1(try decoder.decodeFromSingleValueContainer())
-                    return
-                } catch {
-                    errors.append(error)
-                }
-                do {
-                    self = .PetKind(try decoder.decodeFromSingleValueContainer())
-                    return
-                } catch {
-                    errors.append(error)
-                }
-                do {
-                    self = .Pet(try .init(from: decoder))
-                    return
-                } catch {
-                    errors.append(error)
-                }
-                throw Swift.DecodingError.failedToDecodeOneOfSchema(
-                    type: Self.self,
-                    codingPath: decoder.codingPath,
-                    errors: errors
-                )
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                switch self {
-                case let .case1(value):
-                    try encoder.encodeToSingleValueContainer(value)
-                case let .PetKind(value):
-                    try encoder.encodeToSingleValueContainer(value)
-                case let .Pet(value):
-                    try value.encode(to: encoder)
-                }
-            }
-        }
-        /// - Remark: Generated from `#/components/schemas/MixedAllOfPrimitive`.
-        public struct MixedAllOfPrimitive: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/MixedAllOfPrimitive/value1`.
-            public var value1: Foundation.Date
-            /// - Remark: Generated from `#/components/schemas/MixedAllOfPrimitive/value2`.
-            public var value2: Swift.String
-            /// Creates a new `MixedAllOfPrimitive`.
-            ///
-            /// - Parameters:
-            ///   - value1:
-            ///   - value2:
-            public init(
-                value1: Foundation.Date,
-                value2: Swift.String
-            ) {
-                self.value1 = value1
-                self.value2 = value2
-            }
-            public init(from decoder: any Swift.Decoder) throws {
-                self.value1 = try decoder.decodeFromSingleValueContainer()
-                self.value2 = try decoder.decodeFromSingleValueContainer()
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try encoder.encodeToSingleValueContainer(self.value1)
-            }
-        }
-        /// Kind of pet
+    }
+    /// - Remark: Generated from `#/components/schemas/MixedAllOfPrimitive`.
+    public struct MixedAllOfPrimitive: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/MixedAllOfPrimitive/value1`.
+        public var value1: Foundation.Date
+        /// - Remark: Generated from `#/components/schemas/MixedAllOfPrimitive/value2`.
+        public var value2: Swift.String
+        /// Creates a new `MixedAllOfPrimitive`.
         ///
-        /// - Remark: Generated from `#/components/schemas/PetKind`.
-        @frozen public enum PetKind: String, Codable, Hashable, Sendable, CaseIterable {
-            case cat = "cat"
-            case dog = "dog"
-            case elephant = "ELEPHANT"
-            case bigElephant1 = "BIG_ELEPHANT_1"
-            case _dollar_nake = "$nake"
-            case _public = "public"
+        /// - Parameters:
+        ///   - value1:
+        ///   - value2:
+        public init(
+            value1: Foundation.Date,
+            value2: Swift.String
+        ) {
+            self.value1 = value1
+            self.value2 = value2
         }
-        /// - Remark: Generated from `#/components/schemas/CreatePetRequest`.
-        public struct CreatePetRequest: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/CreatePetRequest/name`.
-            public var name: Swift.String
-            /// - Remark: Generated from `#/components/schemas/CreatePetRequest/kind`.
-            public var kind: Components.Schemas.PetKind?
-            /// - Remark: Generated from `#/components/schemas/CreatePetRequest/tag`.
-            public var tag: Swift.String?
-            /// - Remark: Generated from `#/components/schemas/CreatePetRequest/genome`.
-            public var genome: OpenAPIRuntime.Base64EncodedData?
-            /// Creates a new `CreatePetRequest`.
+        public init(from decoder: any Swift.Decoder) throws {
+            self.value1 = try decoder.decodeFromSingleValueContainer()
+            self.value2 = try decoder.decodeFromSingleValueContainer()
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try encoder.encodeToSingleValueContainer(self.value1)
+        }
+    }
+    /// Kind of pet
+    ///
+    /// - Remark: Generated from `#/components/schemas/PetKind`.
+    @frozen public enum PetKind: String, Codable, Hashable, Sendable, CaseIterable {
+        case cat = "cat"
+        case dog = "dog"
+        case elephant = "ELEPHANT"
+        case bigElephant1 = "BIG_ELEPHANT_1"
+        case _dollar_nake = "$nake"
+        case _public = "public"
+    }
+    /// - Remark: Generated from `#/components/schemas/CreatePetRequest`.
+    public struct CreatePetRequest: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/CreatePetRequest/name`.
+        public var name: Swift.String
+        /// - Remark: Generated from `#/components/schemas/CreatePetRequest/kind`.
+        public var kind: Components.Schemas.PetKind?
+        /// - Remark: Generated from `#/components/schemas/CreatePetRequest/tag`.
+        public var tag: Swift.String?
+        /// - Remark: Generated from `#/components/schemas/CreatePetRequest/genome`.
+        public var genome: OpenAPIRuntime.Base64EncodedData?
+        /// Creates a new `CreatePetRequest`.
+        ///
+        /// - Parameters:
+        ///   - name:
+        ///   - kind:
+        ///   - tag:
+        ///   - genome:
+        public init(
+            name: Swift.String,
+            kind: Components.Schemas.PetKind? = nil,
+            tag: Swift.String? = nil,
+            genome: OpenAPIRuntime.Base64EncodedData? = nil
+        ) {
+            self.name = name
+            self.kind = kind
+            self.tag = tag
+            self.genome = genome
+        }
+        public enum CodingKeys: String, CodingKey {
+            case name
+            case kind
+            case tag
+            case genome
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/Pets`.
+    public typealias Pets = [Components.Schemas.Pet]
+    /// - Remark: Generated from `#/components/schemas/Error`.
+    public struct _Error: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/Error/code`.
+        public var code: Swift.Int32
+        /// - Remark: Generated from `#/components/schemas/Error/me$sage`.
+        public var me_dollar_sage: Swift.String
+        /// Extra information about the error.
+        ///
+        /// - Remark: Generated from `#/components/schemas/Error/extraInfo`.
+        public var extraInfo: Components.Schemas.ExtraInfo?
+        /// Custom user-provided key-value pairs.
+        ///
+        /// - Remark: Generated from `#/components/schemas/Error/userData`.
+        public var userData: OpenAPIRuntime.OpenAPIObjectContainer?
+        /// Creates a new `_Error`.
+        ///
+        /// - Parameters:
+        ///   - code:
+        ///   - me_dollar_sage:
+        ///   - extraInfo: Extra information about the error.
+        ///   - userData: Custom user-provided key-value pairs.
+        public init(
+            code: Swift.Int32,
+            me_dollar_sage: Swift.String,
+            extraInfo: Components.Schemas.ExtraInfo? = nil,
+            userData: OpenAPIRuntime.OpenAPIObjectContainer? = nil
+        ) {
+            self.code = code
+            self.me_dollar_sage = me_dollar_sage
+            self.extraInfo = extraInfo
+            self.userData = userData
+        }
+        public enum CodingKeys: String, CodingKey {
+            case code
+            case me_dollar_sage = "me$sage"
+            case extraInfo
+            case userData
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/PetFeeding`.
+    public struct PetFeeding: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/PetFeeding/schedule`.
+        @frozen public enum SchedulePayload: String, Codable, Hashable, Sendable, CaseIterable {
+            case hourly = "hourly"
+            case daily = "daily"
+            case weekly = "weekly"
+        }
+        /// - Remark: Generated from `#/components/schemas/PetFeeding/schedule`.
+        public var schedule: Components.Schemas.PetFeeding.SchedulePayload?
+        /// Creates a new `PetFeeding`.
+        ///
+        /// - Parameters:
+        ///   - schedule:
+        public init(schedule: Components.Schemas.PetFeeding.SchedulePayload? = nil) {
+            self.schedule = schedule
+        }
+        public enum CodingKeys: String, CodingKey {
+            case schedule
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/DOB`.
+    public typealias Dob = Foundation.Date
+    /// - Remark: Generated from `#/components/schemas/ExtraInfo`.
+    public typealias ExtraInfo = Swift.String
+    /// - Remark: Generated from `#/components/schemas/NoAdditionalProperties`.
+    public struct NoAdditionalProperties: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/NoAdditionalProperties/foo`.
+        public var foo: Swift.String?
+        /// Creates a new `NoAdditionalProperties`.
+        ///
+        /// - Parameters:
+        ///   - foo:
+        public init(foo: Swift.String? = nil) {
+            self.foo = foo
+        }
+        public enum CodingKeys: String, CodingKey {
+            case foo
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.foo = try container.decodeIfPresent(
+                Swift.String.self,
+                forKey: .foo
+            )
+            try decoder.ensureNoAdditionalProperties(knownKeys: [
+                "foo"
+            ])
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/AnyAdditionalProperties`.
+    public struct AnyAdditionalProperties: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/AnyAdditionalProperties/foo`.
+        public var foo: Swift.String?
+        /// A container of undocumented properties.
+        public var additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer
+        /// Creates a new `AnyAdditionalProperties`.
+        ///
+        /// - Parameters:
+        ///   - foo:
+        ///   - additionalProperties: A container of undocumented properties.
+        public init(
+            foo: Swift.String? = nil,
+            additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer = .init()
+        ) {
+            self.foo = foo
+            self.additionalProperties = additionalProperties
+        }
+        public enum CodingKeys: String, CodingKey {
+            case foo
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.foo = try container.decodeIfPresent(
+                Swift.String.self,
+                forKey: .foo
+            )
+            additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [
+                "foo"
+            ])
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(
+                self.foo,
+                forKey: .foo
+            )
+            try encoder.encodeAdditionalProperties(additionalProperties)
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/TypedAdditionalProperties`.
+    public struct TypedAdditionalProperties: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/TypedAdditionalProperties/foo`.
+        public var foo: Swift.String?
+        /// A container of undocumented properties.
+        public var additionalProperties: [String: Swift.Int]
+        /// Creates a new `TypedAdditionalProperties`.
+        ///
+        /// - Parameters:
+        ///   - foo:
+        ///   - additionalProperties: A container of undocumented properties.
+        public init(
+            foo: Swift.String? = nil,
+            additionalProperties: [String: Swift.Int] = .init()
+        ) {
+            self.foo = foo
+            self.additionalProperties = additionalProperties
+        }
+        public enum CodingKeys: String, CodingKey {
+            case foo
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.foo = try container.decodeIfPresent(
+                Swift.String.self,
+                forKey: .foo
+            )
+            additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [
+                "foo"
+            ])
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(
+                self.foo,
+                forKey: .foo
+            )
+            try encoder.encodeAdditionalProperties(additionalProperties)
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/ObjectWithOptionalNullableArrayOfNullableItems`.
+    public struct ObjectWithOptionalNullableArrayOfNullableItems: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/ObjectWithOptionalNullableArrayOfNullableItems/foo`.
+        public var foo: [Swift.String?]?
+        /// Creates a new `ObjectWithOptionalNullableArrayOfNullableItems`.
+        ///
+        /// - Parameters:
+        ///   - foo:
+        public init(foo: [Swift.String?]? = nil) {
+            self.foo = foo
+        }
+        public enum CodingKeys: String, CodingKey {
+            case foo
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/TypedAdditionalPropertiesWithPropertyNamedContainer`.
+    public struct TypedAdditionalPropertiesWithPropertyNamedContainer: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/TypedAdditionalPropertiesWithPropertyNamedContainer/container`.
+        public var container: Swift.String?
+        /// A container of undocumented properties.
+        public var additionalProperties: [String: Swift.Int]
+        /// Creates a new `TypedAdditionalPropertiesWithPropertyNamedContainer`.
+        ///
+        /// - Parameters:
+        ///   - container:
+        ///   - additionalProperties: A container of undocumented properties.
+        public init(
+            container: Swift.String? = nil,
+            additionalProperties: [String: Swift.Int] = .init()
+        ) {
+            self.container = container
+            self.additionalProperties = additionalProperties
+        }
+        public enum CodingKeys: String, CodingKey {
+            case container
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.container = try container.decodeIfPresent(
+                Swift.String.self,
+                forKey: .container
+            )
+            additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [
+                "container"
+            ])
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(
+                self.container,
+                forKey: .container
+            )
+            try encoder.encodeAdditionalProperties(additionalProperties)
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/CodeError`.
+    public struct CodeError: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/CodeError/code`.
+        public var code: Swift.Int
+        /// Creates a new `CodeError`.
+        ///
+        /// - Parameters:
+        ///   - code:
+        public init(code: Swift.Int) {
+            self.code = code
+        }
+        public enum CodingKeys: String, CodingKey {
+            case code
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/AllOfObjects`.
+    public struct AllOfObjects: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1`.
+        public struct Value1Payload: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1/message`.
+            public var message: Swift.String
+            /// Creates a new `Value1Payload`.
             ///
             /// - Parameters:
-            ///   - name:
-            ///   - kind:
-            ///   - tag:
-            ///   - genome:
-            public init(
-                name: Swift.String,
-                kind: Components.Schemas.PetKind? = nil,
-                tag: Swift.String? = nil,
-                genome: OpenAPIRuntime.Base64EncodedData? = nil
-            ) {
-                self.name = name
-                self.kind = kind
-                self.tag = tag
-                self.genome = genome
+            ///   - message:
+            public init(message: Swift.String) {
+                self.message = message
             }
             public enum CodingKeys: String, CodingKey {
-                case name
-                case kind
-                case tag
-                case genome
+                case message
             }
         }
-        /// - Remark: Generated from `#/components/schemas/Pets`.
-        public typealias Pets = [Components.Schemas.Pet]
-        /// - Remark: Generated from `#/components/schemas/Error`.
-        public struct _Error: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/Error/code`.
-            public var code: Swift.Int32
-            /// - Remark: Generated from `#/components/schemas/Error/me$sage`.
-            public var me_dollar_sage: Swift.String
-            /// Extra information about the error.
-            ///
-            /// - Remark: Generated from `#/components/schemas/Error/extraInfo`.
-            public var extraInfo: Components.Schemas.ExtraInfo?
-            /// Custom user-provided key-value pairs.
-            ///
-            /// - Remark: Generated from `#/components/schemas/Error/userData`.
-            public var userData: OpenAPIRuntime.OpenAPIObjectContainer?
-            /// Creates a new `_Error`.
+        /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1`.
+        public var value1: Components.Schemas.AllOfObjects.Value1Payload
+        /// - Remark: Generated from `#/components/schemas/AllOfObjects/value2`.
+        public var value2: Components.Schemas.CodeError
+        /// Creates a new `AllOfObjects`.
+        ///
+        /// - Parameters:
+        ///   - value1:
+        ///   - value2:
+        public init(
+            value1: Components.Schemas.AllOfObjects.Value1Payload,
+            value2: Components.Schemas.CodeError
+        ) {
+            self.value1 = value1
+            self.value2 = value2
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            self.value1 = try .init(from: decoder)
+            self.value2 = try .init(from: decoder)
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try self.value1.encode(to: encoder)
+            try self.value2.encode(to: encoder)
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/AnyOfObjects`.
+    public struct AnyOfObjects: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1`.
+        public struct Value1Payload: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1/message`.
+            public var message: Swift.String
+            /// Creates a new `Value1Payload`.
             ///
             /// - Parameters:
-            ///   - code:
-            ///   - me_dollar_sage:
-            ///   - extraInfo: Extra information about the error.
-            ///   - userData: Custom user-provided key-value pairs.
-            public init(
-                code: Swift.Int32,
-                me_dollar_sage: Swift.String,
-                extraInfo: Components.Schemas.ExtraInfo? = nil,
-                userData: OpenAPIRuntime.OpenAPIObjectContainer? = nil
-            ) {
-                self.code = code
-                self.me_dollar_sage = me_dollar_sage
-                self.extraInfo = extraInfo
-                self.userData = userData
+            ///   - message:
+            public init(message: Swift.String) {
+                self.message = message
             }
             public enum CodingKeys: String, CodingKey {
-                case code
-                case me_dollar_sage = "me$sage"
-                case extraInfo
-                case userData
+                case message
             }
         }
-        /// - Remark: Generated from `#/components/schemas/PetFeeding`.
-        public struct PetFeeding: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/PetFeeding/schedule`.
-            @frozen public enum SchedulePayload: String, Codable, Hashable, Sendable, CaseIterable {
-                case hourly = "hourly"
-                case daily = "daily"
-                case weekly = "weekly"
-            }
-            /// - Remark: Generated from `#/components/schemas/PetFeeding/schedule`.
-            public var schedule: Components.Schemas.PetFeeding.SchedulePayload?
-            /// Creates a new `PetFeeding`.
-            ///
-            /// - Parameters:
-            ///   - schedule:
-            public init(schedule: Components.Schemas.PetFeeding.SchedulePayload? = nil) {
-                self.schedule = schedule
-            }
-            public enum CodingKeys: String, CodingKey {
-                case schedule
-            }
+        /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1`.
+        public var value1: Components.Schemas.AnyOfObjects.Value1Payload?
+        /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value2`.
+        public var value2: Components.Schemas.CodeError?
+        /// Creates a new `AnyOfObjects`.
+        ///
+        /// - Parameters:
+        ///   - value1:
+        ///   - value2:
+        public init(
+            value1: Components.Schemas.AnyOfObjects.Value1Payload? = nil,
+            value2: Components.Schemas.CodeError? = nil
+        ) {
+            self.value1 = value1
+            self.value2 = value2
         }
-        /// - Remark: Generated from `#/components/schemas/DOB`.
-        public typealias Dob = Foundation.Date
-        /// - Remark: Generated from `#/components/schemas/ExtraInfo`.
-        public typealias ExtraInfo = Swift.String
-        /// - Remark: Generated from `#/components/schemas/NoAdditionalProperties`.
-        public struct NoAdditionalProperties: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/NoAdditionalProperties/foo`.
-            public var foo: Swift.String?
-            /// Creates a new `NoAdditionalProperties`.
-            ///
-            /// - Parameters:
-            ///   - foo:
-            public init(foo: Swift.String? = nil) {
-                self.foo = foo
-            }
-            public enum CodingKeys: String, CodingKey {
-                case foo
-            }
-            public init(from decoder: any Swift.Decoder) throws {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                self.foo = try container.decodeIfPresent(
-                    Swift.String.self,
-                    forKey: .foo
-                )
-                try decoder.ensureNoAdditionalProperties(knownKeys: [
-                    "foo"
-                ])
-            }
-        }
-        /// - Remark: Generated from `#/components/schemas/AnyAdditionalProperties`.
-        public struct AnyAdditionalProperties: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/AnyAdditionalProperties/foo`.
-            public var foo: Swift.String?
-            /// A container of undocumented properties.
-            public var additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer
-            /// Creates a new `AnyAdditionalProperties`.
-            ///
-            /// - Parameters:
-            ///   - foo:
-            ///   - additionalProperties: A container of undocumented properties.
-            public init(
-                foo: Swift.String? = nil,
-                additionalProperties: OpenAPIRuntime.OpenAPIObjectContainer = .init()
-            ) {
-                self.foo = foo
-                self.additionalProperties = additionalProperties
-            }
-            public enum CodingKeys: String, CodingKey {
-                case foo
-            }
-            public init(from decoder: any Swift.Decoder) throws {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                self.foo = try container.decodeIfPresent(
-                    Swift.String.self,
-                    forKey: .foo
-                )
-                additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [
-                    "foo"
-                ])
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                var container = encoder.container(keyedBy: CodingKeys.self)
-                try container.encodeIfPresent(
-                    self.foo,
-                    forKey: .foo
-                )
-                try encoder.encodeAdditionalProperties(additionalProperties)
-            }
-        }
-        /// - Remark: Generated from `#/components/schemas/TypedAdditionalProperties`.
-        public struct TypedAdditionalProperties: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/TypedAdditionalProperties/foo`.
-            public var foo: Swift.String?
-            /// A container of undocumented properties.
-            public var additionalProperties: [String: Swift.Int]
-            /// Creates a new `TypedAdditionalProperties`.
-            ///
-            /// - Parameters:
-            ///   - foo:
-            ///   - additionalProperties: A container of undocumented properties.
-            public init(
-                foo: Swift.String? = nil,
-                additionalProperties: [String: Swift.Int] = .init()
-            ) {
-                self.foo = foo
-                self.additionalProperties = additionalProperties
-            }
-            public enum CodingKeys: String, CodingKey {
-                case foo
-            }
-            public init(from decoder: any Swift.Decoder) throws {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                self.foo = try container.decodeIfPresent(
-                    Swift.String.self,
-                    forKey: .foo
-                )
-                additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [
-                    "foo"
-                ])
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                var container = encoder.container(keyedBy: CodingKeys.self)
-                try container.encodeIfPresent(
-                    self.foo,
-                    forKey: .foo
-                )
-                try encoder.encodeAdditionalProperties(additionalProperties)
-            }
-        }
-        /// - Remark: Generated from `#/components/schemas/ObjectWithOptionalNullableArrayOfNullableItems`.
-        public struct ObjectWithOptionalNullableArrayOfNullableItems: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/ObjectWithOptionalNullableArrayOfNullableItems/foo`.
-            public var foo: [Swift.String?]?
-            /// Creates a new `ObjectWithOptionalNullableArrayOfNullableItems`.
-            ///
-            /// - Parameters:
-            ///   - foo:
-            public init(foo: [Swift.String?]? = nil) {
-                self.foo = foo
-            }
-            public enum CodingKeys: String, CodingKey {
-                case foo
-            }
-        }
-        /// - Remark: Generated from `#/components/schemas/TypedAdditionalPropertiesWithPropertyNamedContainer`.
-        public struct TypedAdditionalPropertiesWithPropertyNamedContainer: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/TypedAdditionalPropertiesWithPropertyNamedContainer/container`.
-            public var container: Swift.String?
-            /// A container of undocumented properties.
-            public var additionalProperties: [String: Swift.Int]
-            /// Creates a new `TypedAdditionalPropertiesWithPropertyNamedContainer`.
-            ///
-            /// - Parameters:
-            ///   - container:
-            ///   - additionalProperties: A container of undocumented properties.
-            public init(
-                container: Swift.String? = nil,
-                additionalProperties: [String: Swift.Int] = .init()
-            ) {
-                self.container = container
-                self.additionalProperties = additionalProperties
-            }
-            public enum CodingKeys: String, CodingKey {
-                case container
-            }
-            public init(from decoder: any Swift.Decoder) throws {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                self.container = try container.decodeIfPresent(
-                    Swift.String.self,
-                    forKey: .container
-                )
-                additionalProperties = try decoder.decodeAdditionalProperties(knownKeys: [
-                    "container"
-                ])
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                var container = encoder.container(keyedBy: CodingKeys.self)
-                try container.encodeIfPresent(
-                    self.container,
-                    forKey: .container
-                )
-                try encoder.encodeAdditionalProperties(additionalProperties)
-            }
-        }
-        /// - Remark: Generated from `#/components/schemas/CodeError`.
-        public struct CodeError: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/CodeError/code`.
-            public var code: Swift.Int
-            /// Creates a new `CodeError`.
-            ///
-            /// - Parameters:
-            ///   - code:
-            public init(code: Swift.Int) {
-                self.code = code
-            }
-            public enum CodingKeys: String, CodingKey {
-                case code
-            }
-        }
-        /// - Remark: Generated from `#/components/schemas/AllOfObjects`.
-        public struct AllOfObjects: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1`.
-            public struct Value1Payload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1/message`.
-                public var message: Swift.String
-                /// Creates a new `Value1Payload`.
-                ///
-                /// - Parameters:
-                ///   - message:
-                public init(message: Swift.String) {
-                    self.message = message
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case message
-                }
-            }
-            /// - Remark: Generated from `#/components/schemas/AllOfObjects/value1`.
-            public var value1: Components.Schemas.AllOfObjects.Value1Payload
-            /// - Remark: Generated from `#/components/schemas/AllOfObjects/value2`.
-            public var value2: Components.Schemas.CodeError
-            /// Creates a new `AllOfObjects`.
-            ///
-            /// - Parameters:
-            ///   - value1:
-            ///   - value2:
-            public init(
-                value1: Components.Schemas.AllOfObjects.Value1Payload,
-                value2: Components.Schemas.CodeError
-            ) {
-                self.value1 = value1
-                self.value2 = value2
-            }
-            public init(from decoder: any Swift.Decoder) throws {
+        public init(from decoder: any Swift.Decoder) throws {
+            var errors: [any Swift.Error] = []
+            do {
                 self.value1 = try .init(from: decoder)
+            } catch {
+                errors.append(error)
+            }
+            do {
                 self.value2 = try .init(from: decoder)
+            } catch {
+                errors.append(error)
             }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try self.value1.encode(to: encoder)
-                try self.value2.encode(to: encoder)
-            }
+            try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                [
+                    self.value1,
+                    self.value2
+                ],
+                type: Self.self,
+                codingPath: decoder.codingPath,
+                errors: errors
+            )
         }
-        /// - Remark: Generated from `#/components/schemas/AnyOfObjects`.
-        public struct AnyOfObjects: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1`.
-            public struct Value1Payload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1/message`.
-                public var message: Swift.String
-                /// Creates a new `Value1Payload`.
-                ///
-                /// - Parameters:
-                ///   - message:
-                public init(message: Swift.String) {
-                    self.message = message
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case message
-                }
-            }
-            /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value1`.
-            public var value1: Components.Schemas.AnyOfObjects.Value1Payload?
-            /// - Remark: Generated from `#/components/schemas/AnyOfObjects/value2`.
-            public var value2: Components.Schemas.CodeError?
-            /// Creates a new `AnyOfObjects`.
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try self.value1?.encode(to: encoder)
+            try self.value2?.encode(to: encoder)
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/OneOfAny`.
+    @frozen public enum OneOfAny: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/OneOfAny/case1`.
+        case case1(Swift.String)
+        /// - Remark: Generated from `#/components/schemas/OneOfAny/case2`.
+        case case2(Swift.Int)
+        /// - Remark: Generated from `#/components/schemas/OneOfAny/case3`.
+        case CodeError(Components.Schemas.CodeError)
+        /// - Remark: Generated from `#/components/schemas/OneOfAny/case4`.
+        public struct Case4Payload: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/OneOfAny/case4/message`.
+            public var message: Swift.String
+            /// Creates a new `Case4Payload`.
             ///
             /// - Parameters:
-            ///   - value1:
-            ///   - value2:
-            public init(
-                value1: Components.Schemas.AnyOfObjects.Value1Payload? = nil,
-                value2: Components.Schemas.CodeError? = nil
-            ) {
-                self.value1 = value1
-                self.value2 = value2
+            ///   - message:
+            public init(message: Swift.String) {
+                self.message = message
             }
-            public init(from decoder: any Swift.Decoder) throws {
-                var errors: [any Swift.Error] = []
-                do {
-                    self.value1 = try .init(from: decoder)
-                } catch {
-                    errors.append(error)
-                }
-                do {
-                    self.value2 = try .init(from: decoder)
-                } catch {
-                    errors.append(error)
-                }
-                try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
-                    [
-                        self.value1,
-                        self.value2
-                    ],
-                    type: Self.self,
-                    codingPath: decoder.codingPath,
-                    errors: errors
+            public enum CodingKeys: String, CodingKey {
+                case message
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/OneOfAny/case4`.
+        case case4(Components.Schemas.OneOfAny.Case4Payload)
+        public init(from decoder: any Swift.Decoder) throws {
+            var errors: [any Swift.Error] = []
+            do {
+                self = .case1(try decoder.decodeFromSingleValueContainer())
+                return
+            } catch {
+                errors.append(error)
+            }
+            do {
+                self = .case2(try decoder.decodeFromSingleValueContainer())
+                return
+            } catch {
+                errors.append(error)
+            }
+            do {
+                self = .CodeError(try .init(from: decoder))
+                return
+            } catch {
+                errors.append(error)
+            }
+            do {
+                self = .case4(try .init(from: decoder))
+                return
+            } catch {
+                errors.append(error)
+            }
+            throw Swift.DecodingError.failedToDecodeOneOfSchema(
+                type: Self.self,
+                codingPath: decoder.codingPath,
+                errors: errors
+            )
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            switch self {
+            case let .case1(value):
+                try encoder.encodeToSingleValueContainer(value)
+            case let .case2(value):
+                try encoder.encodeToSingleValueContainer(value)
+            case let .CodeError(value):
+                try value.encode(to: encoder)
+            case let .case4(value):
+                try value.encode(to: encoder)
+            }
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/PetExercise`.
+    public struct PetExercise: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/PetExercise/kind`.
+        public var kind: Swift.String
+        /// Creates a new `PetExercise`.
+        ///
+        /// - Parameters:
+        ///   - kind:
+        public init(kind: Swift.String) {
+            self.kind = kind
+        }
+        public enum CodingKeys: String, CodingKey {
+            case kind
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/Walk`.
+    public struct Walk: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/Walk/kind`.
+        public var kind: Swift.String
+        /// - Remark: Generated from `#/components/schemas/Walk/length`.
+        public var length: Swift.Int
+        /// Creates a new `Walk`.
+        ///
+        /// - Parameters:
+        ///   - kind:
+        ///   - length:
+        public init(
+            kind: Swift.String,
+            length: Swift.Int
+        ) {
+            self.kind = kind
+            self.length = length
+        }
+        public enum CodingKeys: String, CodingKey {
+            case kind
+            case length
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/MessagedExercise`.
+    public struct MessagedExercise: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/MessagedExercise/value1`.
+        public var value1: Components.Schemas.PetExercise
+        /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2`.
+        public struct Value2Payload: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2/message`.
+            public var message: Swift.String
+            /// Creates a new `Value2Payload`.
+            ///
+            /// - Parameters:
+            ///   - message:
+            public init(message: Swift.String) {
+                self.message = message
+            }
+            public enum CodingKeys: String, CodingKey {
+                case message
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2`.
+        public var value2: Components.Schemas.MessagedExercise.Value2Payload
+        /// Creates a new `MessagedExercise`.
+        ///
+        /// - Parameters:
+        ///   - value1:
+        ///   - value2:
+        public init(
+            value1: Components.Schemas.PetExercise,
+            value2: Components.Schemas.MessagedExercise.Value2Payload
+        ) {
+            self.value1 = value1
+            self.value2 = value2
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            self.value1 = try .init(from: decoder)
+            self.value2 = try .init(from: decoder)
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try self.value1.encode(to: encoder)
+            try self.value2.encode(to: encoder)
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator`.
+    @frozen public enum OneOfObjectsWithDiscriminator: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/Walk`.
+        case walk(Components.Schemas.Walk)
+        /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/MessagedExercise`.
+        case messagedExercise(Components.Schemas.MessagedExercise)
+        public enum CodingKeys: String, CodingKey {
+            case kind
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let discriminator = try container.decode(
+                Swift.String.self,
+                forKey: .kind
+            )
+            switch discriminator {
+            case "Walk", "#/components/schemas/Walk":
+                self = .walk(try .init(from: decoder))
+            case "MessagedExercise", "#/components/schemas/MessagedExercise":
+                self = .messagedExercise(try .init(from: decoder))
+            default:
+                throw Swift.DecodingError.unknownOneOfDiscriminator(
+                    discriminatorKey: CodingKeys.kind,
+                    discriminatorValue: discriminator,
+                    codingPath: decoder.codingPath
                 )
             }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try self.value1?.encode(to: encoder)
-                try self.value2?.encode(to: encoder)
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            switch self {
+            case let .walk(value):
+                try value.encode(to: encoder)
+            case let .messagedExercise(value):
+                try value.encode(to: encoder)
             }
         }
-        /// - Remark: Generated from `#/components/schemas/OneOfAny`.
-        @frozen public enum OneOfAny: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/OneOfAny/case1`.
-            case case1(Swift.String)
-            /// - Remark: Generated from `#/components/schemas/OneOfAny/case2`.
-            case case2(Swift.Int)
-            /// - Remark: Generated from `#/components/schemas/OneOfAny/case3`.
-            case CodeError(Components.Schemas.CodeError)
-            /// - Remark: Generated from `#/components/schemas/OneOfAny/case4`.
-            public struct Case4Payload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/OneOfAny/case4/message`.
-                public var message: Swift.String
-                /// Creates a new `Case4Payload`.
-                ///
-                /// - Parameters:
-                ///   - message:
-                public init(message: Swift.String) {
-                    self.message = message
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case message
-                }
+    }
+    /// - Remark: Generated from `#/components/schemas/PetStats`.
+    public struct PetStats: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/PetStats/count`.
+        public var count: Swift.Int
+        /// Creates a new `PetStats`.
+        ///
+        /// - Parameters:
+        ///   - count:
+        public init(count: Swift.Int) {
+            self.count = count
+        }
+        public enum CodingKeys: String, CodingKey {
+            case count
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/RecursivePet`.
+    public struct RecursivePet: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/RecursivePet/name`.
+        public var name: Swift.String {
+            get  {
+                self.storage.value.name
             }
-            /// - Remark: Generated from `#/components/schemas/OneOfAny/case4`.
-            case case4(Components.Schemas.OneOfAny.Case4Payload)
-            public init(from decoder: any Swift.Decoder) throws {
-                var errors: [any Swift.Error] = []
-                do {
-                    self = .case1(try decoder.decodeFromSingleValueContainer())
-                    return
-                } catch {
-                    errors.append(error)
-                }
-                do {
-                    self = .case2(try decoder.decodeFromSingleValueContainer())
-                    return
-                } catch {
-                    errors.append(error)
-                }
-                do {
-                    self = .CodeError(try .init(from: decoder))
-                    return
-                } catch {
-                    errors.append(error)
-                }
-                do {
-                    self = .case4(try .init(from: decoder))
-                    return
-                } catch {
-                    errors.append(error)
-                }
-                throw Swift.DecodingError.failedToDecodeOneOfSchema(
-                    type: Self.self,
-                    codingPath: decoder.codingPath,
-                    errors: errors
-                )
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                switch self {
-                case let .case1(value):
-                    try encoder.encodeToSingleValueContainer(value)
-                case let .case2(value):
-                    try encoder.encodeToSingleValueContainer(value)
-                case let .CodeError(value):
-                    try value.encode(to: encoder)
-                case let .case4(value):
-                    try value.encode(to: encoder)
-                }
+            _modify {
+                yield &self.storage.value.name
             }
         }
-        /// - Remark: Generated from `#/components/schemas/PetExercise`.
-        public struct PetExercise: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/PetExercise/kind`.
-            public var kind: Swift.String
-            /// Creates a new `PetExercise`.
-            ///
-            /// - Parameters:
-            ///   - kind:
-            public init(kind: Swift.String) {
-                self.kind = kind
+        /// - Remark: Generated from `#/components/schemas/RecursivePet/parent`.
+        public var parent: Components.Schemas.RecursivePet? {
+            get  {
+                self.storage.value.parent
             }
-            public enum CodingKeys: String, CodingKey {
-                case kind
+            _modify {
+                yield &self.storage.value.parent
             }
         }
-        /// - Remark: Generated from `#/components/schemas/Walk`.
-        public struct Walk: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/Walk/kind`.
-            public var kind: Swift.String
-            /// - Remark: Generated from `#/components/schemas/Walk/length`.
-            public var length: Swift.Int
-            /// Creates a new `Walk`.
-            ///
-            /// - Parameters:
-            ///   - kind:
-            ///   - length:
-            public init(
-                kind: Swift.String,
-                length: Swift.Int
-            ) {
-                self.kind = kind
-                self.length = length
-            }
-            public enum CodingKeys: String, CodingKey {
-                case kind
-                case length
-            }
+        /// Creates a new `RecursivePet`.
+        ///
+        /// - Parameters:
+        ///   - name:
+        ///   - parent:
+        public init(
+            name: Swift.String,
+            parent: Components.Schemas.RecursivePet? = nil
+        ) {
+            self.storage = .init(value: .init(
+                name: name,
+                parent: parent
+            ))
         }
-        /// - Remark: Generated from `#/components/schemas/MessagedExercise`.
-        public struct MessagedExercise: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/MessagedExercise/value1`.
-            public var value1: Components.Schemas.PetExercise
-            /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2`.
-            public struct Value2Payload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2/message`.
-                public var message: Swift.String
-                /// Creates a new `Value2Payload`.
-                ///
-                /// - Parameters:
-                ///   - message:
-                public init(message: Swift.String) {
-                    self.message = message
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case message
-                }
-            }
-            /// - Remark: Generated from `#/components/schemas/MessagedExercise/value2`.
-            public var value2: Components.Schemas.MessagedExercise.Value2Payload
-            /// Creates a new `MessagedExercise`.
-            ///
-            /// - Parameters:
-            ///   - value1:
-            ///   - value2:
-            public init(
-                value1: Components.Schemas.PetExercise,
-                value2: Components.Schemas.MessagedExercise.Value2Payload
-            ) {
-                self.value1 = value1
-                self.value2 = value2
-            }
-            public init(from decoder: any Swift.Decoder) throws {
-                self.value1 = try .init(from: decoder)
-                self.value2 = try .init(from: decoder)
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try self.value1.encode(to: encoder)
-                try self.value2.encode(to: encoder)
-            }
+        public enum CodingKeys: String, CodingKey {
+            case name
+            case parent
         }
-        /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator`.
-        @frozen public enum OneOfObjectsWithDiscriminator: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/Walk`.
-            case walk(Components.Schemas.Walk)
-            /// - Remark: Generated from `#/components/schemas/OneOfObjectsWithDiscriminator/MessagedExercise`.
-            case messagedExercise(Components.Schemas.MessagedExercise)
-            public enum CodingKeys: String, CodingKey {
-                case kind
-            }
-            public init(from decoder: any Swift.Decoder) throws {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                let discriminator = try container.decode(
-                    Swift.String.self,
-                    forKey: .kind
-                )
-                switch discriminator {
-                case "Walk", "#/components/schemas/Walk":
-                    self = .walk(try .init(from: decoder))
-                case "MessagedExercise", "#/components/schemas/MessagedExercise":
-                    self = .messagedExercise(try .init(from: decoder))
-                default:
-                    throw Swift.DecodingError.unknownOneOfDiscriminator(
-                        discriminatorKey: CodingKeys.kind,
-                        discriminatorValue: discriminator,
-                        codingPath: decoder.codingPath
-                    )
-                }
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                switch self {
-                case let .walk(value):
-                    try value.encode(to: encoder)
-                case let .messagedExercise(value):
-                    try value.encode(to: encoder)
-                }
-            }
+        public init(from decoder: any Swift.Decoder) throws {
+            self.storage = try .init(from: decoder)
         }
-        /// - Remark: Generated from `#/components/schemas/PetStats`.
-        public struct PetStats: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/PetStats/count`.
-            public var count: Swift.Int
-            /// Creates a new `PetStats`.
-            ///
-            /// - Parameters:
-            ///   - count:
-            public init(count: Swift.Int) {
-                self.count = count
-            }
-            public enum CodingKeys: String, CodingKey {
-                case count
-            }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try self.storage.encode(to: encoder)
         }
-        /// - Remark: Generated from `#/components/schemas/RecursivePet`.
-        public struct RecursivePet: Codable, Hashable, Sendable {
+        /// Internal reference storage to allow type recursion.
+        private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
+        private struct Storage: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/RecursivePet/name`.
-            public var name: Swift.String {
-                get  {
-                    self.storage.value.name
-                }
-                _modify {
-                    yield &self.storage.value.name
-                }
-            }
+            var name: Swift.String
             /// - Remark: Generated from `#/components/schemas/RecursivePet/parent`.
-            public var parent: Components.Schemas.RecursivePet? {
-                get  {
-                    self.storage.value.parent
-                }
-                _modify {
-                    yield &self.storage.value.parent
-                }
-            }
-            /// Creates a new `RecursivePet`.
-            ///
-            /// - Parameters:
-            ///   - name:
-            ///   - parent:
-            public init(
+            var parent: Components.Schemas.RecursivePet?
+            init(
                 name: Swift.String,
                 parent: Components.Schemas.RecursivePet? = nil
             ) {
-                self.storage = .init(value: .init(
-                    name: name,
-                    parent: parent
-                ))
+                self.name = name
+                self.parent = parent
             }
-            public enum CodingKeys: String, CodingKey {
-                case name
-                case parent
+            typealias CodingKeys = Components.Schemas.RecursivePet.CodingKeys
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/RecursivePetNested`.
+    public struct RecursivePetNested: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/RecursivePetNested/name`.
+        public var name: Swift.String {
+            get  {
+                self.storage.value.name
             }
-            public init(from decoder: any Swift.Decoder) throws {
-                self.storage = try .init(from: decoder)
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try self.storage.encode(to: encoder)
-            }
-            /// Internal reference storage to allow type recursion.
-            private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
-            private struct Storage: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/RecursivePet/name`.
-                var name: Swift.String
-                /// - Remark: Generated from `#/components/schemas/RecursivePet/parent`.
-                var parent: Components.Schemas.RecursivePet?
-                init(
-                    name: Swift.String,
-                    parent: Components.Schemas.RecursivePet? = nil
-                ) {
-                    self.name = name
-                    self.parent = parent
-                }
-                typealias CodingKeys = Components.Schemas.RecursivePet.CodingKeys
+            _modify {
+                yield &self.storage.value.name
             }
         }
-        /// - Remark: Generated from `#/components/schemas/RecursivePetNested`.
-        public struct RecursivePetNested: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/RecursivePetNested/name`.
-            public var name: Swift.String {
-                get  {
-                    self.storage.value.name
-                }
-                _modify {
-                    yield &self.storage.value.name
-                }
+        /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent`.
+        public struct ParentPayload: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent/nested`.
+            public var nested: Components.Schemas.RecursivePetNested
+            /// Creates a new `ParentPayload`.
+            ///
+            /// - Parameters:
+            ///   - nested:
+            public init(nested: Components.Schemas.RecursivePetNested) {
+                self.nested = nested
             }
+            public enum CodingKeys: String, CodingKey {
+                case nested
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent`.
+        public var parent: Components.Schemas.RecursivePetNested.ParentPayload? {
+            get  {
+                self.storage.value.parent
+            }
+            _modify {
+                yield &self.storage.value.parent
+            }
+        }
+        /// Creates a new `RecursivePetNested`.
+        ///
+        /// - Parameters:
+        ///   - name:
+        ///   - parent:
+        public init(
+            name: Swift.String,
+            parent: Components.Schemas.RecursivePetNested.ParentPayload? = nil
+        ) {
+            self.storage = .init(value: .init(
+                name: name,
+                parent: parent
+            ))
+        }
+        public enum CodingKeys: String, CodingKey {
+            case name
+            case parent
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            self.storage = try .init(from: decoder)
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try self.storage.encode(to: encoder)
+        }
+        /// Internal reference storage to allow type recursion.
+        private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
+        private struct Storage: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RecursivePetNested/name`.
+            var name: Swift.String
             /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent`.
-            public struct ParentPayload: Codable, Hashable, Sendable {
+            struct ParentPayload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent/nested`.
                 public var nested: Components.Schemas.RecursivePetNested
                 /// Creates a new `ParentPayload`.
@@ -882,83 +933,79 @@ extension Components {
                 }
             }
             /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent`.
-            public var parent: Components.Schemas.RecursivePetNested.ParentPayload? {
-                get  {
-                    self.storage.value.parent
-                }
-                _modify {
-                    yield &self.storage.value.parent
-                }
-            }
-            /// Creates a new `RecursivePetNested`.
-            ///
-            /// - Parameters:
-            ///   - name:
-            ///   - parent:
-            public init(
+            var parent: Components.Schemas.RecursivePetNested.ParentPayload?
+            init(
                 name: Swift.String,
                 parent: Components.Schemas.RecursivePetNested.ParentPayload? = nil
             ) {
-                self.storage = .init(value: .init(
-                    name: name,
-                    parent: parent
-                ))
+                self.name = name
+                self.parent = parent
             }
-            public enum CodingKeys: String, CodingKey {
-                case name
-                case parent
+            typealias CodingKeys = Components.Schemas.RecursivePetNested.CodingKeys
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst`.
+    public struct RecursivePetOneOfFirst: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value1`.
+        public var value1: Components.Schemas.RecursivePetOneOf {
+            get  {
+                self.storage.value.value1
             }
-            public init(from decoder: any Swift.Decoder) throws {
-                self.storage = try .init(from: decoder)
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try self.storage.encode(to: encoder)
-            }
-            /// Internal reference storage to allow type recursion.
-            private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
-            private struct Storage: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/RecursivePetNested/name`.
-                var name: Swift.String
-                /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent`.
-                struct ParentPayload: Codable, Hashable, Sendable {
-                    /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent/nested`.
-                    public var nested: Components.Schemas.RecursivePetNested
-                    /// Creates a new `ParentPayload`.
-                    ///
-                    /// - Parameters:
-                    ///   - nested:
-                    public init(nested: Components.Schemas.RecursivePetNested) {
-                        self.nested = nested
-                    }
-                    public enum CodingKeys: String, CodingKey {
-                        case nested
-                    }
-                }
-                /// - Remark: Generated from `#/components/schemas/RecursivePetNested/parent`.
-                var parent: Components.Schemas.RecursivePetNested.ParentPayload?
-                init(
-                    name: Swift.String,
-                    parent: Components.Schemas.RecursivePetNested.ParentPayload? = nil
-                ) {
-                    self.name = name
-                    self.parent = parent
-                }
-                typealias CodingKeys = Components.Schemas.RecursivePetNested.CodingKeys
+            _modify {
+                yield &self.storage.value.value1
             }
         }
-        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst`.
-        public struct RecursivePetOneOfFirst: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value1`.
-            public var value1: Components.Schemas.RecursivePetOneOf {
-                get  {
-                    self.storage.value.value1
-                }
-                _modify {
-                    yield &self.storage.value.value1
-                }
+        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2`.
+        public struct Value2Payload: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2/type`.
+            public var _type: Swift.String
+            /// Creates a new `Value2Payload`.
+            ///
+            /// - Parameters:
+            ///   - _type:
+            public init(_type: Swift.String) {
+                self._type = _type
             }
+            public enum CodingKeys: String, CodingKey {
+                case _type = "type"
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2`.
+        public var value2: Components.Schemas.RecursivePetOneOfFirst.Value2Payload {
+            get  {
+                self.storage.value.value2
+            }
+            _modify {
+                yield &self.storage.value.value2
+            }
+        }
+        /// Creates a new `RecursivePetOneOfFirst`.
+        ///
+        /// - Parameters:
+        ///   - value1:
+        ///   - value2:
+        public init(
+            value1: Components.Schemas.RecursivePetOneOf,
+            value2: Components.Schemas.RecursivePetOneOfFirst.Value2Payload
+        ) {
+            self.storage = .init(value: .init(
+                value1: value1,
+                value2: value2
+            ))
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            self.storage = try .init(from: decoder)
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try self.storage.encode(to: encoder)
+        }
+        /// Internal reference storage to allow type recursion.
+        private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
+        private struct Storage: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value1`.
+            var value1: Components.Schemas.RecursivePetOneOf
             /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2`.
-            public struct Value2Payload: Codable, Hashable, Sendable {
+            struct Value2Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2/type`.
                 public var _type: Swift.String
                 /// Creates a new `Value2Payload`.
@@ -973,240 +1020,231 @@ extension Components {
                 }
             }
             /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2`.
-            public var value2: Components.Schemas.RecursivePetOneOfFirst.Value2Payload {
-                get  {
-                    self.storage.value.value2
-                }
-                _modify {
-                    yield &self.storage.value.value2
-                }
-            }
-            /// Creates a new `RecursivePetOneOfFirst`.
-            ///
-            /// - Parameters:
-            ///   - value1:
-            ///   - value2:
-            public init(
+            var value2: Components.Schemas.RecursivePetOneOfFirst.Value2Payload
+            init(
                 value1: Components.Schemas.RecursivePetOneOf,
                 value2: Components.Schemas.RecursivePetOneOfFirst.Value2Payload
-            ) {
-                self.storage = .init(value: .init(
-                    value1: value1,
-                    value2: value2
-                ))
-            }
-            public init(from decoder: any Swift.Decoder) throws {
-                self.storage = try .init(from: decoder)
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try self.storage.encode(to: encoder)
-            }
-            /// Internal reference storage to allow type recursion.
-            private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
-            private struct Storage: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value1`.
-                var value1: Components.Schemas.RecursivePetOneOf
-                /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2`.
-                struct Value2Payload: Codable, Hashable, Sendable {
-                    /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2/type`.
-                    public var _type: Swift.String
-                    /// Creates a new `Value2Payload`.
-                    ///
-                    /// - Parameters:
-                    ///   - _type:
-                    public init(_type: Swift.String) {
-                        self._type = _type
-                    }
-                    public enum CodingKeys: String, CodingKey {
-                        case _type = "type"
-                    }
-                }
-                /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfFirst/value2`.
-                var value2: Components.Schemas.RecursivePetOneOfFirst.Value2Payload
-                init(
-                    value1: Components.Schemas.RecursivePetOneOf,
-                    value2: Components.Schemas.RecursivePetOneOfFirst.Value2Payload
-                ) {
-                    self.value1 = value1
-                    self.value2 = value2
-                }
-                init(from decoder: any Swift.Decoder) throws {
-                    self.value1 = try .init(from: decoder)
-                    self.value2 = try .init(from: decoder)
-                }
-                func encode(to encoder: any Swift.Encoder) throws {
-                    try self.value1.encode(to: encoder)
-                    try self.value2.encode(to: encoder)
-                }
-            }
-        }
-        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond`.
-        public struct RecursivePetOneOfSecond: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond/value1`.
-            public var value1: Components.Schemas.Pet
-            /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond/value2`.
-            public struct Value2Payload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond/value2/type`.
-                public var _type: Swift.String
-                /// Creates a new `Value2Payload`.
-                ///
-                /// - Parameters:
-                ///   - _type:
-                public init(_type: Swift.String) {
-                    self._type = _type
-                }
-                public enum CodingKeys: String, CodingKey {
-                    case _type = "type"
-                }
-            }
-            /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond/value2`.
-            public var value2: Components.Schemas.RecursivePetOneOfSecond.Value2Payload
-            /// Creates a new `RecursivePetOneOfSecond`.
-            ///
-            /// - Parameters:
-            ///   - value1:
-            ///   - value2:
-            public init(
-                value1: Components.Schemas.Pet,
-                value2: Components.Schemas.RecursivePetOneOfSecond.Value2Payload
             ) {
                 self.value1 = value1
                 self.value2 = value2
             }
-            public init(from decoder: any Swift.Decoder) throws {
+            init(from decoder: any Swift.Decoder) throws {
                 self.value1 = try .init(from: decoder)
                 self.value2 = try .init(from: decoder)
             }
-            public func encode(to encoder: any Swift.Encoder) throws {
+            func encode(to encoder: any Swift.Encoder) throws {
                 try self.value1.encode(to: encoder)
                 try self.value2.encode(to: encoder)
             }
         }
-        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOf`.
-        @frozen public enum RecursivePetOneOf: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/RecursivePetOneOf/RecursivePetOneOfFirst`.
-            case recursivePetOneOfFirst(Components.Schemas.RecursivePetOneOfFirst)
-            /// - Remark: Generated from `#/components/schemas/RecursivePetOneOf/RecursivePetOneOfSecond`.
-            case recursivePetOneOfSecond(Components.Schemas.RecursivePetOneOfSecond)
+    }
+    /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond`.
+    public struct RecursivePetOneOfSecond: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond/value1`.
+        public var value1: Components.Schemas.Pet
+        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond/value2`.
+        public struct Value2Payload: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond/value2/type`.
+            public var _type: Swift.String
+            /// Creates a new `Value2Payload`.
+            ///
+            /// - Parameters:
+            ///   - _type:
+            public init(_type: Swift.String) {
+                self._type = _type
+            }
             public enum CodingKeys: String, CodingKey {
                 case _type = "type"
             }
-            public init(from decoder: any Swift.Decoder) throws {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                let discriminator = try container.decode(
-                    Swift.String.self,
-                    forKey: ._type
+        }
+        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOfSecond/value2`.
+        public var value2: Components.Schemas.RecursivePetOneOfSecond.Value2Payload
+        /// Creates a new `RecursivePetOneOfSecond`.
+        ///
+        /// - Parameters:
+        ///   - value1:
+        ///   - value2:
+        public init(
+            value1: Components.Schemas.Pet,
+            value2: Components.Schemas.RecursivePetOneOfSecond.Value2Payload
+        ) {
+            self.value1 = value1
+            self.value2 = value2
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            self.value1 = try .init(from: decoder)
+            self.value2 = try .init(from: decoder)
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try self.value1.encode(to: encoder)
+            try self.value2.encode(to: encoder)
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/RecursivePetOneOf`.
+    @frozen public enum RecursivePetOneOf: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOf/RecursivePetOneOfFirst`.
+        case recursivePetOneOfFirst(Components.Schemas.RecursivePetOneOfFirst)
+        /// - Remark: Generated from `#/components/schemas/RecursivePetOneOf/RecursivePetOneOfSecond`.
+        case recursivePetOneOfSecond(Components.Schemas.RecursivePetOneOfSecond)
+        public enum CodingKeys: String, CodingKey {
+            case _type = "type"
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let discriminator = try container.decode(
+                Swift.String.self,
+                forKey: ._type
+            )
+            switch discriminator {
+            case "RecursivePetOneOfFirst", "#/components/schemas/RecursivePetOneOfFirst":
+                self = .recursivePetOneOfFirst(try .init(from: decoder))
+            case "RecursivePetOneOfSecond", "#/components/schemas/RecursivePetOneOfSecond":
+                self = .recursivePetOneOfSecond(try .init(from: decoder))
+            default:
+                throw Swift.DecodingError.unknownOneOfDiscriminator(
+                    discriminatorKey: CodingKeys._type,
+                    discriminatorValue: discriminator,
+                    codingPath: decoder.codingPath
                 )
-                switch discriminator {
-                case "RecursivePetOneOfFirst", "#/components/schemas/RecursivePetOneOfFirst":
-                    self = .recursivePetOneOfFirst(try .init(from: decoder))
-                case "RecursivePetOneOfSecond", "#/components/schemas/RecursivePetOneOfSecond":
-                    self = .recursivePetOneOfSecond(try .init(from: decoder))
-                default:
-                    throw Swift.DecodingError.unknownOneOfDiscriminator(
-                        discriminatorKey: CodingKeys._type,
-                        discriminatorValue: discriminator,
-                        codingPath: decoder.codingPath
-                    )
-                }
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                switch self {
-                case let .recursivePetOneOfFirst(value):
-                    try value.encode(to: encoder)
-                case let .recursivePetOneOfSecond(value):
-                    try value.encode(to: encoder)
-                }
             }
         }
-        /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf`.
-        public struct RecursivePetAnyOf: Codable, Hashable, Sendable {
+        public func encode(to encoder: any Swift.Encoder) throws {
+            switch self {
+            case let .recursivePetOneOfFirst(value):
+                try value.encode(to: encoder)
+            case let .recursivePetOneOfSecond(value):
+                try value.encode(to: encoder)
+            }
+        }
+    }
+    /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf`.
+    public struct RecursivePetAnyOf: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf/value1`.
+        public var value1: Components.Schemas.RecursivePetAnyOf? {
+            get  {
+                self.storage.value.value1
+            }
+            _modify {
+                yield &self.storage.value.value1
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf/value2`.
+        public var value2: Swift.String? {
+            get  {
+                self.storage.value.value2
+            }
+            _modify {
+                yield &self.storage.value.value2
+            }
+        }
+        /// Creates a new `RecursivePetAnyOf`.
+        ///
+        /// - Parameters:
+        ///   - value1:
+        ///   - value2:
+        public init(
+            value1: Components.Schemas.RecursivePetAnyOf? = nil,
+            value2: Swift.String? = nil
+        ) {
+            self.storage = .init(value: .init(
+                value1: value1,
+                value2: value2
+            ))
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            self.storage = try .init(from: decoder)
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try self.storage.encode(to: encoder)
+        }
+        /// Internal reference storage to allow type recursion.
+        private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
+        private struct Storage: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf/value1`.
-            public var value1: Components.Schemas.RecursivePetAnyOf? {
-                get  {
-                    self.storage.value.value1
-                }
-                _modify {
-                    yield &self.storage.value.value1
-                }
-            }
+            var value1: Components.Schemas.RecursivePetAnyOf?
             /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf/value2`.
-            public var value2: Swift.String? {
-                get  {
-                    self.storage.value.value2
-                }
-                _modify {
-                    yield &self.storage.value.value2
-                }
-            }
-            /// Creates a new `RecursivePetAnyOf`.
-            ///
-            /// - Parameters:
-            ///   - value1:
-            ///   - value2:
-            public init(
+            var value2: Swift.String?
+            init(
                 value1: Components.Schemas.RecursivePetAnyOf? = nil,
                 value2: Swift.String? = nil
             ) {
-                self.storage = .init(value: .init(
-                    value1: value1,
-                    value2: value2
-                ))
+                self.value1 = value1
+                self.value2 = value2
             }
-            public init(from decoder: any Swift.Decoder) throws {
-                self.storage = try .init(from: decoder)
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try self.storage.encode(to: encoder)
-            }
-            /// Internal reference storage to allow type recursion.
-            private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
-            private struct Storage: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf/value1`.
-                var value1: Components.Schemas.RecursivePetAnyOf?
-                /// - Remark: Generated from `#/components/schemas/RecursivePetAnyOf/value2`.
-                var value2: Swift.String?
-                init(
-                    value1: Components.Schemas.RecursivePetAnyOf? = nil,
-                    value2: Swift.String? = nil
-                ) {
-                    self.value1 = value1
-                    self.value2 = value2
+            init(from decoder: any Swift.Decoder) throws {
+                var errors: [any Swift.Error] = []
+                do {
+                    self.value1 = try .init(from: decoder)
+                } catch {
+                    errors.append(error)
                 }
-                init(from decoder: any Swift.Decoder) throws {
-                    var errors: [any Swift.Error] = []
-                    do {
-                        self.value1 = try .init(from: decoder)
-                    } catch {
-                        errors.append(error)
-                    }
-                    do {
-                        self.value2 = try decoder.decodeFromSingleValueContainer()
-                    } catch {
-                        errors.append(error)
-                    }
-                    try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
-                        [
-                            self.value1,
-                            self.value2
-                        ],
-                        type: Self.self,
-                        codingPath: decoder.codingPath,
-                        errors: errors
-                    )
+                do {
+                    self.value2 = try decoder.decodeFromSingleValueContainer()
+                } catch {
+                    errors.append(error)
                 }
-                func encode(to encoder: any Swift.Encoder) throws {
-                    try encoder.encodeFirstNonNilValueToSingleValueContainer([
+                try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                    [
+                        self.value1,
                         self.value2
-                    ])
-                    try self.value1?.encode(to: encoder)
-                }
+                    ],
+                    type: Self.self,
+                    codingPath: decoder.codingPath,
+                    errors: errors
+                )
+            }
+            func encode(to encoder: any Swift.Encoder) throws {
+                try encoder.encodeFirstNonNilValueToSingleValueContainer([
+                    self.value2
+                ])
+                try self.value1?.encode(to: encoder)
             }
         }
-        /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf`.
-        public struct RecursivePetAllOf: Codable, Hashable, Sendable {
+    }
+    /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf`.
+    public struct RecursivePetAllOf: Codable, Hashable, Sendable {
+        /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1`.
+        public struct Value1Payload: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1/parent`.
+            public var parent: Components.Schemas.RecursivePetAllOf?
+            /// Creates a new `Value1Payload`.
+            ///
+            /// - Parameters:
+            ///   - parent:
+            public init(parent: Components.Schemas.RecursivePetAllOf? = nil) {
+                self.parent = parent
+            }
+            public enum CodingKeys: String, CodingKey {
+                case parent
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1`.
+        public var value1: Components.Schemas.RecursivePetAllOf.Value1Payload {
+            get  {
+                self.storage.value.value1
+            }
+            _modify {
+                yield &self.storage.value.value1
+            }
+        }
+        /// Creates a new `RecursivePetAllOf`.
+        ///
+        /// - Parameters:
+        ///   - value1:
+        public init(value1: Components.Schemas.RecursivePetAllOf.Value1Payload) {
+            self.storage = .init(value: .init(value1: value1))
+        }
+        public init(from decoder: any Swift.Decoder) throws {
+            self.storage = try .init(from: decoder)
+        }
+        public func encode(to encoder: any Swift.Encoder) throws {
+            try self.storage.encode(to: encoder)
+        }
+        /// Internal reference storage to allow type recursion.
+        private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
+        private struct Storage: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1`.
-            public struct Value1Payload: Codable, Hashable, Sendable {
+            struct Value1Payload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1/parent`.
                 public var parent: Components.Schemas.RecursivePetAllOf?
                 /// Creates a new `Value1Payload`.
@@ -1221,56 +1259,15 @@ extension Components {
                 }
             }
             /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1`.
-            public var value1: Components.Schemas.RecursivePetAllOf.Value1Payload {
-                get  {
-                    self.storage.value.value1
-                }
-                _modify {
-                    yield &self.storage.value.value1
-                }
+            var value1: Components.Schemas.RecursivePetAllOf.Value1Payload
+            init(value1: Components.Schemas.RecursivePetAllOf.Value1Payload) {
+                self.value1 = value1
             }
-            /// Creates a new `RecursivePetAllOf`.
-            ///
-            /// - Parameters:
-            ///   - value1:
-            public init(value1: Components.Schemas.RecursivePetAllOf.Value1Payload) {
-                self.storage = .init(value: .init(value1: value1))
+            init(from decoder: any Swift.Decoder) throws {
+                self.value1 = try .init(from: decoder)
             }
-            public init(from decoder: any Swift.Decoder) throws {
-                self.storage = try .init(from: decoder)
-            }
-            public func encode(to encoder: any Swift.Encoder) throws {
-                try self.storage.encode(to: encoder)
-            }
-            /// Internal reference storage to allow type recursion.
-            private var storage: OpenAPIRuntime.CopyOnWriteBox<Storage>
-            private struct Storage: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1`.
-                struct Value1Payload: Codable, Hashable, Sendable {
-                    /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1/parent`.
-                    public var parent: Components.Schemas.RecursivePetAllOf?
-                    /// Creates a new `Value1Payload`.
-                    ///
-                    /// - Parameters:
-                    ///   - parent:
-                    public init(parent: Components.Schemas.RecursivePetAllOf? = nil) {
-                        self.parent = parent
-                    }
-                    public enum CodingKeys: String, CodingKey {
-                        case parent
-                    }
-                }
-                /// - Remark: Generated from `#/components/schemas/RecursivePetAllOf/value1`.
-                var value1: Components.Schemas.RecursivePetAllOf.Value1Payload
-                init(value1: Components.Schemas.RecursivePetAllOf.Value1Payload) {
-                    self.value1 = value1
-                }
-                init(from decoder: any Swift.Decoder) throws {
-                    self.value1 = try .init(from: decoder)
-                }
-                func encode(to encoder: any Swift.Encoder) throws {
-                    try self.value1.encode(to: encoder)
-                }
+            func encode(to encoder: any Swift.Encoder) throws {
+                try self.value1.encode(to: encoder)
             }
         }
     }

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Components.swift
@@ -9,5 +9,15 @@ public import struct Foundation.URL
 public import struct Foundation.Data
 public import struct Foundation.Date
 #endif
-/// Types generated from the components section of the OpenAPI document.
-public enum Components {}
+extension Components {
+    /// Types generated from the `#/components/schemas` section of the OpenAPI document.
+    public enum Schemas {}
+    /// Types generated from the `#/components/parameters` section of the OpenAPI document.
+    public enum Parameters {}
+    /// Types generated from the `#/components/requestBodies` section of the OpenAPI document.
+    public enum RequestBodies {}
+    /// Types generated from the `#/components/responses` section of the OpenAPI document.
+    public enum Responses {}
+    /// Types generated from the `#/components/headers` section of the OpenAPI document.
+    public enum Headers {}
+}

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Operations.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types+Operations.swift
@@ -9,8 +9,7 @@ public import struct Foundation.URL
 public import struct Foundation.Data
 public import struct Foundation.Date
 #endif
-/// API operations, with input and output types, generated from `#/paths` in the OpenAPI document.
-public enum Operations {
+extension Operations {
     /// List all pets
     ///
     /// You can fetch

--- a/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
+++ b/Tests/OpenAPIGeneratorReferenceTests/Resources/ReferenceSources/Petstore/Types.swift
@@ -270,3 +270,9 @@ public enum Servers {
         )
     }
 }
+
+/// Types generated from the components section of the OpenAPI document.
+public enum Components {}
+
+/// API operations, with input and output types, generated from `#/paths` in the OpenAPI document.
+public enum Operations {}

--- a/Tests/OpenAPIGeneratorTests/Test_GenerateOptions.swift
+++ b/Tests/OpenAPIGeneratorTests/Test_GenerateOptions.swift
@@ -90,6 +90,123 @@ final class Test_GenerateOptions: XCTestCase {
         XCTAssertFalse(try Data(contentsOf: temporaryDirectory.appendingPathComponent("Client.swift")).isEmpty)
     }
 
+    func testBuildPluginRejectsDynamicDeclarationSplitting() async throws {
+        do {
+            try await _Tool.runGenerator(
+                doc: URL(fileURLWithPath: "/unused/openapi.yaml"),
+                configs: [
+                    Config(mode: .types, access: .internal, namingStrategy: .defensive, maxDeclarationsPerFile: 100)
+                ],
+                pluginSource: .build,
+                outputDirectory: FileManager.default.temporaryDirectory,
+                isDryRun: false,
+                diagnostics: StdErrPrintingDiagnosticCollector()
+            )
+            XCTFail("Expected dynamic declaration splitting to be rejected by the build-tool plugin.")
+        } catch let error as ArgumentParser.ValidationError {
+            XCTAssertTrue(
+                String(describing: error).contains("maxDeclarationsPerFile is not supported by the build-tool plugin")
+            )
+        }
+    }
+
+    func testDirectAndCommandPluginGenerationSupportDynamicDeclarationSplitting() async throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let documentURL = temporaryDirectory.appendingPathComponent("openapi.yaml")
+        try Data(
+            """
+            openapi: "3.1.0"
+            info:
+              title: GreetingService
+              version: "1.0.0"
+            paths: {}
+            components:
+              schemas:
+                First:
+                  type: string
+                Second:
+                  type: string
+            """
+            .utf8
+        )
+        .write(to: documentURL)
+
+        let invocations: [(name: String, pluginSource: PluginSource?)] = [("direct", nil), ("command", .command)]
+        for (name, pluginSource) in invocations {
+            let outputDirectory = temporaryDirectory.appendingPathComponent(name)
+            try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+            try await _Tool.runGenerator(
+                doc: documentURL,
+                configs: [
+                    Config(mode: .types, access: .internal, namingStrategy: .defensive, maxDeclarationsPerFile: 1)
+                ],
+                pluginSource: pluginSource,
+                outputDirectory: outputDirectory,
+                isDryRun: false,
+                diagnostics: StdErrPrintingDiagnosticCollector()
+            )
+            XCTAssertTrue(
+                FileManager.default.fileExists(
+                    atPath: outputDirectory.appendingPathComponent("Types+Components+Schemas+1.swift").path
+                )
+            )
+        }
+    }
+
+    func testLoadsMaximumDeclarationsPerFileFromConfig() throws {
+        let configURL = try makeTemporaryConfig(
+            """
+            generate:
+              - types
+            output:
+              maxDeclarationsPerFile: 100
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: configURL.deletingLastPathComponent()) }
+
+        let options = try _GenerateOptions.parse(["openapi.yaml", "--config", configURL.path])
+        let config = try XCTUnwrap(options.loadedConfig())
+
+        XCTAssertEqual(config.output?.maxDeclarationsPerFile, 100)
+    }
+
+    func testRejectsNonPositiveMaximumDeclarationsPerFileFromConfig() async throws {
+        for invalidLimit in [0, -1] {
+            let configURL = try makeTemporaryConfig(
+                """
+                generate:
+                  - client
+                output:
+                  maxDeclarationsPerFile: \(invalidLimit)
+                """
+            )
+            defer { try? FileManager.default.removeItem(at: configURL.deletingLastPathComponent()) }
+
+            let options = try _GenerateOptions.parse(["unused-openapi.yaml", "--config", configURL.path])
+            do {
+                try await options.runGenerator(
+                    outputDirectory: FileManager.default.temporaryDirectory,
+                    pluginSource: nil,
+                    isDryRun: true
+                )
+                XCTFail("Expected output.maxDeclarationsPerFile=\(invalidLimit) to be rejected.")
+            } catch let error as ArgumentParser.ValidationError {
+                XCTAssertTrue(String(describing: error).contains("maxDeclarationsPerFile to be greater than zero"))
+            }
+        }
+    }
+
+    private func makeTemporaryConfig(_ contents: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let configURL = directory.appendingPathComponent("openapi-generator-config.yaml")
+        try Data(contents.utf8).write(to: configURL)
+        return configURL
+    }
+
     /// Tests that `handleFileOperation` correctly transforms file-not-found errors into user-friendly messages.
     /// This test verifies the error handling works correctly on both macOS and Linux.
     func testHandleFileOperation_FileNotFound() throws {

--- a/Tests/OpenAPIGeneratorTests/Test_GenerateOptions.swift
+++ b/Tests/OpenAPIGeneratorTests/Test_GenerateOptions.swift
@@ -105,7 +105,25 @@ final class Test_GenerateOptions: XCTestCase {
             XCTFail("Expected dynamic declaration splitting to be rejected by the build-tool plugin.")
         } catch let error as ArgumentParser.ValidationError {
             XCTAssertTrue(
-                String(describing: error).contains("maxDeclarationsPerFile is not supported by the build-tool plugin")
+                String(describing: error).contains("Dynamic output splitting is not supported by the build-tool plugin")
+            )
+        }
+    }
+
+    func testBuildPluginRejectsDependencyLayers() async throws {
+        do {
+            try await _Tool.runGenerator(
+                doc: URL(fileURLWithPath: "/unused/openapi.yaml"),
+                configs: [Config(mode: .types, access: .internal, namingStrategy: .defensive, dependencyLayerCount: 2)],
+                pluginSource: .build,
+                outputDirectory: FileManager.default.temporaryDirectory,
+                isDryRun: false,
+                diagnostics: StdErrPrintingDiagnosticCollector()
+            )
+            XCTFail("Expected dependency layers to be rejected by the build-tool plugin.")
+        } catch let error as ArgumentParser.ValidationError {
+            XCTAssertTrue(
+                String(describing: error).contains("Dynamic output splitting is not supported by the build-tool plugin")
             )
         }
     }
@@ -156,6 +174,48 @@ final class Test_GenerateOptions: XCTestCase {
         }
     }
 
+    func testDirectAndCommandPluginGenerationSupportDependencyLayers() async throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let documentURL = temporaryDirectory.appendingPathComponent("openapi.yaml")
+        try Data(
+            """
+            openapi: "3.1.0"
+            info:
+              title: GreetingService
+              version: "1.0.0"
+            paths: {}
+            components:
+              schemas:
+                First:
+                  type: string
+            """
+            .utf8
+        )
+        .write(to: documentURL)
+
+        let invocations: [(name: String, pluginSource: PluginSource?)] = [("direct", nil), ("command", .command)]
+        for (name, pluginSource) in invocations {
+            let outputDirectory = temporaryDirectory.appendingPathComponent(name)
+            try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+            try await _Tool.runGenerator(
+                doc: documentURL,
+                configs: [Config(mode: .types, access: .internal, namingStrategy: .defensive, dependencyLayerCount: 2)],
+                pluginSource: pluginSource,
+                outputDirectory: outputDirectory,
+                isDryRun: false,
+                diagnostics: StdErrPrintingDiagnosticCollector()
+            )
+            XCTAssertTrue(
+                FileManager.default.fileExists(
+                    atPath: outputDirectory.appendingPathComponent("Types+Components+Schemas+Layer0.swift").path
+                )
+            )
+        }
+    }
+
     func testLoadsMaximumDeclarationsPerFileFromConfig() throws {
         let configURL = try makeTemporaryConfig(
             """
@@ -171,6 +231,25 @@ final class Test_GenerateOptions: XCTestCase {
         let config = try XCTUnwrap(options.loadedConfig())
 
         XCTAssertEqual(config.output?.maxDeclarationsPerFile, 100)
+    }
+
+    func testLoadsComposableDependencyLayerConfiguration() throws {
+        let configURL = try makeTemporaryConfig(
+            """
+            generate:
+              - types
+            output:
+              maxDeclarationsPerFile: 100
+              dependencyLayerCount: 4
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: configURL.deletingLastPathComponent()) }
+
+        let options = try _GenerateOptions.parse(["openapi.yaml", "--config", configURL.path])
+        let config = try XCTUnwrap(options.loadedConfig())
+
+        XCTAssertEqual(config.output?.maxDeclarationsPerFile, 100)
+        XCTAssertEqual(config.output?.dependencyLayerCount, 4)
     }
 
     func testRejectsNonPositiveMaximumDeclarationsPerFileFromConfig() async throws {
@@ -195,6 +274,32 @@ final class Test_GenerateOptions: XCTestCase {
                 XCTFail("Expected output.maxDeclarationsPerFile=\(invalidLimit) to be rejected.")
             } catch let error as ArgumentParser.ValidationError {
                 XCTAssertTrue(String(describing: error).contains("maxDeclarationsPerFile to be greater than zero"))
+            }
+        }
+    }
+
+    func testRejectsNonPositiveDependencyLayerCountFromConfig() async throws {
+        for invalidCount in [0, -1] {
+            let configURL = try makeTemporaryConfig(
+                """
+                generate:
+                  - types
+                output:
+                  dependencyLayerCount: \(invalidCount)
+                """
+            )
+            defer { try? FileManager.default.removeItem(at: configURL.deletingLastPathComponent()) }
+
+            let options = try _GenerateOptions.parse(["unused-openapi.yaml", "--config", configURL.path])
+            do {
+                try await options.runGenerator(
+                    outputDirectory: FileManager.default.temporaryDirectory,
+                    pluginSource: nil,
+                    isDryRun: true
+                )
+                XCTFail("Expected output.dependencyLayerCount=\(invalidCount) to be rejected.")
+            } catch let error as ArgumentParser.ValidationError {
+                XCTAssertTrue(String(describing: error).contains("dependencyLayerCount to be greater than zero"))
             }
         }
     }


### PR DESCRIPTION
## Summary

- split generated types files by declaration count
- group schema declarations into deterministic dependency-ordered layers
- preserve existing unsplit output when the new output settings are not configured

## Validation

- full Swift package test suite
- file-based Petstore reference tests
- 17-spec compatibility suite, including GitHub Enterprise and Kubernetes
- downstream Ramp iOS clean Debug and distribution builds
